### PR TITLE
feat: add installer manifests

### DIFF
--- a/manifests/installers.json
+++ b/manifests/installers.json
@@ -1,0 +1,12 @@
+{
+  "installers": [
+    {
+      "template": "qcma",
+      "version": "1"
+    },
+    {
+      "template": "qcmamt",
+      "version": "1"
+    }
+  ]
+}


### PR DESCRIPTION
Adding installer manifest file. Initially to add version tracking, but use cases to be expanded in time.

Doesn't use semver as I can't imagine a use case where we wouldn't want users to update.