### PR TITLE
Add API key role check for groups to single tenant deployer

### DIFF
--- a/automations/singleTenantDeployer.json
+++ b/automations/singleTenantDeployer.json
@@ -386,8 +386,8 @@
           "isCollapsed": false
         }
       ],
-      "x": -2930,
-      "y": 3657
+      "x": -2922,
+      "y": 3654
     },
     {
       "id": "F718EF32-99B6-49C3-A5A5-6996F86B0B87",
@@ -455,8 +455,8 @@
           "isCollapsed": false
         }
       ],
-      "x": -3292,
-      "y": 7334,
+      "x": -2922,
+      "y": 7314,
       "loopBlockId": null,
       "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
       "endpoint_guid": "590a1a20-6d2e-11eb-9714-df1bbaac055d",
@@ -478,8 +478,8 @@
           "isCollapsed": false
         }
       ],
-      "x": -3292,
-      "y": 7494,
+      "x": -2922,
+      "y": 7474,
       "variableGuid": "DE390532-B1F9-4098-BBE0-B7E6101BD502",
       "operations": [
         {
@@ -520,8 +520,8 @@
           "isCollapsed": true
         }
       ],
-      "x": -3172,
-      "y": 7834
+      "x": -2802,
+      "y": 7814
     },
     {
       "id": "34B88617-9583-4EA4-948E-D580D65F3C49",
@@ -568,8 +568,8 @@
           "isCollapsed": false
         }
       ],
-      "x": -3292,
-      "y": 7614,
+      "x": -2922,
+      "y": 7594,
       "loopBlockId": "7E7CFBF2-F088-4F93-9BA8-DE932E22956E"
     },
     {
@@ -588,8 +588,8 @@
           "isCollapsed": true
         }
       ],
-      "x": -3172,
-      "y": 7714,
+      "x": -2802,
+      "y": 7694,
       "variableGuid": "DE390532-B1F9-4098-BBE0-B7E6101BD502",
       "operations": [
         {
@@ -640,8 +640,8 @@
           "isCollapsed": true
         }
       ],
-      "x": -3172,
-      "y": 7954,
+      "x": -2802,
+      "y": 7934,
       "childTrueId": "A29FDF70-7705-4848-B467-90DD6CD8F293",
       "childFalseId": "EABD8111-E99F-4C5B-A67D-3D7F0ACE778E"
     },
@@ -1261,8 +1261,8 @@
           "isCollapsed": false
         }
       ],
-      "x": -3292,
-      "y": 8314,
+      "x": -2922,
+      "y": 8294,
       "variableGuid": "B6C34135-EF0E-42EF-AC0D-621D8A8A165D",
       "operations": [
         {
@@ -1371,8 +1371,8 @@
           "isCollapsed": false
         }
       ],
-      "x": -3292,
-      "y": 8154,
+      "x": -2922,
+      "y": 8134,
       "loopBlockId": null,
       "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
       "endpoint_guid": "590a1a20-6d2e-11eb-9714-df1bbaac055d",
@@ -1423,8 +1423,8 @@
           "isCollapsed": false
         }
       ],
-      "x": -3292,
-      "y": 8434,
+      "x": -2922,
+      "y": 8414,
       "loopBlockId": "FCBE0570-D739-43D6-B0AD-B16A2DA6F28A"
     },
     {
@@ -1443,8 +1443,8 @@
           "isCollapsed": true
         }
       ],
-      "x": -3172,
-      "y": 8534,
+      "x": -2802,
+      "y": 8514,
       "variableGuid": "B6C34135-EF0E-42EF-AC0D-621D8A8A165D",
       "operations": [
         {
@@ -1485,8 +1485,8 @@
           "isCollapsed": true
         }
       ],
-      "x": -3172,
-      "y": 8654
+      "x": -2802,
+      "y": 8634
     },
     {
       "id": "B35B33BE-B45B-4749-813C-64BA4AA4FA1D",
@@ -1528,8 +1528,8 @@
           "isCollapsed": false
         }
       ],
-      "x": -3172,
-      "y": 8774,
+      "x": -2802,
+      "y": 8754,
       "childTrueId": "F0DEE5BC-C9A2-4F91-964A-EA7C64F90457",
       "childFalseId": "2FDCB00D-3E41-4B95-A904-51DBFF7345AA"
     },
@@ -1549,8 +1549,8 @@
           "isCollapsed": true
         }
       ],
-      "x": -3052,
-      "y": 8854,
+      "x": -2682,
+      "y": 8834,
       "variableGuid": "407730A6-EC96-4337-BE80-CF4C0D552F08",
       "operations": [
         {
@@ -1577,8 +1577,8 @@
           "isCollapsed": true
         }
       ],
-      "x": -3052,
-      "y": 8974,
+      "x": -2682,
+      "y": 8954,
       "variableGuid": "1BF2068B-106E-4D58-BC51-884F1810F03C",
       "operations": [
         {
@@ -1613,8 +1613,8 @@
           "isCollapsed": true
         }
       ],
-      "x": -3052,
-      "y": 9094
+      "x": -2682,
+      "y": 9074
     },
     {
       "id": "2FDCB00D-3E41-4B95-A904-51DBFF7345AA",
@@ -1656,8 +1656,8 @@
           "isCollapsed": false
         }
       ],
-      "x": -3052,
-      "y": 9254,
+      "x": -2682,
+      "y": 9234,
       "childTrueId": "064FC5B0-AF19-4C57-B22A-E171D71F3643",
       "childFalseId": "F37D6ACE-DF7C-4EB9-A990-E7DBCD31ABDF"
     },
@@ -1722,8 +1722,8 @@
           "isCollapsed": false
         }
       ],
-      "x": -2932,
-      "y": 9334,
+      "x": -2562,
+      "y": 9314,
       "loopBlockId": null,
       "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
       "endpoint_guid": "ffe6d930-6d33-11eb-ad8a-334e25c5e295",
@@ -1769,8 +1769,8 @@
           "isCollapsed": false
         }
       ],
-      "x": -2932,
-      "y": 9494,
+      "x": -2562,
+      "y": 9474,
       "childTrueId": "D0EEE98C-7DA0-47F5-B8C6-31B0507505FD",
       "childFalseId": "9CC93349-E133-4BCC-860C-7AAE4991A788"
     },
@@ -1819,8 +1819,8 @@
           "isCollapsed": false
         }
       ],
-      "x": -2812,
-      "y": 9574,
+      "x": -2442,
+      "y": 9554,
       "childTrueId": "BE0D6DE8-CA32-466A-917B-40EA75EB91C9",
       "childFalseId": "253E7602-5CB9-473C-A66A-ABB7711934A6"
     },
@@ -1840,8 +1840,8 @@
           "isCollapsed": true
         }
       ],
-      "x": -2692,
-      "y": 9654,
+      "x": -2322,
+      "y": 9634,
       "variableGuid": "E413E2FB-E4E7-4AFF-8894-6D27792FA8D8",
       "operations": [
         {
@@ -1919,8 +1919,8 @@
           "isCollapsed": true
         }
       ],
-      "x": -2692,
-      "y": 9774,
+      "x": -2322,
+      "y": 9754,
       "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
       "endpoint_guid": "8c54ade0-6d42-11eb-b3a8-75befcc89b0a",
       "endpoint_role": "update"
@@ -1955,8 +1955,8 @@
           "isCollapsed": true
         }
       ],
-      "x": -2692,
-      "y": 9894
+      "x": -2322,
+      "y": 9874
     },
     {
       "id": "253E7602-5CB9-473C-A66A-ABB7711934A6",
@@ -1988,8 +1988,8 @@
           "isCollapsed": true
         }
       ],
-      "x": -2692,
-      "y": 10054
+      "x": -2322,
+      "y": 10034
     },
     {
       "id": "9CC93349-E133-4BCC-860C-7AAE4991A788",
@@ -2046,8 +2046,8 @@
           "isCollapsed": true
         }
       ],
-      "x": -2812,
-      "y": 10294,
+      "x": -2442,
+      "y": 10274,
       "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
       "endpoint_guid": "272d9c70-6d31-11eb-870f-67624392ed86",
       "endpoint_role": "create"
@@ -2082,8 +2082,8 @@
           "isCollapsed": true
         }
       ],
-      "x": -2812,
-      "y": 10414
+      "x": -2442,
+      "y": 10394
     },
     {
       "id": "F37D6ACE-DF7C-4EB9-A990-E7DBCD31ABDF",
@@ -2115,8 +2115,8 @@
           "isCollapsed": true
         }
       ],
-      "x": -2932,
-      "y": 10654
+      "x": -2562,
+      "y": 10634
     },
     {
       "id": "7C0C15A5-F334-4AD6-A9D4-C0AC674CC34B",
@@ -2158,8 +2158,8 @@
           "isCollapsed": false
         }
       ],
-      "x": -3292,
-      "y": 10974,
+      "x": -2922,
+      "y": 10954,
       "childTrueId": "A835D799-19FC-450D-BF01-88DB67C89291",
       "childFalseId": null
     },
@@ -2211,8 +2211,8 @@
           "isCollapsed": true
         }
       ],
-      "x": -3172,
-      "y": 11054,
+      "x": -2802,
+      "y": 11034,
       "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
       "endpoint_guid": "f0c14620-6d24-11eb-aa67-c519e2671d3d",
       "endpoint_role": "create"
@@ -2233,8 +2233,8 @@
           "isCollapsed": true
         }
       ],
-      "x": -3172,
-      "y": 11174,
+      "x": -2802,
+      "y": 11154,
       "variableGuid": "DE390532-B1F9-4098-BBE0-B7E6101BD502",
       "operations": [
         {
@@ -2275,8 +2275,8 @@
           "isCollapsed": true
         }
       ],
-      "x": -3172,
-      "y": 11294
+      "x": -2802,
+      "y": 11274
     },
     {
       "id": "230E3338-D040-459F-A88C-47CD38B6BD39",
@@ -2318,8 +2318,8 @@
           "isCollapsed": false
         }
       ],
-      "x": -3292,
-      "y": 11494,
+      "x": -2922,
+      "y": 11474,
       "childTrueId": "ED0FFFF7-7BA3-4BC5-B2CC-37F2AE4C0408",
       "childFalseId": null
     },
@@ -2371,8 +2371,8 @@
           "isCollapsed": true
         }
       ],
-      "x": -3172,
-      "y": 11574,
+      "x": -2802,
+      "y": 11554,
       "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
       "endpoint_guid": "f0c14620-6d24-11eb-aa67-c519e2671d3d",
       "endpoint_role": "create"
@@ -2393,8 +2393,8 @@
           "isCollapsed": true
         }
       ],
-      "x": -3172,
-      "y": 11694,
+      "x": -2802,
+      "y": 11674,
       "variableGuid": "B6C34135-EF0E-42EF-AC0D-621D8A8A165D",
       "operations": [
         {
@@ -2435,8 +2435,8 @@
           "isCollapsed": true
         }
       ],
-      "x": -3172,
-      "y": 11814
+      "x": -2802,
+      "y": 11794
     },
     {
       "id": "4BE16981-95D8-4418-B598-B26CA6843820",
@@ -2454,8 +2454,8 @@
           "isCollapsed": true
         }
       ],
-      "x": -3052,
-      "y": 23574,
+      "x": -2682,
+      "y": 23554,
       "variableGuid": "F6ED0768-9852-46AF-B822-2172586824B7",
       "operations": [
         {
@@ -2586,8 +2586,8 @@
           "isCollapsed": false
         }
       ],
-      "x": -3052,
-      "y": 23694,
+      "x": -2682,
+      "y": 23674,
       "loopBlockId": "1B323E62-40BB-40D7-AD9A-D04DA4A5FFB6",
       "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
       "endpoint_guid": "84ad9050-6f72-11eb-aa08-a1dda4364ef5",
@@ -2633,8 +2633,8 @@
           "isCollapsed": false
         }
       ],
-      "x": -2932,
-      "y": 23794,
+      "x": -2562,
+      "y": 23774,
       "childTrueId": "1C69733A-CADE-4901-9BC2-4CDA59A50DA2",
       "childFalseId": null
     },
@@ -2674,8 +2674,8 @@
           "isCollapsed": true
         }
       ],
-      "x": -2812,
-      "y": 23874,
+      "x": -2442,
+      "y": 23854,
       "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
       "endpoint_guid": "fcc108b0-67b2-11eb-806a-3957ec36f31b",
       "endpoint_role": "delete"
@@ -2710,8 +2710,8 @@
           "isCollapsed": true
         }
       ],
-      "x": -2812,
-      "y": 23994
+      "x": -2442,
+      "y": 23974
     },
     {
       "id": "D5570044-9796-4DC7-81B6-C6D2F937FB1F",
@@ -2729,8 +2729,8 @@
           "isCollapsed": true
         }
       ],
-      "x": -2932,
-      "y": 24194,
+      "x": -2562,
+      "y": 24174,
       "variableGuid": "F6ED0768-9852-46AF-B822-2172586824B7",
       "operations": [
         {
@@ -3962,8 +3962,8 @@
           "isCollapsed": false
         }
       ],
-      "x": -3292,
-      "y": 3794
+      "x": -2922,
+      "y": 3774
     },
     {
       "id": "D68D0C47-8D62-4ADC-AC47-553E8E9A05ED",
@@ -3981,8 +3981,8 @@
           "isCollapsed": false
         }
       ],
-      "x": -3292,
-      "y": 3914,
+      "x": -2922,
+      "y": 3894,
       "variableGuid": "4FCFD564-CA0B-4516-AD61-A1A2EE9CF38C",
       "operations": [
         {
@@ -4033,8 +4033,8 @@
           "isCollapsed": false
         }
       ],
-      "x": -3292,
-      "y": 4154,
+      "x": -2922,
+      "y": 4134,
       "childTrueId": "FBD838AA-F63C-4948-B755-00F8F6F2CDCF",
       "childFalseId": "8968628A-54FC-4578-98FD-32FAE0B1454F"
     },
@@ -4088,8 +4088,8 @@
           "isCollapsed": false
         }
       ],
-      "x": -3172,
-      "y": 4234,
+      "x": -2802,
+      "y": 4214,
       "loopBlockId": "D3F1FBD1-BEBC-4148-92AF-528D93FE1B8A"
     },
     {
@@ -4108,8 +4108,8 @@
           "isCollapsed": true
         }
       ],
-      "x": -2932,
-      "y": 4414,
+      "x": -2562,
+      "y": 4394,
       "variableGuid": "1ECFDB29-BC7A-4B7A-AE5F-2A2DBE77B1E0",
       "operations": [
         {
@@ -4170,8 +4170,8 @@
           "isCollapsed": false
         }
       ],
-      "x": -3172,
-      "y": 4734,
+      "x": -2802,
+      "y": 4714,
       "loopBlockId": "619BAD5D-8B64-4866-9E4B-A6E8108FF386"
     },
     {
@@ -4190,8 +4190,8 @@
           "isCollapsed": true
         }
       ],
-      "x": -2932,
-      "y": 4914,
+      "x": -2562,
+      "y": 4894,
       "variableGuid": "1ECFDB29-BC7A-4B7A-AE5F-2A2DBE77B1E0",
       "operations": [
         {
@@ -4246,8 +4246,8 @@
           "isCollapsed": false
         }
       ],
-      "x": -3292,
-      "y": 4034,
+      "x": -2922,
+      "y": 4014,
       "variableGuid": "1ECFDB29-BC7A-4B7A-AE5F-2A2DBE77B1E0",
       "operations": [
         {
@@ -4362,8 +4362,8 @@
           "isCollapsed": false
         }
       ],
-      "x": -3052,
-      "y": 4334,
+      "x": -2682,
+      "y": 4314,
       "childTrueId": "8C37F961-8477-4705-A167-CACE4E579177",
       "childFalseId": null
     },
@@ -4407,8 +4407,8 @@
           "isCollapsed": false
         }
       ],
-      "x": -3052,
-      "y": 4834,
+      "x": -2682,
+      "y": 4814,
       "childTrueId": "D5F81616-F18E-481D-8254-DC54513F20A3",
       "childFalseId": null
     },
@@ -4442,8 +4442,8 @@
           "isCollapsed": false
         }
       ],
-      "x": -3292,
-      "y": 5234
+      "x": -2922,
+      "y": 5214
     },
     {
       "id": "F211A56A-FBCB-4413-BA12-91144F38B722",
@@ -4475,8 +4475,8 @@
           "isCollapsed": true
         }
       ],
-      "x": -3052,
-      "y": 5774
+      "x": -2682,
+      "y": 5754
     },
     {
       "id": "B67C3598-6171-40D5-87CE-E7CBA1D58E16",
@@ -4494,8 +4494,8 @@
           "isCollapsed": false
         }
       ],
-      "x": -3292,
-      "y": 5354,
+      "x": -2922,
+      "y": 5334,
       "variableGuid": "09C608F2-CF67-4C9A-983E-F39019D443B9",
       "operations": [
         {
@@ -4536,8 +4536,8 @@
           "isCollapsed": false
         }
       ],
-      "x": -3292,
-      "y": 5594,
+      "x": -2922,
+      "y": 5574,
       "loopBlockId": "7CE340D0-20D9-4B6B-80C0-9295582D1CF9"
     },
     {
@@ -4580,8 +4580,8 @@
           "isCollapsed": false
         }
       ],
-      "x": -3172,
-      "y": 5694,
+      "x": -2802,
+      "y": 5674,
       "childTrueId": "F211A56A-FBCB-4413-BA12-91144F38B722",
       "childFalseId": null
     },
@@ -4625,8 +4625,8 @@
           "isCollapsed": false
         }
       ],
-      "x": -3292,
-      "y": 6174,
+      "x": -2922,
+      "y": 6154,
       "childTrueId": "EBDE966E-F544-46BF-89EA-FB5A671494B7",
       "childFalseId": null
     },
@@ -4646,8 +4646,8 @@
           "isCollapsed": true
         }
       ],
-      "x": -3172,
-      "y": 6254,
+      "x": -2802,
+      "y": 6234,
       "variableGuid": "407730A6-EC96-4337-BE80-CF4C0D552F08",
       "operations": [
         {
@@ -4674,8 +4674,8 @@
           "isCollapsed": true
         }
       ],
-      "x": -3172,
-      "y": 6374,
+      "x": -2802,
+      "y": 6354,
       "variableGuid": "1BF2068B-106E-4D58-BC51-884F1810F03C",
       "operations": [
         {
@@ -4710,8 +4710,8 @@
           "isCollapsed": true
         }
       ],
-      "x": -3172,
-      "y": 6494
+      "x": -2802,
+      "y": 6474
     },
     {
       "id": "ECCD6D36-805D-44EF-A411-A73316586DD1",
@@ -4770,8 +4770,8 @@
           "isCollapsed": false
         }
       ],
-      "x": -3292,
-      "y": 6694,
+      "x": -2922,
+      "y": 6674,
       "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
       "endpoint_guid": "72d48530-bbb0-11f0-875a-b322bf237aeb",
       "endpoint_role": "create"
@@ -4792,8 +4792,8 @@
           "isCollapsed": true
         }
       ],
-      "x": -3052,
-      "y": 5894,
+      "x": -2682,
+      "y": 5874,
       "variableGuid": "CB55538C-0F1A-4871-98DD-C68EC5B00D84",
       "operations": [
         {
@@ -4820,8 +4820,8 @@
           "isCollapsed": false
         }
       ],
-      "x": -3292,
-      "y": 5474,
+      "x": -2922,
+      "y": 5454,
       "variableGuid": "CB55538C-0F1A-4871-98DD-C68EC5B00D84",
       "operations": [
         {
@@ -4886,8 +4886,8 @@
           "isCollapsed": false
         }
       ],
-      "x": -3292,
-      "y": 15034,
+      "x": -2922,
+      "y": 15014,
       "loopBlockId": "DAD45F04-D485-42E3-B7DD-D8C3106EA5FC",
       "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
       "endpoint_guid": "8cc63340-107b-11ec-ab5d-f9b221ed2dc5",
@@ -4950,8 +4950,8 @@
           "isCollapsed": true
         }
       ],
-      "x": -3172,
-      "y": 15134,
+      "x": -2802,
+      "y": 15114,
       "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
       "endpoint_guid": "72d48530-bbb0-11f0-875a-b322bf237aeb",
       "endpoint_role": "create"
@@ -4972,8 +4972,8 @@
           "isCollapsed": false
         }
       ],
-      "x": -3292,
-      "y": 14914,
+      "x": -2922,
+      "y": 14894,
       "variableGuid": "2E37F6E5-BE30-44ED-B0B6-B544ECEAAB9E",
       "operations": [
         {
@@ -5014,8 +5014,8 @@
           "isCollapsed": false
         }
       ],
-      "x": -3292,
-      "y": 15414,
+      "x": -2922,
+      "y": 15394,
       "loopBlockId": "0DBF0B78-A809-4DDE-B02F-EF043A628D39"
     },
     {
@@ -5063,8 +5063,8 @@
           "isCollapsed": false
         }
       ],
-      "x": -3172,
-      "y": 18134,
+      "x": -2802,
+      "y": 18114,
       "childTrueId": "40EC15FE-C25F-442B-8CD9-5C87150436B3",
       "childFalseId": null
     },
@@ -5084,8 +5084,8 @@
           "isCollapsed": true
         }
       ],
-      "x": -3172,
-      "y": 15254,
+      "x": -2802,
+      "y": 15234,
       "variableGuid": "2E37F6E5-BE30-44ED-B0B6-B544ECEAAB9E",
       "operations": [
         {
@@ -5126,8 +5126,8 @@
           "isCollapsed": false
         }
       ],
-      "x": -3172,
-      "y": 15994,
+      "x": -2802,
+      "y": 15974,
       "loopBlockId": "5BD148B9-BDD1-4C37-8EB3-73641F532BB3"
     },
     {
@@ -5170,8 +5170,8 @@
           "isCollapsed": false
         }
       ],
-      "x": -3052,
-      "y": 16094,
+      "x": -2682,
+      "y": 16074,
       "childTrueId": "0C03554A-88E9-4987-8DA7-2707C33613B5",
       "childFalseId": null
     },
@@ -5191,8 +5191,8 @@
           "isCollapsed": true
         }
       ],
-      "x": -3172,
-      "y": 15514,
+      "x": -2802,
+      "y": 15494,
       "variableGuid": "B762B4A7-25F9-4764-BECA-D4461377CE04",
       "operations": [
         {
@@ -5219,8 +5219,8 @@
           "isCollapsed": true
         }
       ],
-      "x": -2572,
-      "y": 16694,
+      "x": -2202,
+      "y": 16674,
       "variableGuid": "B762B4A7-25F9-4764-BECA-D4461377CE04",
       "operations": [
         {
@@ -5261,8 +5261,8 @@
           "isCollapsed": true
         }
       ],
-      "x": -2812,
-      "y": 17774
+      "x": -2442,
+      "y": 17754
     },
     {
       "id": "0C03554A-88E9-4987-8DA7-2707C33613B5",
@@ -5309,8 +5309,8 @@
           "isCollapsed": false
         }
       ],
-      "x": -2932,
-      "y": 16174,
+      "x": -2562,
+      "y": 16154,
       "loopBlockId": null
     },
     {
@@ -5353,8 +5353,8 @@
           "isCollapsed": false
         }
       ],
-      "x": -2932,
-      "y": 16334,
+      "x": -2562,
+      "y": 16314,
       "childTrueId": "7FC2859A-CB6D-4A81-B1B7-8DA4C1DF9E27",
       "childFalseId": "1D37B0B5-533A-4C98-8C0C-5D27CA83E613"
     },
@@ -5398,8 +5398,8 @@
           "isCollapsed": false
         }
       ],
-      "x": -2812,
-      "y": 16414,
+      "x": -2442,
+      "y": 16394,
       "childTrueId": "C1A9C7CC-6DAC-4E03-B987-F44C2C040BF9",
       "childFalseId": "A6B5E4EE-819B-4767-AE9A-2E127BD6DC6C"
     },
@@ -5419,8 +5419,8 @@
           "isCollapsed": true
         }
       ],
-      "x": -3172,
-      "y": 15874,
+      "x": -2802,
+      "y": 15854,
       "variableGuid": "4CFD6FDB-6937-45CE-8677-203A280087D1",
       "operations": [
         {
@@ -5447,8 +5447,8 @@
           "isCollapsed": true
         }
       ],
-      "x": -3172,
-      "y": 15754,
+      "x": -2802,
+      "y": 15734,
       "variableGuid": "12A37AC8-CD9C-41FC-9626-508B24997C86",
       "operations": [
         {
@@ -5489,8 +5489,8 @@
           "isCollapsed": true
         }
       ],
-      "x": -2692,
-      "y": 17534
+      "x": -2322,
+      "y": 17514
     },
     {
       "id": "EE2B05F0-E29D-4EF4-8016-AD92050B6D2D",
@@ -5522,8 +5522,8 @@
           "isCollapsed": true
         }
       ],
-      "x": -2572,
-      "y": 16574
+      "x": -2202,
+      "y": 16554
     },
     {
       "id": "C1A9C7CC-6DAC-4E03-B987-F44C2C040BF9",
@@ -5565,8 +5565,8 @@
           "isCollapsed": false
         }
       ],
-      "x": -2692,
-      "y": 16494,
+      "x": -2322,
+      "y": 16474,
       "childTrueId": "EE2B05F0-E29D-4EF4-8016-AD92050B6D2D",
       "childFalseId": "6E0F226F-5497-4493-9201-8FB2CFE66C25"
     },
@@ -5586,8 +5586,8 @@
           "isCollapsed": true
         }
       ],
-      "x": -3172,
-      "y": 15634,
+      "x": -2802,
+      "y": 15614,
       "variableGuid": "D8F8BD27-8FF5-42FF-82ED-0EE947E55327",
       "operations": [
         {
@@ -5614,8 +5614,8 @@
           "isCollapsed": true
         }
       ],
-      "x": -2572,
-      "y": 17094,
+      "x": -2202,
+      "y": 17074,
       "variableGuid": "D8F8BD27-8FF5-42FF-82ED-0EE947E55327",
       "operations": [
         {
@@ -5656,8 +5656,8 @@
           "isCollapsed": true
         }
       ],
-      "x": -2572,
-      "y": 16974
+      "x": -2202,
+      "y": 16954
     },
     {
       "id": "0C14812A-A344-4903-9697-1426DB5C5DFA",
@@ -5675,8 +5675,8 @@
           "isCollapsed": true
         }
       ],
-      "x": -2572,
-      "y": 16814,
+      "x": -2202,
+      "y": 16794,
       "variableGuid": "D8F8BD27-8FF5-42FF-82ED-0EE947E55327",
       "operations": [
         {
@@ -5717,8 +5717,8 @@
           "isCollapsed": true
         }
       ],
-      "x": -3052,
-      "y": 18494
+      "x": -2682,
+      "y": 18474
     },
     {
       "id": "4F36612D-0B32-4DA5-9803-85D5EEB3EDCB",
@@ -5800,8 +5800,8 @@
           "isCollapsed": true
         }
       ],
-      "x": -3052,
-      "y": 18614
+      "x": -2682,
+      "y": 18594
     },
     {
       "id": "9E937365-2524-466B-95E9-309B3293FF8D",
@@ -5819,8 +5819,8 @@
           "isCollapsed": true
         }
       ],
-      "x": -3052,
-      "y": 18734,
+      "x": -2682,
+      "y": 18714,
       "variableGuid": "996190EC-165A-4CF1-A3B6-363B8F0DDF31",
       "operations": [
         {
@@ -5891,8 +5891,8 @@
           "isCollapsed": true
         }
       ],
-      "x": -3052,
-      "y": 18854,
+      "x": -2682,
+      "y": 18834,
       "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
       "endpoint_guid": "194b9430-67b1-11eb-9e04-6dbde84bea83",
       "endpoint_role": "create"
@@ -5927,8 +5927,8 @@
           "isCollapsed": true
         }
       ],
-      "x": -3052,
-      "y": 19214
+      "x": -2682,
+      "y": 19194
     },
     {
       "id": "40EC15FE-C25F-442B-8CD9-5C87150436B3",
@@ -5970,8 +5970,8 @@
           "isCollapsed": false
         }
       ],
-      "x": -3052,
-      "y": 18214,
+      "x": -2682,
+      "y": 18194,
       "childTrueId": "BC596D9A-38F8-4F9A-8DC9-1D0DC81A57C4",
       "childFalseId": null
     },
@@ -6005,8 +6005,8 @@
           "isCollapsed": true
         }
       ],
-      "x": -2932,
-      "y": 18294
+      "x": -2562,
+      "y": 18274
     },
     {
       "id": "15A91B88-3C31-400B-A2C8-D697AB8F175E",
@@ -6038,8 +6038,8 @@
           "isCollapsed": true
         }
       ],
-      "x": -2932,
-      "y": 21514
+      "x": -2562,
+      "y": 21494
     },
     {
       "id": "ECB7B639-F151-4B44-A89E-491B20BE66F3",
@@ -6081,8 +6081,8 @@
           "isCollapsed": false
         }
       ],
-      "x": -3052,
-      "y": 21194,
+      "x": -2682,
+      "y": 21174,
       "childTrueId": "35EFB375-D90C-4F76-A966-47EDB1EAFAD2",
       "childFalseId": "9EE0A5EF-EE84-4F46-811E-312073C232C6"
     },
@@ -6154,8 +6154,8 @@
           "isCollapsed": true
         }
       ],
-      "x": -2932,
-      "y": 21274,
+      "x": -2562,
+      "y": 21254,
       "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
       "snippet_guid": "76a45090-00e1-11ec-ad85-b3b86b5b9a24"
     },
@@ -6225,8 +6225,8 @@
           "isCollapsed": true
         }
       ],
-      "x": -3052,
-      "y": 19094,
+      "x": -2682,
+      "y": 19074,
       "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
       "endpoint_guid": "72d48530-bbb0-11f0-875a-b322bf237aeb",
       "endpoint_role": "create"
@@ -6254,8 +6254,8 @@
           "isCollapsed": true
         }
       ],
-      "x": -3052,
-      "y": 18974
+      "x": -2682,
+      "y": 18954
     },
     {
       "id": "9F37EC62-2694-40D2-8DB1-7F5265D9EB9F",
@@ -6273,8 +6273,8 @@
           "isCollapsed": true
         }
       ],
-      "x": -3052,
-      "y": 19814,
+      "x": -2682,
+      "y": 19794,
       "variableGuid": "AE6C347F-BAAD-4FD0-A820-80AFEE588B29",
       "operations": [
         {
@@ -6330,8 +6330,8 @@
           "isCollapsed": false
         }
       ],
-      "x": -3052,
-      "y": 19934,
+      "x": -2682,
+      "y": 19914,
       "loopBlockId": "AFD7305E-B419-4128-95D3-1A9EAF98F9C8"
     },
     {
@@ -6400,8 +6400,8 @@
           "isCollapsed": true
         }
       ],
-      "x": -2932,
-      "y": 20034,
+      "x": -2562,
+      "y": 20014,
       "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
       "endpoint_guid": "72d48530-bbb0-11f0-875a-b322bf237aeb",
       "endpoint_role": "create"
@@ -6446,8 +6446,8 @@
           "isCollapsed": false
         }
       ],
-      "x": -2932,
-      "y": 20154,
+      "x": -2562,
+      "y": 20134,
       "childTrueId": "814E1A6D-6BCB-47DD-BD1D-39EC0CA9C101",
       "childFalseId": "4DA2DA61-2BB9-41DB-B354-3A2B8C5F2F2E"
     },
@@ -6508,8 +6508,8 @@
           "isCollapsed": true
         }
       ],
-      "x": -2932,
-      "y": 20914,
+      "x": -2562,
+      "y": 20894,
       "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
       "endpoint_guid": "72d48530-bbb0-11f0-875a-b322bf237aeb",
       "endpoint_role": "create"
@@ -6544,8 +6544,8 @@
           "isCollapsed": true
         }
       ],
-      "x": -2932,
-      "y": 21034
+      "x": -2562,
+      "y": 21014
     },
     {
       "id": "814E1A6D-6BCB-47DD-BD1D-39EC0CA9C101",
@@ -6577,8 +6577,8 @@
           "isCollapsed": true
         }
       ],
-      "x": -2812,
-      "y": 20234
+      "x": -2442,
+      "y": 20214
     },
     {
       "id": "E287D197-83E3-4C50-8598-34DDB03BD857",
@@ -6596,8 +6596,8 @@
           "isCollapsed": true
         }
       ],
-      "x": -2812,
-      "y": 20354,
+      "x": -2442,
+      "y": 20334,
       "variableGuid": "FA7C823B-3AA8-41EA-990F-21837758447A",
       "operations": [
         {
@@ -6643,8 +6643,8 @@
           "isCollapsed": true
         }
       ],
-      "x": -2812,
-      "y": 20634
+      "x": -2442,
+      "y": 20614
     },
     {
       "id": "4DA2DA61-2BB9-41DB-B354-3A2B8C5F2F2E",
@@ -6703,8 +6703,8 @@
           "isCollapsed": true
         }
       ],
-      "x": -2812,
-      "y": 20514,
+      "x": -2442,
+      "y": 20494,
       "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
       "endpoint_guid": "72d48530-bbb0-11f0-875a-b322bf237aeb",
       "endpoint_role": "create"
@@ -6725,8 +6725,8 @@
           "isCollapsed": true
         }
       ],
-      "x": -2812,
-      "y": 20754,
+      "x": -2442,
+      "y": 20734,
       "variableGuid": "FA7C823B-3AA8-41EA-990F-21837758447A",
       "operations": [
         {
@@ -6772,8 +6772,8 @@
           "isCollapsed": true
         }
       ],
-      "x": -3052,
-      "y": 19334
+      "x": -2682,
+      "y": 19314
     },
     {
       "id": "73B15F09-DCC3-43F4-8DCB-9ACE58E3FACF",
@@ -6811,8 +6811,8 @@
           "isCollapsed": true
         }
       ],
-      "x": -3052,
-      "y": 19454,
+      "x": -2682,
+      "y": 19434,
       "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
       "snippet_guid": "8d2f7da0-5028-11eb-8889-317a6c8ea7fc"
     },
@@ -6864,8 +6864,8 @@
           "isCollapsed": true
         }
       ],
-      "x": -3052,
-      "y": 19574,
+      "x": -2682,
+      "y": 19554,
       "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
       "endpoint_guid": "916661a0-a12b-11ed-882f-fb01a4e99b0a",
       "endpoint_role": "create"
@@ -6900,8 +6900,8 @@
           "isCollapsed": true
         }
       ],
-      "x": -3052,
-      "y": 19694
+      "x": -2682,
+      "y": 19674
     },
     {
       "id": "9EE0A5EF-EE84-4F46-811E-312073C232C6",
@@ -6933,8 +6933,8 @@
           "isCollapsed": false
         }
       ],
-      "x": -2932,
-      "y": 22294,
+      "x": -2562,
+      "y": 22274,
       "loopBlockId": "0D70200F-BF52-4CCD-8FB5-C81C9692D24B"
     },
     {
@@ -6994,8 +6994,8 @@
           "isCollapsed": true
         }
       ],
-      "x": -2812,
-      "y": 21974,
+      "x": -2442,
+      "y": 21954,
       "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
       "endpoint_guid": "72d48530-bbb0-11f0-875a-b322bf237aeb",
       "endpoint_role": "create"
@@ -7030,8 +7030,8 @@
           "isCollapsed": true
         }
       ],
-      "x": -2812,
-      "y": 22094
+      "x": -2442,
+      "y": 22074
     },
     {
       "id": "292F6681-A0A3-4149-8900-B146F799C502",
@@ -7063,8 +7063,8 @@
           "isCollapsed": false
         }
       ],
-      "x": -2932,
-      "y": 21874,
+      "x": -2562,
+      "y": 21854,
       "loopBlockId": "75038005-FF42-4CA7-B4C9-0CA9EE70631D"
     },
     {
@@ -7090,8 +7090,8 @@
           "isCollapsed": true
         }
       ],
-      "x": -2932,
-      "y": 21634
+      "x": -2562,
+      "y": 21614
     },
     {
       "id": "D39D8A7B-718C-46EC-B3F1-24E2A2BF5185",
@@ -7159,8 +7159,8 @@
           "isCollapsed": true
         }
       ],
-      "x": -2932,
-      "y": 21754,
+      "x": -2562,
+      "y": 21734,
       "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
       "endpoint_guid": "72d48530-bbb0-11f0-875a-b322bf237aeb",
       "endpoint_role": "create"
@@ -7181,8 +7181,8 @@
           "isCollapsed": true
         }
       ],
-      "x": -2932,
-      "y": 21394,
+      "x": -2562,
+      "y": 21374,
       "variableGuid": "A812E467-95BC-419E-B6A6-4341D6347C3A",
       "operations": [
         {
@@ -7209,8 +7209,8 @@
           "isCollapsed": true
         }
       ],
-      "x": -2692,
-      "y": 17374,
+      "x": -2322,
+      "y": 17354,
       "variableGuid": "A812E467-95BC-419E-B6A6-4341D6347C3A",
       "operations": [
         {
@@ -7278,8 +7278,8 @@
           "isCollapsed": true
         }
       ],
-      "x": -2812,
-      "y": 22514,
+      "x": -2442,
+      "y": 22494,
       "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
       "endpoint_guid": "72d48530-bbb0-11f0-875a-b322bf237aeb",
       "endpoint_role": "create"
@@ -7314,8 +7314,8 @@
           "isCollapsed": true
         }
       ],
-      "x": -2812,
-      "y": 22634
+      "x": -2442,
+      "y": 22614
     },
     {
       "id": "0D70200F-BF52-4CCD-8FB5-C81C9692D24B",
@@ -7347,8 +7347,8 @@
           "isCollapsed": true
         }
       ],
-      "x": -2812,
-      "y": 22394
+      "x": -2442,
+      "y": 22374
     },
     {
       "id": "3ABDBFAA-8E94-4AA9-87C6-AC03B13D58F0",
@@ -7416,8 +7416,8 @@
           "isCollapsed": true
         }
       ],
-      "x": -2812,
-      "y": 22754,
+      "x": -2442,
+      "y": 22734,
       "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
       "endpoint_guid": "72d48530-bbb0-11f0-875a-b322bf237aeb",
       "endpoint_role": "create"
@@ -7479,8 +7479,8 @@
           "isCollapsed": true
         }
       ],
-      "x": -2812,
-      "y": 23254,
+      "x": -2442,
+      "y": 23234,
       "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
       "endpoint_guid": "72d48530-bbb0-11f0-875a-b322bf237aeb",
       "endpoint_role": "create"
@@ -7515,8 +7515,8 @@
           "isCollapsed": true
         }
       ],
-      "x": -2812,
-      "y": 23374
+      "x": -2442,
+      "y": 23354
     },
     {
       "id": "AD01998A-BEE0-473B-99F7-E6CC8C4B60CF",
@@ -7563,8 +7563,8 @@
           "isCollapsed": false
         }
       ],
-      "x": -2812,
-      "y": 22874,
+      "x": -2442,
+      "y": 22854,
       "loopBlockId": "151AA8FD-9389-44F0-8522-5AFF01889D68"
     },
     {
@@ -7624,8 +7624,8 @@
           "isCollapsed": true
         }
       ],
-      "x": -2692,
-      "y": 22974,
+      "x": -2322,
+      "y": 22954,
       "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
       "endpoint_guid": "72d48530-bbb0-11f0-875a-b322bf237aeb",
       "endpoint_role": "create"
@@ -7660,8 +7660,8 @@
           "isCollapsed": true
         }
       ],
-      "x": -2692,
-      "y": 23094
+      "x": -2322,
+      "y": 23074
     },
     {
       "id": "F959E5AA-4EC0-4284-AA66-F59C788B6B08",
@@ -7783,8 +7783,8 @@
           "isCollapsed": false
         }
       ],
-      "x": -3292,
-      "y": 13914,
+      "x": -2922,
+      "y": 13894,
       "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
       "endpoint_guid": "72d48530-bbb0-11f0-875a-b322bf237aeb",
       "endpoint_role": "create"
@@ -7829,8 +7829,8 @@
           "isCollapsed": false
         }
       ],
-      "x": -3292,
-      "y": 14034,
+      "x": -2922,
+      "y": 14014,
       "childTrueId": "D2202317-6AF5-42C3-A20F-5806BAEABEDA",
       "childFalseId": null
     },
@@ -7891,8 +7891,8 @@
           "isCollapsed": false
         }
       ],
-      "x": -3292,
-      "y": 14674,
+      "x": -2922,
+      "y": 14654,
       "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
       "endpoint_guid": "72d48530-bbb0-11f0-875a-b322bf237aeb",
       "endpoint_role": "create"
@@ -7913,8 +7913,8 @@
           "isCollapsed": false
         }
       ],
-      "x": -3292,
-      "y": 13794,
+      "x": -2922,
+      "y": 13774,
       "variableGuid": "218D5568-BA73-49F2-9996-926C40E2AE08",
       "operations": [
         {
@@ -7955,8 +7955,8 @@
           "isCollapsed": false
         }
       ],
-      "x": -3292,
-      "y": 14554
+      "x": -2922,
+      "y": 14534
     },
     {
       "id": "5E1CFE7D-C393-4315-85EF-086507112AC6",
@@ -7988,8 +7988,8 @@
           "isCollapsed": false
         }
       ],
-      "x": -3292,
-      "y": 14794
+      "x": -2922,
+      "y": 14774
     },
     {
       "id": "C5498C80-2759-492A-A46F-58DEF52F8F9A",
@@ -8048,8 +8048,8 @@
           "isCollapsed": true
         }
       ],
-      "x": -3172,
-      "y": 14234,
+      "x": -2802,
+      "y": 14214,
       "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
       "endpoint_guid": "72d48530-bbb0-11f0-875a-b322bf237aeb",
       "endpoint_role": "create"
@@ -8084,8 +8084,8 @@
           "isCollapsed": true
         }
       ],
-      "x": -3172,
-      "y": 14114
+      "x": -2802,
+      "y": 14094
     },
     {
       "id": "D5C5031D-9058-4671-A035-978DBB1DC8E4",
@@ -8117,8 +8117,8 @@
           "isCollapsed": true
         }
       ],
-      "x": -3172,
-      "y": 14354
+      "x": -2802,
+      "y": 14334
     },
     {
       "id": "56DF743F-3565-4BB7-B484-27DB0E8E13F5",
@@ -8165,8 +8165,8 @@
           "isCollapsed": false
         }
       ],
-      "x": -3292,
-      "y": 12814,
+      "x": -2922,
+      "y": 12794,
       "loopBlockId": "439A8A90-8CAD-4F2F-A673-90754BB6B0AD"
     },
     {
@@ -8226,8 +8226,8 @@
           "isCollapsed": true
         }
       ],
-      "x": -3172,
-      "y": 13034,
+      "x": -2802,
+      "y": 13014,
       "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
       "endpoint_guid": "72d48530-bbb0-11f0-875a-b322bf237aeb",
       "endpoint_role": "create"
@@ -8262,8 +8262,8 @@
           "isCollapsed": true
         }
       ],
-      "x": -3172,
-      "y": 12914
+      "x": -2802,
+      "y": 12894
     },
     {
       "id": "848D7B98-1FE1-4584-BF60-F518D86E41F0",
@@ -8295,8 +8295,8 @@
           "isCollapsed": true
         }
       ],
-      "x": -3172,
-      "y": 13154
+      "x": -2802,
+      "y": 13134
     },
     {
       "id": "C9CA459B-7C50-4EDF-BD71-300FF8437382",
@@ -8328,8 +8328,8 @@
           "isCollapsed": false
         }
       ],
-      "x": -3292,
-      "y": 13314
+      "x": -2922,
+      "y": 13294
     },
     {
       "id": "28997C80-CF89-4863-BAD6-DD9A15FC72EF",
@@ -8388,8 +8388,8 @@
           "isCollapsed": false
         }
       ],
-      "x": -3292,
-      "y": 13434,
+      "x": -2922,
+      "y": 13414,
       "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
       "endpoint_guid": "72d48530-bbb0-11f0-875a-b322bf237aeb",
       "endpoint_role": "create"
@@ -8410,8 +8410,8 @@
           "isCollapsed": false
         }
       ],
-      "x": -3292,
-      "y": 13554,
+      "x": -2922,
+      "y": 13534,
       "variableGuid": "AABC69B3-4AB6-4777-A443-FCFCFDA805C4",
       "operations": [
         {
@@ -8452,8 +8452,8 @@
           "isCollapsed": false
         }
       ],
-      "x": -3292,
-      "y": 13674
+      "x": -2922,
+      "y": 13654
     },
     {
       "id": "F4D0DE07-AD02-4C58-9CEA-A3409E738389",
@@ -8471,8 +8471,8 @@
           "isCollapsed": false
         }
       ],
-      "x": -3292,
-      "y": 12014,
+      "x": -2922,
+      "y": 11994,
       "variableGuid": "DB5AD6FD-CA6D-4BDB-B12B-91C248324EE1",
       "operations": [
         {
@@ -8533,8 +8533,8 @@
           "isCollapsed": false
         }
       ],
-      "x": -3292,
-      "y": 12134,
+      "x": -2922,
+      "y": 12114,
       "loopBlockId": null
     },
     {
@@ -8577,8 +8577,8 @@
           "isCollapsed": false
         }
       ],
-      "x": -3292,
-      "y": 12294,
+      "x": -2922,
+      "y": 12274,
       "childTrueId": "1AEE9D36-5C63-4334-8758-ECD4056C36B3",
       "childFalseId": null
     },
@@ -8598,8 +8598,8 @@
           "isCollapsed": true
         }
       ],
-      "x": -3172,
-      "y": 12374,
+      "x": -2802,
+      "y": 12354,
       "variableGuid": "407730A6-EC96-4337-BE80-CF4C0D552F08",
       "operations": [
         {
@@ -8626,8 +8626,8 @@
           "isCollapsed": true
         }
       ],
-      "x": -3172,
-      "y": 12494,
+      "x": -2802,
+      "y": 12474,
       "variableGuid": "1BF2068B-106E-4D58-BC51-884F1810F03C",
       "operations": [
         {
@@ -8662,8 +8662,8 @@
           "isCollapsed": true
         }
       ],
-      "x": -3172,
-      "y": 12614
+      "x": -2802,
+      "y": 12594
     },
     {
       "id": "2E61A575-F621-4713-B446-C1BAC52D8834",
@@ -8761,8 +8761,8 @@
           "isCollapsed": false
         }
       ],
-      "x": -3292,
-      "y": 24514,
+      "x": -2922,
+      "y": 24494,
       "childTrueId": "FB25A35E-49F7-4A93-951E-84B8CF244FC0",
       "childFalseId": "1AC4CBD1-A4F2-4A7A-AAD8-E90C9F324004"
     },
@@ -8796,8 +8796,8 @@
           "isCollapsed": false
         }
       ],
-      "x": -3172,
-      "y": 24714,
+      "x": -2802,
+      "y": 24694,
       "loopBlockId": "3B9FCBAE-B4AD-491D-AA8C-95619A4C827C"
     },
     {
@@ -8875,8 +8875,8 @@
           "isCollapsed": true
         }
       ],
-      "x": -3052,
-      "y": 24814,
+      "x": -2682,
+      "y": 24794,
       "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
       "snippet_guid": "b5dbb7a0-e715-11ea-b2bf-43bb35adee19"
     },
@@ -8910,8 +8910,8 @@
           "isCollapsed": true
         }
       ],
-      "x": -3172,
-      "y": 24594
+      "x": -2802,
+      "y": 24574
     },
     {
       "id": "3F546BF0-1269-4DA8-A132-0F3DE54E86F4",
@@ -8943,8 +8943,8 @@
           "isCollapsed": true
         }
       ],
-      "x": -3052,
-      "y": 24934
+      "x": -2682,
+      "y": 24914
     },
     {
       "id": "3F25D3AA-32C6-4C4A-968D-7EA29AA29A76",
@@ -8976,8 +8976,8 @@
           "isCollapsed": true
         }
       ],
-      "x": -3052,
-      "y": 26634
+      "x": -2682,
+      "y": 26614
     },
     {
       "id": "CEEB9F64-6EF8-4820-AB01-EE03F916B81D",
@@ -9009,8 +9009,8 @@
           "isCollapsed": false
         }
       ],
-      "x": -3172,
-      "y": 25494,
+      "x": -2802,
+      "y": 25474,
       "loopBlockId": "DBF1BB1B-4211-420D-8B2C-AC9A5EC74B31"
     },
     {
@@ -9043,8 +9043,8 @@
           "isCollapsed": false
         }
       ],
-      "x": -3172,
-      "y": 25374
+      "x": -2802,
+      "y": 25354
     },
     {
       "id": "EC299E1F-F2CA-4149-B148-FC4319064F9D",
@@ -9086,8 +9086,8 @@
           "isCollapsed": false
         }
       ],
-      "x": -3292,
-      "y": 25294,
+      "x": -2922,
+      "y": 25274,
       "childTrueId": "4F1E7C76-BDAF-4C71-A828-279277FEBEBC",
       "childFalseId": "0B7C9754-D191-41BC-A121-E09CEB1D1E0C"
     },
@@ -9121,8 +9121,8 @@
           "isCollapsed": true
         }
       ],
-      "x": -3172,
-      "y": 25134
+      "x": -2802,
+      "y": 25114
     },
     {
       "id": "0B7C9754-D191-41BC-A121-E09CEB1D1E0C",
@@ -9154,8 +9154,8 @@
           "isCollapsed": true
         }
       ],
-      "x": -3172,
-      "y": 26834
+      "x": -2802,
+      "y": 26814
     },
     {
       "id": "DBF1BB1B-4211-420D-8B2C-AC9A5EC74B31",
@@ -9218,8 +9218,8 @@
           "isCollapsed": false
         }
       ],
-      "x": -3052,
-      "y": 25594,
+      "x": -2682,
+      "y": 25574,
       "loopBlockId": null,
       "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
       "endpoint_guid": "9f6166e0-bbb2-11f0-acdd-bd47067b5fbf",
@@ -9283,8 +9283,8 @@
           "isCollapsed": true
         }
       ],
-      "x": -2932,
-      "y": 25854,
+      "x": -2562,
+      "y": 25834,
       "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
       "endpoint_guid": "72d48530-bbb0-11f0-875a-b322bf237aeb",
       "endpoint_role": "create"
@@ -9334,8 +9334,8 @@
           "isCollapsed": false
         }
       ],
-      "x": -3052,
-      "y": 25754,
+      "x": -2682,
+      "y": 25734,
       "loopBlockId": "FDC0A602-52CC-46BF-9DAC-9320101C6DE5"
     },
     {
@@ -9368,8 +9368,8 @@
           "isCollapsed": true
         }
       ],
-      "x": -2932,
-      "y": 25974
+      "x": -2562,
+      "y": 25954
     },
     {
       "id": "87CA29E5-FAC2-4E81-A611-555DD014D546",
@@ -9432,8 +9432,8 @@
           "isCollapsed": false
         }
       ],
-      "x": -3052,
-      "y": 26134,
+      "x": -2682,
+      "y": 26114,
       "loopBlockId": "34F8AAE5-2A39-4EA6-84DD-200050879981",
       "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
       "endpoint_guid": "9f6166e0-bbb2-11f0-acdd-bd47067b5fbf",
@@ -9497,8 +9497,8 @@
           "isCollapsed": true
         }
       ],
-      "x": -2932,
-      "y": 26234,
+      "x": -2562,
+      "y": 26214,
       "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
       "endpoint_guid": "72d48530-bbb0-11f0-875a-b322bf237aeb",
       "endpoint_role": "create"
@@ -9533,8 +9533,8 @@
           "isCollapsed": true
         }
       ],
-      "x": -2932,
-      "y": 26354
+      "x": -2562,
+      "y": 26334
     },
     {
       "id": "BF1A16BF-5256-4500-953B-F576C3C6B651",
@@ -9594,8 +9594,8 @@
           "isCollapsed": true
         }
       ],
-      "x": -3052,
-      "y": 26514,
+      "x": -2682,
+      "y": 26494,
       "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
       "endpoint_guid": "72d48530-bbb0-11f0-875a-b322bf237aeb",
       "endpoint_role": "create"
@@ -9669,8 +9669,8 @@
           "isCollapsed": true
         }
       ],
-      "x": -3172,
-      "y": 7134
+      "x": -2802,
+      "y": 7114
     },
     {
       "id": "D0CE93F3-2D1E-4F03-8384-E10EDA8D85F7",
@@ -9688,8 +9688,8 @@
           "isCollapsed": true
         }
       ],
-      "x": -3172,
-      "y": 7014,
+      "x": -2802,
+      "y": 6994,
       "variableGuid": "1BF2068B-106E-4D58-BC51-884F1810F03C",
       "operations": [
         {
@@ -9716,8 +9716,8 @@
           "isCollapsed": true
         }
       ],
-      "x": -3172,
-      "y": 6894,
+      "x": -2802,
+      "y": 6874,
       "variableGuid": "407730A6-EC96-4337-BE80-CF4C0D552F08",
       "operations": [
         {
@@ -9768,8 +9768,8 @@
           "isCollapsed": false
         }
       ],
-      "x": -3292,
-      "y": 6814,
+      "x": -2922,
+      "y": 6794,
       "childTrueId": "71CF1DF2-EDD5-4BD0-859E-8B644FFA7552",
       "childFalseId": null
     },
@@ -9803,8 +9803,8 @@
           "isCollapsed": true
         }
       ],
-      "x": -3292,
-      "y": 26994
+      "x": -2922,
+      "y": 26974
     },
     {
       "id": "215C3F93-2B59-4ADA-A98E-870483095D2C",
@@ -9836,8 +9836,8 @@
           "isCollapsed": true
         }
       ],
-      "x": -3292,
-      "y": 27114
+      "x": -2922,
+      "y": 27094
     },
     {
       "id": "4D28FE57-54CB-4FA9-A5EE-A7C65992D3FD",
@@ -9964,8 +9964,8 @@
           "isCollapsed": true
         }
       ],
-      "x": -2692,
-      "y": 17254,
+      "x": -2322,
+      "y": 17234,
       "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
       "endpoint_guid": "dbdc5470-c7a5-11ea-9135-b9442d1570d8",
       "endpoint_role": "get"
@@ -10072,7 +10072,7 @@
       "disabled": false,
       "name": "inputs4",
       "displayName": "Inputs 4",
-      "comment": "",
+      "comment": "want to proceed with update?",
       "childId": "ABF9478A-D559-4049-BA23-984416DB5D99",
       "inputs": [],
       "settings": [
@@ -10117,7 +10117,7 @@
       "disabled": false,
       "name": "output55",
       "displayName": "Output 55",
-      "comment": "",
+      "comment": "Ouptut - Upate needed",
       "childId": "3521F356-424C-44DE-8801-3042B0539E8D",
       "inputs": [
         {
@@ -10150,7 +10150,7 @@
       "disabled": false,
       "name": "condition36",
       "displayName": "Condition 36",
-      "comment": "",
+      "comment": "Users answer",
       "childId": null,
       "inputs": [
         {
@@ -10195,7 +10195,7 @@
       "disabled": false,
       "name": "callURL4",
       "displayName": "Call URL 4",
-      "comment": "",
+      "comment": "Get the current version ",
       "childId": "1C53F6DA-FE4F-4BE3-8A95-82EF0EC3E288",
       "inputs": [
         {
@@ -10278,7 +10278,7 @@
       "disabled": false,
       "name": "updateAutomation",
       "displayName": "Qlik Cloud Services - Update Automation",
-      "comment": "",
+      "comment": "Update this automation",
       "childId": "99C259DE-CADE-4561-8634-3C93EA662301",
       "inputs": [
         {
@@ -10344,7 +10344,7 @@
       "disabled": false,
       "name": "output56",
       "displayName": "Output 56",
-      "comment": "",
+      "comment": "Output - Automation has been updated",
       "childId": "08CBB6D5-ACC3-40AD-A7DA-AA28CD5AD4DB",
       "inputs": [
         {
@@ -10377,7 +10377,7 @@
       "disabled": false,
       "name": "stop",
       "displayName": "Stop",
-      "comment": "",
+      "comment": "Don't continue.",
       "childId": null,
       "inputs": [],
       "settings": [],
@@ -10396,7 +10396,7 @@
       "disabled": false,
       "name": "updateRunTitle3",
       "displayName": "Update Run Title 3",
-      "comment": "",
+      "comment": "Update title - New version and run again.",
       "childId": "F8CCF961-2D55-43AE-A8B3-CED17A4A0B9A",
       "inputs": [
         {

--- a/automations/singleTenantDeployer.json
+++ b/automations/singleTenantDeployer.json
@@ -1,10604 +1,10687 @@
 {
   "blocks": [
-    {
-      "id": "6841B156-73A9-4B99-AF20-87BE64A92442",
-      "type": "StartBlock",
-      "disabled": false,
-      "name": "Start",
-      "displayName": "Start",
-      "comment": "",
-      "childId": "E71CFD36-7B6D-4CFC-8F5F-AF73409624B4",
-      "inputs": [
-        {
-          "id": "run_mode",
-          "value": "manual",
-          "type": "select",
-          "structure": {}
-        }
-      ],
-      "settings": [],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": false
-        }
-      ],
-      "x": -2922,
-      "y": -3826
-    },
-    {
-      "id": "E71CFD36-7B6D-4CFC-8F5F-AF73409624B4",
-      "type": "ShowBlock",
-      "disabled": false,
-      "name": "output",
-      "displayName": "Output",
-      "comment": "README: Check the variables below, perform a manual run to successfully deploy all apps the first time, and then schedule this automation to run weekly or monthly.",
-      "childId": "A9BBBC6E-49FE-4819-BE22-504FC54335F2",
-      "inputs": [
-        {
-          "id": "input",
-          "value": "## Qlik Cloud Monitoring App deployer\n\nThe Qlik Cloud monitoring app deployer automates the installation and update of the monitoring apps from the [Qlik Cloud monitoring apps repository](https://github.com/qlik-oss/qlik-cloud-monitoring-apps). Check the variables below, then run manually, or schedule for when you'd like your apps updated.\n\n**Some apps require specific license entitlements and will not be installed if these criteria are not met.**",
-          "type": "string",
-          "structure": []
-        }
-      ],
-      "settings": [
-        {
-          "id": "display_mode",
-          "value": "add",
-          "type": "select",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": false
-        }
-      ],
-      "x": -2922,
-      "y": -3706
-    },
-    {
-      "id": "6AC0239B-01A8-47F9-AD4C-ED09CCB2B83F",
-      "type": "VariableBlock",
-      "disabled": false,
-      "name": "sharedSpaceName",
-      "displayName": "Variable - sharedSpaceName",
-      "comment": "Enter a space name to use as the staging space. A space will be created if it does not exist.",
-      "childId": "816EE781-6447-4CB2-AE71-07512C23A11E",
-      "inputs": [],
-      "settings": [],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2802,
-      "y": -3026,
-      "variableGuid": "E3084D5D-4DE7-428E-BDE0-440DCD055EDD",
-      "operations": [
-        {
-          "id": "set_value",
-          "key": "14252438-DA6C-489E-BA9F-97F75C4BF373",
-          "name": "Set value of { variable }",
-          "value": "Monitoring - staging"
-        }
-      ]
-    },
-    {
-      "id": "816EE781-6447-4CB2-AE71-07512C23A11E",
-      "type": "VariableBlock",
-      "disabled": false,
-      "name": "managedSpaceName",
-      "displayName": "Variable - managedSpaceName",
-      "comment": "Enter a space name to use as the managed space. A space will be created if it does not exist.",
-      "childId": "749BB890-520A-4E81-8C75-5738241F7586",
-      "inputs": [],
-      "settings": [],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2802,
-      "y": -2906,
-      "variableGuid": "247B71DE-30E7-4526-AC3D-BE5E17AA9194",
-      "operations": [
-        {
-          "id": "set_value",
-          "key": "14252438-DA6C-489E-BA9F-97F75C4BF373",
-          "name": "Set value of { variable }",
-          "value": "Monitoring"
-        }
-      ]
-    },
-    {
-      "id": "749BB890-520A-4E81-8C75-5738241F7586",
-      "type": "VariableBlock",
-      "disabled": false,
-      "name": "versionsToKeep",
-      "displayName": "Variable - versionsToKeep",
-      "comment": "If you wish to keep previously deployed apps in the staging space, enter a number of apps to keep. Set to 0 to always delete all apps from the shared space. Default = 0",
-      "childId": null,
-      "inputs": [],
-      "settings": [],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2802,
-      "y": -2786,
-      "variableGuid": "9679AB7C-F7EB-4A7F-A217-B2F9F14CE7E5",
-      "operations": [
-        {
-          "id": "set_value",
-          "key": "1CC6616E-100F-4B1E-AB18-98A204CBE862",
-          "name": "Set value of { variable }",
-          "value": "0"
-        }
-      ]
-    },
-    {
-      "id": "F9DCB126-6ED4-4D9A-BF35-CFD7A6D9CECD",
-      "type": "EndpointBlock",
-      "disabled": false,
-      "name": "getCurrentUserId",
-      "displayName": "Qlik Cloud Services - Get Current User Id",
-      "comment": "RUN: Don't edit below this point.\nFind current user ID.",
-      "childId": "BB38C4E9-A2B4-428B-BAAF-903E14CB56B1",
-      "inputs": [],
-      "settings": [
-        {
-          "id": "blendr_on_error",
-          "value": "stop",
-          "type": "select",
-          "structure": []
-        },
-        {
-          "id": "cache",
-          "value": "0",
-          "type": "select",
-          "structure": []
-        },
-        {
-          "id": "automations_censor_data",
-          "value": false,
-          "type": "checkbox",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": false
-        }
-      ],
-      "x": -2922,
-      "y": -2586,
-      "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
-      "endpoint_guid": "6e9dbaa0-c7a4-11ea-9bd3-0da55b4cbed9",
-      "endpoint_role": "get"
-    },
-    {
-      "id": "BB38C4E9-A2B4-428B-BAAF-903E14CB56B1",
-      "type": "EndpointBlock",
-      "disabled": false,
-      "name": "getUser",
-      "displayName": "Qlik Cloud Services - Get User",
-      "comment": "Get record for the current user.",
-      "childId": "43D8ED19-F455-48F9-9CC4-7FE2A93B1884",
-      "inputs": [
-        {
-          "id": "8eedf1d0-c7a5-11ea-9022-0fb2ce625902",
-          "value": "{$.getCurrentUserId}",
-          "type": "string",
-          "structure": []
-        }
-      ],
-      "settings": [
-        {
-          "id": "blendr_on_error",
-          "value": "stop",
-          "type": "select",
-          "structure": []
-        },
-        {
-          "id": "cache",
-          "value": "0",
-          "type": "select",
-          "structure": []
-        },
-        {
-          "id": "automations_censor_data",
-          "value": false,
-          "type": "checkbox",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": false
-        }
-      ],
-      "x": -2922,
-      "y": -2466,
-      "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
-      "endpoint_guid": "7e670290-c7a5-11ea-9a9c-6dd2b282df86",
-      "endpoint_role": "get"
-    },
-    {
-      "id": "E9A1664E-7B3A-4333-9DCA-65E34A43AD2D",
-      "type": "ShowBlock",
-      "disabled": false,
-      "name": "output2",
-      "displayName": "Output 2",
-      "comment": "Status output.",
-      "childId": "C199B1F5-97A8-493A-BA22-0632702923FD",
-      "inputs": [
-        {
-          "id": "input",
-          "value": "| Variable | Value |\n| -------- | ------- |\n| monitoringAppsToInstall | { implode: {$.configuredMonitoringApps}, ',' } |\n| refreshConnectorCredentials | {$.refreshConnectorCredentials} |\n| sharedSpaceName | {$.sharedSpaceName} |\n| managedSpaceName | {$.managedSpaceName} | \n| versionsToKeep | {$.versionsToKeep} |\n| Current User | {$.getUser.id} |\n| Tenant hostname | {$.tenantHostname} |\n| Template version | {$.currentTemplateVersionNum} |",
-          "type": "string",
-          "structure": []
-        }
-      ],
-      "settings": [
-        {
-          "id": "display_mode",
-          "value": "add",
-          "type": "select",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": false
-        }
-      ],
-      "x": -2922,
-      "y": -1866
-    },
-    {
-      "id": "D0E7DF6C-C216-4DB6-8502-1F3C4ADF5AFE",
-      "type": "IfElseBlock",
-      "disabled": false,
-      "name": "condition3",
-      "displayName": "Condition 3",
-      "comment": "Ensures that the current user has the TenantAdmin role. This is required for license checks and the detail app.",
-      "childId": "948CF475-AF52-4C8B-AF9E-07DD7DE82F45",
-      "inputs": [
-        {
-          "id": "conditions",
-          "value": {
-            "mode": "all",
-            "conditions": [
+      {
+          "id": "6841B156-73A9-4B99-AF20-87BE64A92442",
+          "type": "StartBlock",
+          "disabled": false,
+          "name": "Start",
+          "displayName": "Start",
+          "comment": "",
+          "childId": "E71CFD36-7B6D-4CFC-8F5F-AF73409624B4",
+          "inputs": [
               {
-                "input1": "{$.getUser.assignedRoles[*].name}",
-                "input2": "TenantAdmin",
-                "operator": "notInList"
-              },
-              {
-                "input1": "{$.getUser.assignedGroups[*].assignedRoles[*].name}",
-                "input2": "TenantAdmin",
-                "operator": "notInList"
+                  "id": "run_mode",
+                  "value": "manual",
+                  "type": "select",
+                  "structure": {}
               }
-            ]
-          },
-          "type": "custom",
-          "structure": []
-        }
-      ],
-      "settings": [],
-      "collapsed": [
-        {
-          "name": "yes",
-          "isCollapsed": false
-        },
-        {
-          "name": "no",
-          "isCollapsed": false
-        },
-        {
-          "name": "both",
-          "isCollapsed": false
-        }
-      ],
-      "x": -2922,
-      "y": -506,
-      "childTrueId": "BE7F53B8-B1FD-48DF-A8A5-D6638F74FA2C",
-      "childFalseId": null
-    },
-    {
-      "id": "9C6779A3-FFA8-49D8-B3AE-ADA3D57BA1D5",
-      "type": "EndpointBlock",
-      "disabled": false,
-      "name": "getLicenseOverview",
-      "displayName": "Qlik Cloud Services - Get License Overview",
-      "comment": "Get license to check for capacity-based flags.",
-      "childId": "6AB100F2-DB70-49EC-AA91-33C3F4639953",
-      "inputs": [],
-      "settings": [
-        {
-          "id": "blendr_on_error",
-          "value": "stop",
-          "type": "select",
-          "structure": []
-        },
-        {
-          "id": "cache",
-          "value": "0",
-          "type": "select",
-          "structure": []
-        },
-        {
-          "id": "automations_censor_data",
-          "value": false,
-          "type": "checkbox",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": false
-        }
-      ],
-      "x": -2922,
-      "y": 1934,
-      "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
-      "endpoint_guid": "0e6d4530-3291-11ed-a2e9-3bc221fc190c",
-      "endpoint_role": "get"
-    },
-    {
-      "id": "6C0A56A0-B3A3-4740-858E-57ABB5BF2CAC",
-      "type": "ShowBlock",
-      "disabled": false,
-      "name": "output3",
-      "displayName": "Output 3",
-      "comment": "Status output.",
-      "childId": "7BB23A76-A47D-4859-AE1D-D5532E49031D",
-      "inputs": [
-        {
-          "id": "input",
-          "value": "## Deployment progress\n\nDeployment is in progress. Status will be updated below.\n\n| Step | Status |\n| -------- | ------- |",
-          "type": "string",
-          "structure": []
-        }
-      ],
-      "settings": [
-        {
-          "id": "display_mode",
-          "value": "add",
-          "type": "select",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": false
-        }
-      ],
-      "x": -2922,
-      "y": 3654
-    },
-    {
-      "id": "F718EF32-99B6-49C3-A5A5-6996F86B0B87",
-      "type": "EndpointBlock",
-      "disabled": false,
-      "name": "searchSpaces",
-      "displayName": "Qlik Cloud Services - Search Spaces",
-      "comment": "Look for shared space.",
-      "childId": "FEA21EF3-D8E8-48DF-9013-8DC36FE5A54D",
-      "inputs": [
-        {
-          "id": "592e21a0-6d2e-11eb-9985-3ff14fb3335f",
-          "value": null,
-          "type": "string",
-          "structure": []
-        },
-        {
-          "id": "5935dec0-6d2e-11eb-8365-ab8493d4c237",
-          "value": null,
-          "type": "string",
-          "structure": []
-        },
-        {
-          "id": "593c5340-6d2e-11eb-a82b-e17cfa6c8a6d",
-          "value": null,
-          "type": "string",
-          "structure": []
-        },
-        {
-          "id": "59429c60-6d2e-11eb-b7b1-e7ca1f22830c",
-          "value": "{$.sharedSpaceName}",
-          "type": "string",
-          "structure": []
-        },
-        {
-          "id": "5949c230-6d2e-11eb-b345-99be61e9908c",
-          "value": null,
-          "type": "string",
-          "structure": []
-        }
-      ],
-      "settings": [
-        {
-          "id": "maxitemcount",
-          "value": "",
-          "type": "string",
-          "structure": []
-        },
-        {
-          "id": "blendr_on_error",
-          "value": "stop",
-          "type": "select",
-          "structure": []
-        },
-        {
-          "id": "automations_censor_data",
-          "value": false,
-          "type": "checkbox",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": false
-        }
-      ],
-      "x": -2922,
-      "y": 7314,
-      "loopBlockId": null,
-      "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
-      "endpoint_guid": "590a1a20-6d2e-11eb-9714-df1bbaac055d",
-      "endpoint_role": "search"
-    },
-    {
-      "id": "FEA21EF3-D8E8-48DF-9013-8DC36FE5A54D",
-      "type": "VariableBlock",
-      "disabled": false,
-      "name": "sharedSpaceId",
-      "displayName": "Variable - sharedSpaceId",
-      "comment": "Initialise the variable.",
-      "childId": "34B88617-9583-4EA4-948E-D580D65F3C49",
-      "inputs": [],
-      "settings": [],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": false
-        }
-      ],
-      "x": -2922,
-      "y": 7474,
-      "variableGuid": "DE390532-B1F9-4098-BBE0-B7E6101BD502",
-      "operations": [
-        {
-          "id": "empty",
-          "key": "D491693B-F764-49C2-94C2-C893014C604B",
-          "name": "Empty { variable }",
-          "value": null
-        }
-      ]
-    },
-    {
-      "id": "EB27466E-BFCB-4FFC-8B1A-3AA517AB3F4F",
-      "type": "ShowBlock",
-      "disabled": false,
-      "name": "output6",
-      "displayName": "Output 6",
-      "comment": "Status output.",
-      "childId": "3C37421F-9C07-4344-AD2E-1022C48BADF9",
-      "inputs": [
-        {
-          "id": "input",
-          "value": "| Shared space lookup | Found {$.filterList4.item.type} space matching name [{$.sharedSpaceName}]({$.tenantHostname}analytics/catalog?space_filter={$.sharedSpaceId}). |",
-          "type": "string",
-          "structure": []
-        }
-      ],
-      "settings": [
-        {
-          "id": "display_mode",
-          "value": "add",
-          "type": "select",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2802,
-      "y": 7814
-    },
-    {
-      "id": "34B88617-9583-4EA4-948E-D580D65F3C49",
-      "type": "FilterListBlock",
-      "disabled": false,
-      "name": "filterList4",
-      "displayName": "Filter over Qlik Cloud Services - Search Spaces - Filter List 4",
-      "comment": "Filter for exact name match for shared space.",
-      "childId": "E14426D0-F329-44A1-B59F-A27869D8920F",
-      "inputs": [
-        {
-          "id": "list",
-          "value": "{ $.searchSpaces }",
-          "type": "string",
-          "structure": []
-        },
-        {
-          "id": "conditions",
-          "value": {
-            "mode": "all",
-            "conditions": [
-              {
-                "input1": "name",
-                "input2": "{$.sharedSpaceName}",
-                "operator": "="
-              }
-            ]
-          },
-          "type": "custom",
-          "structure": []
-        }
-      ],
-      "settings": [
-        {
-          "id": "automations_censor_data",
-          "value": false,
-          "type": "checkbox",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": false
-        }
-      ],
-      "x": -2922,
-      "y": 7594,
-      "loopBlockId": "7E7CFBF2-F088-4F93-9BA8-DE932E22956E"
-    },
-    {
-      "id": "7E7CFBF2-F088-4F93-9BA8-DE932E22956E",
-      "type": "VariableBlock",
-      "disabled": false,
-      "name": "sharedSpaceId",
-      "displayName": "Variable - sharedSpaceId",
-      "comment": "Store shared space ID.",
-      "childId": "EB27466E-BFCB-4FFC-8B1A-3AA517AB3F4F",
-      "inputs": [],
-      "settings": [],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2802,
-      "y": 7694,
-      "variableGuid": "DE390532-B1F9-4098-BBE0-B7E6101BD502",
-      "operations": [
-        {
-          "id": "set_value",
-          "key": "112D67F1-764F-46E4-8CD8-79B8735F30E9",
-          "name": "Set value of { variable }",
-          "value": "{ $.filterList4.item.id }"
-        }
-      ]
-    },
-    {
-      "id": "3C37421F-9C07-4344-AD2E-1022C48BADF9",
-      "type": "IfElseBlock",
-      "disabled": false,
-      "name": "condition13",
-      "displayName": "Condition 13",
-      "comment": "If the space type is not shared, exit; otherwise, apply the Can Manage role.",
-      "childId": null,
-      "inputs": [
-        {
-          "id": "conditions",
-          "value": {
-            "mode": "all",
-            "conditions": [
-              {
-                "input1": "{$.filterList4[0].type}",
-                "input2": "shared",
-                "operator": "!="
-              }
-            ]
-          },
-          "type": "custom",
-          "structure": []
-        }
-      ],
-      "settings": [],
-      "collapsed": [
-        {
-          "name": "yes",
-          "isCollapsed": true
-        },
-        {
-          "name": "no",
-          "isCollapsed": true
-        },
-        {
-          "name": "both",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2802,
-      "y": 7934,
-      "childTrueId": "A29FDF70-7705-4848-B467-90DD6CD8F293",
-      "childFalseId": "EABD8111-E99F-4C5B-A67D-3D7F0ACE778E"
-    },
-    {
-      "id": "A29FDF70-7705-4848-B467-90DD6CD8F293",
-      "type": "VariableBlock",
-      "disabled": false,
-      "name": "errorTitle",
-      "displayName": "Variable - errorTitle",
-      "comment": "Set error title for standard error output.",
-      "childId": "6A1F7D55-1177-4CED-96ED-C5EAB1EF473C",
-      "inputs": [],
-      "settings": [],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2561,
-      "y": 7132,
-      "variableGuid": "407730A6-EC96-4337-BE80-CF4C0D552F08",
-      "operations": [
-        {
-          "id": "set_value",
-          "key": "1BC10F4C-68C2-42E9-9000-25865B076073",
-          "name": "Set value of { variable }",
-          "value": "A space of the wrong type was found with the configured shared space name."
-        }
-      ]
-    },
-    {
-      "id": "6A1F7D55-1177-4CED-96ED-C5EAB1EF473C",
-      "type": "VariableBlock",
-      "disabled": false,
-      "name": "errorDetail",
-      "displayName": "Variable - errorDetail",
-      "comment": "Variable to store detailed error message.",
-      "childId": "4B13B3CA-4EE2-4F26-A4E4-ECBE8AD13378",
-      "inputs": [],
-      "settings": [],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2561,
-      "y": 7252,
-      "variableGuid": "1BF2068B-106E-4D58-BC51-884F1810F03C",
-      "operations": [
-        {
-          "id": "set_value",
-          "key": "1BC10F4C-68C2-42E9-9000-25865B076073",
-          "name": "Set value of { variable }",
-          "value": "Exiting, an existing space with a type other than `shared` was found for the provided shared space name. Try another shared space name."
-        }
-      ]
-    },
-    {
-      "id": "4B13B3CA-4EE2-4F26-A4E4-ECBE8AD13378",
-      "type": "GotoBlock",
-      "disabled": false,
-      "name": "goToLabel8",
-      "displayName": "Go To Label 8",
-      "comment": "Go to the label named error.",
-      "childId": null,
-      "inputs": [
-        {
-          "id": "label",
-          "value": "EF82AD29-E2CF-44C9-A7DB-24C784618756",
-          "type": "select",
-          "displayValue": "error",
-          "structure": []
-        }
-      ],
-      "settings": [],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2561,
-      "y": 7372
-    },
-    {
-      "id": "EF82AD29-E2CF-44C9-A7DB-24C784618756",
-      "type": "LabelBlock",
-      "disabled": false,
-      "name": "label",
-      "displayName": "Label - error",
-      "comment": "Standard error handler which provides standardized error output.",
-      "childId": "D46F6E49-3856-430B-A685-0A07984CDAEB",
-      "inputs": [
-        {
-          "id": "name",
-          "value": "error",
-          "type": "string",
-          "structure": []
-        }
-      ],
-      "settings": [],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -1219,
-      "y": -2915
-    },
-    {
-      "id": "EABD8111-E99F-4C5B-A67D-3D7F0ACE778E",
-      "type": "IfElseBlock",
-      "disabled": false,
-      "name": "condition14",
-      "displayName": "Condition 14",
-      "comment": "If not the owner, checks and updates the roles. ",
-      "childId": null,
-      "inputs": [
-        {
-          "id": "conditions",
-          "value": {
-            "mode": "all",
-            "conditions": [
-              {
-                "input1": "{ $.filterList4.item.ownerId }",
-                "input2": "{ $.getCurrentUserId }",
-                "operator": "!="
-              }
-            ]
-          },
-          "type": "custom",
-          "structure": []
-        }
-      ],
-      "settings": [],
-      "collapsed": [
-        {
-          "name": "yes",
-          "isCollapsed": true
-        },
-        {
-          "name": "no",
-          "isCollapsed": true
-        },
-        {
-          "name": "both",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2561,
-      "y": 7532,
-      "childTrueId": "478E6D39-A231-4808-A8C8-AEE1EDF3121E",
-      "childFalseId": "94B0A4B3-5C6A-4958-BF8D-622F72452977"
-    },
-    {
-      "id": "478E6D39-A231-4808-A8C8-AEE1EDF3121E",
-      "type": "EndpointBlock",
-      "disabled": false,
-      "name": "listMembersFromSpace",
-      "displayName": "Qlik Cloud Services - List Members From Space",
-      "comment": "Get a list of members in the shared space.",
-      "childId": "7CFB4DF1-CB8C-4302-AE53-73BCF1F8BFBC",
-      "inputs": [
-        {
-          "id": "358ee8a0-6d34-11eb-b1f3-91a0d7274b22",
-          "value": "{ $.sharedSpaceId }",
-          "type": "string",
-          "structure": []
-        },
-        {
-          "id": "86f34440-dd7e-11ef-91d1-63f16d094078",
-          "value": "{ $.getCurrentUserId }",
-          "type": "string",
-          "structure": []
-        },
-        {
-          "id": "972a9800-dd7e-11ef-95ae-93a368f4ba58",
-          "value": "9fecb2a0-dd7e-11ef-85d3-9f8aefa67848",
-          "type": "select",
-          "displayValue": "user",
-          "structure": []
-        }
-      ],
-      "settings": [
-        {
-          "id": "maxitemcount",
-          "value": "",
-          "type": "string",
-          "structure": []
-        },
-        {
-          "id": "blendr_on_error",
-          "value": "stop",
-          "type": "select",
-          "structure": []
-        },
-        {
-          "id": "cache",
-          "value": "0",
-          "type": "select",
-          "structure": []
-        },
-        {
-          "id": "automations_censor_data",
-          "value": false,
-          "type": "checkbox",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2441,
-      "y": 7612,
-      "loopBlockId": null,
-      "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
-      "endpoint_guid": "ffe6d930-6d33-11eb-ad8a-334e25c5e295",
-      "endpoint_role": "list"
-    },
-    {
-      "id": "7CFB4DF1-CB8C-4302-AE53-73BCF1F8BFBC",
-      "type": "IfElseBlock",
-      "disabled": false,
-      "name": "condition15",
-      "displayName": "Condition 15",
-      "comment": "If the user is found, update; otherwise, add the user to the shared space with the facilitator role.",
-      "childId": null,
-      "inputs": [
-        {
-          "id": "conditions",
-          "value": {
-            "mode": "all",
-            "conditions": [
-              {
-                "input1": "{count: {$.listMembersFromSpace}}",
-                "input2": "1",
-                "operator": "="
-              }
-            ]
-          },
-          "type": "custom",
-          "structure": []
-        }
-      ],
-      "settings": [],
-      "collapsed": [
-        {
-          "name": "yes",
-          "isCollapsed": true
-        },
-        {
-          "name": "no",
-          "isCollapsed": true
-        },
-        {
-          "name": "both",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2441,
-      "y": 7732,
-      "childTrueId": "35CB70BA-0EC6-4883-829C-D9EF6FB850F3",
-      "childFalseId": "463B5474-1CF6-490D-884A-0A2E6252F64F"
-    },
-    {
-      "id": "35CB70BA-0EC6-4883-829C-D9EF6FB850F3",
-      "type": "IfElseBlock",
-      "disabled": false,
-      "name": "condition16",
-      "displayName": "Condition 16",
-      "comment": "If the user does not have the facilitator role, add it.",
-      "childId": null,
-      "inputs": [
-        {
-          "id": "conditions",
-          "value": {
-            "mode": "all",
-            "conditions": [
-              {
-                "input1": "{$.listMembersFromSpace[0].roles}",
-                "input2": "facilitator",
-                "operator": "notInList"
-              }
-            ]
-          },
-          "type": "custom",
-          "structure": []
-        }
-      ],
-      "settings": [],
-      "collapsed": [
-        {
-          "name": "yes",
-          "isCollapsed": true
-        },
-        {
-          "name": "no",
-          "isCollapsed": true
-        },
-        {
-          "name": "both",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2321,
-      "y": 7812,
-      "childTrueId": "824F1EDD-71E4-4833-9634-D37637283AE0",
-      "childFalseId": "A99BD3FB-EB73-41C1-B684-FBFDB4CB6D28"
-    },
-    {
-      "id": "824F1EDD-71E4-4833-9634-D37637283AE0",
-      "type": "VariableBlock",
-      "disabled": false,
-      "name": "spaceRoles",
-      "displayName": "Variable - spaceRoles",
-      "comment": "List variable to add the facilitator role, along with the existing roles, to the user in the shared space.",
-      "childId": "B6226FFD-EC59-4DB5-91A6-A706091A4FD6",
-      "inputs": [],
-      "settings": [],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2201,
-      "y": 7892,
-      "variableGuid": "E413E2FB-E4E7-4AFF-8894-6D27792FA8D8",
-      "operations": [
-        {
-          "id": "empty",
-          "key": "9837B21E-F102-462E-A474-E0C7D78117CE",
-          "name": "Empty { variable }",
-          "value": null
-        },
-        {
-          "id": "add_item",
-          "key": "68A49E6D-72F7-47D1-BD36-892E32464CB5",
-          "name": "Add item to { variable }",
-          "value": "facilitator"
-        },
-        {
-          "id": "merge",
-          "key": "680DE388-428C-40C5-97E2-C4FB11F0930D",
-          "name": "Merge other list into { variable }",
-          "value": "{ $.listMembersFromSpace[0].roles }",
-          "allow_duplicates": "no"
-        }
-      ]
-    },
-    {
-      "id": "B6226FFD-EC59-4DB5-91A6-A706091A4FD6",
-      "type": "EndpointBlock",
-      "disabled": false,
-      "name": "updateRolesOfMemberFromSpace",
-      "displayName": "Qlik Cloud Services - Update Roles Of Member From Space",
-      "comment": "Add the facilitator role to the user in the shared space.",
-      "childId": "E4CAC506-9BC8-4BDE-8F96-7A73212BB4B1",
-      "inputs": [
-        {
-          "id": "8c6b43e0-6d42-11eb-85f6-917131a7d145",
-          "value": "{$.sharedSpaceId}",
-          "type": "string",
-          "structure": []
-        },
-        {
-          "id": "8c72c230-6d42-11eb-837d-b1e5663f20d2",
-          "value": "{$.listMembersFromSpace[0].id}",
-          "type": "string",
-          "structure": []
-        },
-        {
-          "id": "01ac8e60-6d43-11eb-9d02-4d69db8c0501",
-          "value": "{json: {$.spaceRoles}}",
-          "type": "string",
-          "structure": []
-        }
-      ],
-      "settings": [
-        {
-          "id": "blendr_on_error",
-          "value": "stop",
-          "type": "select",
-          "structure": []
-        },
-        {
-          "id": "automations_censor_data",
-          "value": false,
-          "type": "checkbox",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2201,
-      "y": 8012,
-      "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
-      "endpoint_guid": "8c54ade0-6d42-11eb-b3a8-75befcc89b0a",
-      "endpoint_role": "update"
-    },
-    {
-      "id": "E4CAC506-9BC8-4BDE-8F96-7A73212BB4B1",
-      "type": "ShowBlock",
-      "disabled": false,
-      "name": "output7",
-      "displayName": "Output 7",
-      "comment": "Status output.",
-      "childId": null,
-      "inputs": [
-        {
-          "id": "input",
-          "value": "| Shared space permissions | Added facilitator role to existing space assignment. |",
-          "type": "string",
-          "structure": []
-        }
-      ],
-      "settings": [
-        {
-          "id": "display_mode",
-          "value": "add",
-          "type": "select",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2201,
-      "y": 8132
-    },
-    {
-      "id": "A99BD3FB-EB73-41C1-B684-FBFDB4CB6D28",
-      "type": "ShowBlock",
-      "disabled": false,
-      "name": "output8",
-      "displayName": "Output 8",
-      "comment": "Status output.",
-      "childId": null,
-      "inputs": [
-        {
-          "id": "input",
-          "value": "| Shared space permissions | No changes made. |",
-          "type": "string",
-          "structure": []
-        }
-      ],
-      "settings": [
-        {
-          "id": "display_mode",
-          "value": "add",
-          "type": "select",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2201,
-      "y": 8292
-    },
-    {
-      "id": "463B5474-1CF6-490D-884A-0A2E6252F64F",
-      "type": "EndpointBlock",
-      "disabled": false,
-      "name": "addMemberToSpace",
-      "displayName": "Qlik Cloud Services - Add Member To Space",
-      "comment": "Add user with facilitator role.",
-      "childId": "D2438EC7-D532-4274-8D13-27C2EC31CAAE",
-      "inputs": [
-        {
-          "id": "3162f740-6d33-11eb-a089-71f7ccab24b9",
-          "value": "{$.sharedSpaceId}",
-          "type": "string",
-          "structure": []
-        },
-        {
-          "id": "27499b00-6d31-11eb-bbe5-5b3db3c974dc",
-          "value": "{$.getCurrentUserId}",
-          "type": "string",
-          "structure": []
-        },
-        {
-          "id": "2751b870-6d31-11eb-9d77-41c5fae28bc5",
-          "value": "[\"facilitator\"]",
-          "type": "string",
-          "structure": []
-        },
-        {
-          "id": "275e2c50-6d31-11eb-8eeb-157347755492",
-          "value": "aec7c5b0-6d32-11eb-a4b2-f5e181a2c241",
-          "type": "select",
-          "displayValue": "user",
-          "structure": []
-        }
-      ],
-      "settings": [
-        {
-          "id": "blendr_on_error",
-          "value": "stop",
-          "type": "select",
-          "structure": []
-        },
-        {
-          "id": "automations_censor_data",
-          "value": false,
-          "type": "checkbox",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2321,
-      "y": 8532,
-      "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
-      "endpoint_guid": "272d9c70-6d31-11eb-870f-67624392ed86",
-      "endpoint_role": "create"
-    },
-    {
-      "id": "D2438EC7-D532-4274-8D13-27C2EC31CAAE",
-      "type": "ShowBlock",
-      "disabled": false,
-      "name": "output9",
-      "displayName": "Output 9",
-      "comment": "Status output.",
-      "childId": null,
-      "inputs": [
-        {
-          "id": "input",
-          "value": "| Shared space permissions | Added user to shared space. |",
-          "type": "string",
-          "structure": []
-        }
-      ],
-      "settings": [
-        {
-          "id": "display_mode",
-          "value": "add",
-          "type": "select",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2321,
-      "y": 8652
-    },
-    {
-      "id": "94B0A4B3-5C6A-4958-BF8D-622F72452977",
-      "type": "ShowBlock",
-      "disabled": false,
-      "name": "output10",
-      "displayName": "Output 10",
-      "comment": "Status output.",
-      "childId": null,
-      "inputs": [
-        {
-          "id": "input",
-          "value": "| Shared space permissions | Found user is owner of space, no permission updates required. |",
-          "type": "string",
-          "structure": []
-        }
-      ],
-      "settings": [
-        {
-          "id": "display_mode",
-          "value": "add",
-          "type": "select",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2441,
-      "y": 8892
-    },
-    {
-      "id": "EF5E86CE-DE0B-4961-BD90-B7355163A6E9",
-      "type": "VariableBlock",
-      "disabled": false,
-      "name": "managedSpaceId",
-      "displayName": "Variable - managedSpaceId",
-      "comment": "Initialise the variable.",
-      "childId": "8B32EC24-AC36-47A1-B60B-2FC217B835E3",
-      "inputs": [],
-      "settings": [],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": false
-        }
-      ],
-      "x": -2922,
-      "y": 8294,
-      "variableGuid": "B6C34135-EF0E-42EF-AC0D-621D8A8A165D",
-      "operations": [
-        {
-          "id": "empty",
-          "key": "CFAB487E-9183-44D8-8990-4AD864BE24A2",
-          "name": "Empty { variable }",
-          "value": null
-        }
-      ]
-    },
-    {
-      "id": "EA734A3A-B6F0-47F4-BB88-4D3C1DCADBE2",
-      "type": "ErrorBlock",
-      "disabled": false,
-      "name": "error",
-      "displayName": "Error",
-      "comment": "Show the error message and stop the automation.",
-      "childId": null,
-      "inputs": [
-        {
-          "id": "message",
-          "value": "Error: { $.errorTitle }",
-          "type": "string",
-          "structure": []
-        },
-        {
-          "id": "action",
-          "value": "stop",
-          "type": "select",
-          "structure": []
-        }
-      ],
-      "settings": [],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -1219,
-      "y": -2555
-    },
-    {
-      "id": "E14426D0-F329-44A1-B59F-A27869D8920F",
-      "type": "EndpointBlock",
-      "disabled": false,
-      "name": "searchSpaces2",
-      "displayName": "Qlik Cloud Services - Search Spaces 2",
-      "comment": "Look for managed space.",
-      "childId": "EF5E86CE-DE0B-4961-BD90-B7355163A6E9",
-      "inputs": [
-        {
-          "id": "592e21a0-6d2e-11eb-9985-3ff14fb3335f",
-          "value": null,
-          "type": "string",
-          "structure": []
-        },
-        {
-          "id": "5935dec0-6d2e-11eb-8365-ab8493d4c237",
-          "value": null,
-          "type": "string",
-          "structure": []
-        },
-        {
-          "id": "593c5340-6d2e-11eb-a82b-e17cfa6c8a6d",
-          "value": null,
-          "type": "string",
-          "structure": []
-        },
-        {
-          "id": "59429c60-6d2e-11eb-b7b1-e7ca1f22830c",
-          "value": "{$.managedSpaceName}",
-          "type": "string",
-          "structure": []
-        },
-        {
-          "id": "5949c230-6d2e-11eb-b345-99be61e9908c",
-          "value": null,
-          "type": "string",
-          "structure": []
-        }
-      ],
-      "settings": [
-        {
-          "id": "maxitemcount",
-          "value": "",
-          "type": "string",
-          "structure": []
-        },
-        {
-          "id": "blendr_on_error",
-          "value": "stop",
-          "type": "select",
-          "structure": []
-        },
-        {
-          "id": "automations_censor_data",
-          "value": false,
-          "type": "checkbox",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": false
-        }
-      ],
-      "x": -2922,
-      "y": 8134,
-      "loopBlockId": null,
-      "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
-      "endpoint_guid": "590a1a20-6d2e-11eb-9714-df1bbaac055d",
-      "endpoint_role": "search"
-    },
-    {
-      "id": "8B32EC24-AC36-47A1-B60B-2FC217B835E3",
-      "type": "FilterListBlock",
-      "disabled": false,
-      "name": "filterList5",
-      "displayName": "Filter over Qlik Cloud Services - Search Spaces 2 - Filter List 5",
-      "comment": "Filter for exact name match for managed space.",
-      "childId": "7C0C15A5-F334-4AD6-A9D4-C0AC674CC34B",
-      "inputs": [
-        {
-          "id": "list",
-          "value": "{ $.searchSpaces2 }",
-          "type": "string",
-          "structure": []
-        },
-        {
-          "id": "conditions",
-          "value": {
-            "mode": "all",
-            "conditions": [
-              {
-                "input1": "name",
-                "input2": "{$.managedSpaceName}",
-                "operator": "="
-              }
-            ]
-          },
-          "type": "custom",
-          "structure": []
-        }
-      ],
-      "settings": [
-        {
-          "id": "automations_censor_data",
-          "value": false,
-          "type": "checkbox",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": false
-        }
-      ],
-      "x": -2922,
-      "y": 8414,
-      "loopBlockId": "FCBE0570-D739-43D6-B0AD-B16A2DA6F28A"
-    },
-    {
-      "id": "FCBE0570-D739-43D6-B0AD-B16A2DA6F28A",
-      "type": "VariableBlock",
-      "disabled": false,
-      "name": "managedSpaceId",
-      "displayName": "Variable - managedSpaceId",
-      "comment": "Store managed space ID.",
-      "childId": "820347D1-83F1-4F4E-A9A3-AACE4DF3685E",
-      "inputs": [],
-      "settings": [],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2802,
-      "y": 8514,
-      "variableGuid": "B6C34135-EF0E-42EF-AC0D-621D8A8A165D",
-      "operations": [
-        {
-          "id": "set_value",
-          "key": "FF599B67-45E6-44E2-9966-4EEEE9F474D4",
-          "name": "Set value of { variable }",
-          "value": "{$.filterList5.item.id}"
-        }
-      ]
-    },
-    {
-      "id": "820347D1-83F1-4F4E-A9A3-AACE4DF3685E",
-      "type": "ShowBlock",
-      "disabled": false,
-      "name": "output11",
-      "displayName": "Output 11",
-      "comment": "Status output.",
-      "childId": "B35B33BE-B45B-4749-813C-64BA4AA4FA1D",
-      "inputs": [
-        {
-          "id": "input",
-          "value": "| Managed space lookup | Found {$.filterList5.item.type} space matching name [{$.managedSpaceName}]({$.tenantHostname}analytics/catalog?space_filter={$.managedSpaceId}). |",
-          "type": "string",
-          "structure": []
-        }
-      ],
-      "settings": [
-        {
-          "id": "display_mode",
-          "value": "add",
-          "type": "select",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2802,
-      "y": 8634
-    },
-    {
-      "id": "B35B33BE-B45B-4749-813C-64BA4AA4FA1D",
-      "type": "IfElseBlock",
-      "disabled": false,
-      "name": "condition17",
-      "displayName": "Condition 17",
-      "comment": "If the space type is not managed, exit; otherwise, ensure that the publisher role is present.",
-      "childId": null,
-      "inputs": [
-        {
-          "id": "conditions",
-          "value": {
-            "mode": "all",
-            "conditions": [
-              {
-                "input1": "{$.filterList5[0].type}",
-                "input2": "managed",
-                "operator": "!="
-              }
-            ]
-          },
-          "type": "custom",
-          "structure": []
-        }
-      ],
-      "settings": [],
-      "collapsed": [
-        {
-          "name": "yes",
-          "isCollapsed": false
-        },
-        {
-          "name": "no",
-          "isCollapsed": false
-        },
-        {
-          "name": "both",
-          "isCollapsed": false
-        }
-      ],
-      "x": -2802,
-      "y": 8754,
-      "childTrueId": "F0DEE5BC-C9A2-4F91-964A-EA7C64F90457",
-      "childFalseId": "2FDCB00D-3E41-4B95-A904-51DBFF7345AA"
-    },
-    {
-      "id": "F0DEE5BC-C9A2-4F91-964A-EA7C64F90457",
-      "type": "VariableBlock",
-      "disabled": false,
-      "name": "errorTitle",
-      "displayName": "Variable - errorTitle",
-      "comment": "Set error title for standard error output.",
-      "childId": "CDB7C2AB-E721-492F-9238-2A91F9B67CF2",
-      "inputs": [],
-      "settings": [],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2682,
-      "y": 8834,
-      "variableGuid": "407730A6-EC96-4337-BE80-CF4C0D552F08",
-      "operations": [
-        {
-          "id": "set_value",
-          "key": "1BC10F4C-68C2-42E9-9000-25865B076073",
-          "name": "Set value of { variable }",
-          "value": "A space of the wrong type was found with the configured managed space name."
-        }
-      ]
-    },
-    {
-      "id": "CDB7C2AB-E721-492F-9238-2A91F9B67CF2",
-      "type": "VariableBlock",
-      "disabled": false,
-      "name": "errorDetail",
-      "displayName": "Variable - errorDetail",
-      "comment": "Variable to store detailed error message.",
-      "childId": "1324CB60-D99D-4A46-AB5A-734A7B31D12B",
-      "inputs": [],
-      "settings": [],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2682,
-      "y": 8954,
-      "variableGuid": "1BF2068B-106E-4D58-BC51-884F1810F03C",
-      "operations": [
-        {
-          "id": "set_value",
-          "key": "1BC10F4C-68C2-42E9-9000-25865B076073",
-          "name": "Set value of { variable }",
-          "value": "Exiting, an existing space with a type other than `managed` was found for the provided managed space name. Try another managed space name."
-        }
-      ]
-    },
-    {
-      "id": "1324CB60-D99D-4A46-AB5A-734A7B31D12B",
-      "type": "GotoBlock",
-      "disabled": false,
-      "name": "goToLabel9",
-      "displayName": "Go To Label 9",
-      "comment": "Go to the label named error.",
-      "childId": null,
-      "inputs": [
-        {
-          "id": "label",
-          "value": "EF82AD29-E2CF-44C9-A7DB-24C784618756",
-          "type": "select",
-          "displayValue": "error",
-          "structure": []
-        }
-      ],
-      "settings": [],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2682,
-      "y": 9074
-    },
-    {
-      "id": "2FDCB00D-3E41-4B95-A904-51DBFF7345AA",
-      "type": "IfElseBlock",
-      "disabled": false,
-      "name": "condition18",
-      "displayName": "Condition 18",
-      "comment": "If not the owner, check and update roles.",
-      "childId": null,
-      "inputs": [
-        {
-          "id": "conditions",
-          "value": {
-            "mode": "all",
-            "conditions": [
-              {
-                "input1": "{ $.filterList5.item.ownerId }",
-                "input2": "{ $.getCurrentUserId }",
-                "operator": "!="
-              }
-            ]
-          },
-          "type": "custom",
-          "structure": []
-        }
-      ],
-      "settings": [],
-      "collapsed": [
-        {
-          "name": "yes",
-          "isCollapsed": false
-        },
-        {
-          "name": "no",
-          "isCollapsed": false
-        },
-        {
-          "name": "both",
-          "isCollapsed": false
-        }
-      ],
-      "x": -2682,
-      "y": 9234,
-      "childTrueId": "064FC5B0-AF19-4C57-B22A-E171D71F3643",
-      "childFalseId": "F37D6ACE-DF7C-4EB9-A990-E7DBCD31ABDF"
-    },
-    {
-      "id": "064FC5B0-AF19-4C57-B22A-E171D71F3643",
-      "type": "EndpointBlock",
-      "disabled": false,
-      "name": "listMembersFromSpace2",
-      "displayName": "Qlik Cloud Services - List Members From Space 2",
-      "comment": "Get a list of members in the managed space.",
-      "childId": "4C669FE6-61A1-402B-9A79-357A350E8030",
-      "inputs": [
-        {
-          "id": "358ee8a0-6d34-11eb-b1f3-91a0d7274b22",
-          "value": "{ $.managedSpaceId }",
-          "type": "string",
-          "structure": []
-        },
-        {
-          "id": "86f34440-dd7e-11ef-91d1-63f16d094078",
-          "value": "{ $.getCurrentUserId }",
-          "type": "string",
-          "structure": []
-        },
-        {
-          "id": "972a9800-dd7e-11ef-95ae-93a368f4ba58",
-          "value": "9fecb2a0-dd7e-11ef-85d3-9f8aefa67848",
-          "type": "select",
-          "displayValue": "user",
-          "structure": []
-        }
-      ],
-      "settings": [
-        {
-          "id": "maxitemcount",
-          "value": "",
-          "type": "string",
-          "structure": []
-        },
-        {
-          "id": "blendr_on_error",
-          "value": "stop",
-          "type": "select",
-          "structure": []
-        },
-        {
-          "id": "cache",
-          "value": "0",
-          "type": "select",
-          "structure": []
-        },
-        {
-          "id": "automations_censor_data",
-          "value": false,
-          "type": "checkbox",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": false
-        }
-      ],
-      "x": -2562,
-      "y": 9314,
-      "loopBlockId": null,
-      "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
-      "endpoint_guid": "ffe6d930-6d33-11eb-ad8a-334e25c5e295",
-      "endpoint_role": "list"
-    },
-    {
-      "id": "4C669FE6-61A1-402B-9A79-357A350E8030",
-      "type": "IfElseBlock",
-      "disabled": false,
-      "name": "condition19",
-      "displayName": "Condition 19",
-      "comment": "If the user is found, update; otherwise, create an assignment.",
-      "childId": null,
-      "inputs": [
-        {
-          "id": "conditions",
-          "value": {
-            "mode": "all",
-            "conditions": [
-              {
-                "input1": "{count: {$.listMembersFromSpace2}}",
-                "input2": "1",
-                "operator": "="
-              }
-            ]
-          },
-          "type": "custom",
-          "structure": []
-        }
-      ],
-      "settings": [],
-      "collapsed": [
-        {
-          "name": "yes",
-          "isCollapsed": false
-        },
-        {
-          "name": "no",
-          "isCollapsed": false
-        },
-        {
-          "name": "both",
-          "isCollapsed": false
-        }
-      ],
-      "x": -2562,
-      "y": 9474,
-      "childTrueId": "D0EEE98C-7DA0-47F5-B8C6-31B0507505FD",
-      "childFalseId": "9CC93349-E133-4BCC-860C-7AAE4991A788"
-    },
-    {
-      "id": "D0EEE98C-7DA0-47F5-B8C6-31B0507505FD",
-      "type": "IfElseBlock",
-      "disabled": false,
-      "name": "condition20",
-      "displayName": "Condition 20",
-      "comment": "If the user does not have the facilitator and publisher roles, add them.",
-      "childId": null,
-      "inputs": [
-        {
-          "id": "conditions",
-          "value": {
-            "mode": "some",
-            "conditions": [
-              {
-                "input1": "{$.listMembersFromSpace2[0].roles}",
-                "input2": "facilitator",
-                "operator": "notInList"
-              },
-              {
-                "input1": "{ $.listMembersFromSpace2[0].roles }",
-                "input2": "publisher",
-                "operator": "notInList"
-              }
-            ]
-          },
-          "type": "custom",
-          "structure": []
-        }
-      ],
-      "settings": [],
-      "collapsed": [
-        {
-          "name": "yes",
-          "isCollapsed": false
-        },
-        {
-          "name": "no",
-          "isCollapsed": false
-        },
-        {
-          "name": "both",
-          "isCollapsed": false
-        }
-      ],
-      "x": -2442,
-      "y": 9554,
-      "childTrueId": "BE0D6DE8-CA32-466A-917B-40EA75EB91C9",
-      "childFalseId": "253E7602-5CB9-473C-A66A-ABB7711934A6"
-    },
-    {
-      "id": "BE0D6DE8-CA32-466A-917B-40EA75EB91C9",
-      "type": "VariableBlock",
-      "disabled": false,
-      "name": "spaceRoles",
-      "displayName": "Variable - spaceRoles",
-      "comment": "List variable to add facilitator and publisher roles along with the existing roles, to the user in the managed space.",
-      "childId": "759EE2C8-9EAF-4D15-9A14-D059BC43154C",
-      "inputs": [],
-      "settings": [],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2322,
-      "y": 9634,
-      "variableGuid": "E413E2FB-E4E7-4AFF-8894-6D27792FA8D8",
-      "operations": [
-        {
-          "id": "empty",
-          "key": "9837B21E-F102-462E-A474-E0C7D78117CE",
-          "name": "Empty { variable }",
-          "value": null
-        },
-        {
-          "id": "add_item",
-          "key": "68A49E6D-72F7-47D1-BD36-892E32464CB5",
-          "name": "Add item to { variable }",
-          "value": "facilitator"
-        },
-        {
-          "id": "add_item",
-          "key": "17E5F253-7880-4709-BD29-6CDBC72BC2C2",
-          "name": "Add item to { variable }",
-          "value": "publisher"
-        },
-        {
-          "id": "merge",
-          "key": "680DE388-428C-40C5-97E2-C4FB11F0930D",
-          "name": "Merge other list into { variable }",
-          "value": "{ $.listMembersFromSpace2[0].roles }",
-          "allow_duplicates": "no"
-        }
-      ]
-    },
-    {
-      "id": "759EE2C8-9EAF-4D15-9A14-D059BC43154C",
-      "type": "EndpointBlock",
-      "disabled": false,
-      "name": "updateRolesOfMemberFromSpace2",
-      "displayName": "Qlik Cloud Services - Update Roles Of Member From Space 2",
-      "comment": "Add the facilitator and publisher roles to the user in the managed space.",
-      "childId": "3C75AC47-4371-4B5E-B512-BF7319CADCF4",
-      "inputs": [
-        {
-          "id": "8c6b43e0-6d42-11eb-85f6-917131a7d145",
-          "value": "{$.managedSpaceId}",
-          "type": "string",
-          "structure": []
-        },
-        {
-          "id": "8c72c230-6d42-11eb-837d-b1e5663f20d2",
-          "value": "{$.listMembersFromSpace2[0].id}",
-          "type": "string",
-          "structure": []
-        },
-        {
-          "id": "01ac8e60-6d43-11eb-9d02-4d69db8c0501",
-          "value": "{json: {$.spaceRoles}}",
-          "type": "string",
-          "structure": []
-        }
-      ],
-      "settings": [
-        {
-          "id": "blendr_on_error",
-          "value": "stop",
-          "type": "select",
-          "structure": []
-        },
-        {
-          "id": "automations_censor_data",
-          "value": false,
-          "type": "checkbox",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2322,
-      "y": 9754,
-      "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
-      "endpoint_guid": "8c54ade0-6d42-11eb-b3a8-75befcc89b0a",
-      "endpoint_role": "update"
-    },
-    {
-      "id": "3C75AC47-4371-4B5E-B512-BF7319CADCF4",
-      "type": "ShowBlock",
-      "disabled": false,
-      "name": "output12",
-      "displayName": "Output 12",
-      "comment": "Status output.",
-      "childId": null,
-      "inputs": [
-        {
-          "id": "input",
-          "value": "| Managed space permissions | Added facilitator and publisher role to existing space assignment. |",
-          "type": "string",
-          "structure": []
-        }
-      ],
-      "settings": [
-        {
-          "id": "display_mode",
-          "value": "add",
-          "type": "select",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2322,
-      "y": 9874
-    },
-    {
-      "id": "253E7602-5CB9-473C-A66A-ABB7711934A6",
-      "type": "ShowBlock",
-      "disabled": false,
-      "name": "output13",
-      "displayName": "Output 13",
-      "comment": "Status output.",
-      "childId": null,
-      "inputs": [
-        {
-          "id": "input",
-          "value": "| Managed space permissions | No changes made. |",
-          "type": "string",
-          "structure": []
-        }
-      ],
-      "settings": [
-        {
-          "id": "display_mode",
-          "value": "add",
-          "type": "select",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2322,
-      "y": 10034
-    },
-    {
-      "id": "9CC93349-E133-4BCC-860C-7AAE4991A788",
-      "type": "EndpointBlock",
-      "disabled": false,
-      "name": "addMemberToSpace2",
-      "displayName": "Qlik Cloud Services - Add Member To Space 2",
-      "comment": "Add user with facilitator and publisher roles.",
-      "childId": "DD87C70B-9C4F-4DDF-9DFA-4515A73AD2DF",
-      "inputs": [
-        {
-          "id": "3162f740-6d33-11eb-a089-71f7ccab24b9",
-          "value": "{$.managedSpaceId}",
-          "type": "string",
-          "structure": []
-        },
-        {
-          "id": "27499b00-6d31-11eb-bbe5-5b3db3c974dc",
-          "value": "{$.getCurrentUserId}",
-          "type": "string",
-          "structure": []
-        },
-        {
-          "id": "2751b870-6d31-11eb-9d77-41c5fae28bc5",
-          "value": "[\"facilitator\",\"publisher\"]",
-          "type": "string",
-          "structure": []
-        },
-        {
-          "id": "275e2c50-6d31-11eb-8eeb-157347755492",
-          "value": "aec7c5b0-6d32-11eb-a4b2-f5e181a2c241",
-          "type": "select",
-          "displayValue": "user",
-          "structure": []
-        }
-      ],
-      "settings": [
-        {
-          "id": "blendr_on_error",
-          "value": "stop",
-          "type": "select",
-          "structure": []
-        },
-        {
-          "id": "automations_censor_data",
-          "value": false,
-          "type": "checkbox",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2442,
-      "y": 10274,
-      "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
-      "endpoint_guid": "272d9c70-6d31-11eb-870f-67624392ed86",
-      "endpoint_role": "create"
-    },
-    {
-      "id": "DD87C70B-9C4F-4DDF-9DFA-4515A73AD2DF",
-      "type": "ShowBlock",
-      "disabled": false,
-      "name": "output14",
-      "displayName": "Output 14",
-      "comment": "Status output.",
-      "childId": null,
-      "inputs": [
-        {
-          "id": "input",
-          "value": "| Managed space permissions | Added user to managed space. |",
-          "type": "string",
-          "structure": []
-        }
-      ],
-      "settings": [
-        {
-          "id": "display_mode",
-          "value": "add",
-          "type": "select",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2442,
-      "y": 10394
-    },
-    {
-      "id": "F37D6ACE-DF7C-4EB9-A990-E7DBCD31ABDF",
-      "type": "ShowBlock",
-      "disabled": false,
-      "name": "output15",
-      "displayName": "Output 15",
-      "comment": "Status output.",
-      "childId": null,
-      "inputs": [
-        {
-          "id": "input",
-          "value": "| Managed space permissions | Found user is owner of space, no permission updates required. |",
-          "type": "string",
-          "structure": []
-        }
-      ],
-      "settings": [
-        {
-          "id": "display_mode",
-          "value": "add",
-          "type": "select",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2562,
-      "y": 10634
-    },
-    {
-      "id": "7C0C15A5-F334-4AD6-A9D4-C0AC674CC34B",
-      "type": "IfElseBlock",
-      "disabled": false,
-      "name": "condition21",
-      "displayName": "Condition 21",
-      "comment": "If no shared space is found, create it.",
-      "childId": "230E3338-D040-459F-A88C-47CD38B6BD39",
-      "inputs": [
-        {
-          "id": "conditions",
-          "value": {
-            "mode": "all",
-            "conditions": [
-              {
-                "input1": "{$.sharedSpaceId}",
-                "input2": null,
-                "operator": "empty"
-              }
-            ]
-          },
-          "type": "custom",
-          "structure": []
-        }
-      ],
-      "settings": [],
-      "collapsed": [
-        {
-          "name": "yes",
-          "isCollapsed": false
-        },
-        {
-          "name": "no",
-          "isCollapsed": false
-        },
-        {
-          "name": "both",
-          "isCollapsed": false
-        }
-      ],
-      "x": -2922,
-      "y": 10954,
-      "childTrueId": "A835D799-19FC-450D-BF01-88DB67C89291",
-      "childFalseId": null
-    },
-    {
-      "id": "A835D799-19FC-450D-BF01-88DB67C89291",
-      "type": "EndpointBlock",
-      "disabled": false,
-      "name": "createSpace",
-      "displayName": "Qlik Cloud Services - Create Space",
-      "comment": "Create shared space.",
-      "childId": "19A7E512-81F6-407C-B4F5-A537C5DA9597",
-      "inputs": [
-        {
-          "id": "f0de69a0-6d24-11eb-8c07-ebadb5af2511",
-          "value": "{$.sharedSpaceName}",
-          "type": "string",
-          "structure": []
-        },
-        {
-          "id": "79771850-6d25-11eb-8021-177e65e81ac9",
-          "value": "shared",
-          "type": "select",
-          "structure": []
-        },
-        {
-          "id": "f0ecac30-6d24-11eb-a7b6-d15be2d36858",
-          "value": "This space is managed by the Qlik Cloud monitoring app deployer automation. It contains staged monitoring applications which have been imported for publishing to a managed space. This space will contain n copies of each application, where n is the value set for versionsToKeep in the automation.",
-          "type": "string",
-          "structure": []
-        }
-      ],
-      "settings": [
-        {
-          "id": "blendr_on_error",
-          "value": "stop",
-          "type": "select",
-          "structure": []
-        },
-        {
-          "id": "automations_censor_data",
-          "value": false,
-          "type": "checkbox",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2802,
-      "y": 11034,
-      "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
-      "endpoint_guid": "f0c14620-6d24-11eb-aa67-c519e2671d3d",
-      "endpoint_role": "create"
-    },
-    {
-      "id": "19A7E512-81F6-407C-B4F5-A537C5DA9597",
-      "type": "VariableBlock",
-      "disabled": false,
-      "name": "sharedSpaceId",
-      "displayName": "Variable - sharedSpaceId",
-      "comment": "Store the newly created shared space ID in this variable.",
-      "childId": "E43BB4EB-9F53-4ACA-9649-051763575EE8",
-      "inputs": [],
-      "settings": [],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2802,
-      "y": 11154,
-      "variableGuid": "DE390532-B1F9-4098-BBE0-B7E6101BD502",
-      "operations": [
-        {
-          "id": "set_value",
-          "key": "FF599B67-45E6-44E2-9966-4EEEE9F474D4",
-          "name": "Set value of { variable }",
-          "value": "{$.createSpace.id}"
-        }
-      ]
-    },
-    {
-      "id": "E43BB4EB-9F53-4ACA-9649-051763575EE8",
-      "type": "ShowBlock",
-      "disabled": false,
-      "name": "output16",
-      "displayName": "Output 16",
-      "comment": "Status output.",
-      "childId": null,
-      "inputs": [
-        {
-          "id": "input",
-          "value": "| Shared space created | Created space [{$.sharedSpaceName}]({$.tenantHostname}analytics/catalog?space_filter={$.sharedSpaceId}). |",
-          "type": "string",
-          "structure": []
-        }
-      ],
-      "settings": [
-        {
-          "id": "display_mode",
-          "value": "add",
-          "type": "select",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2802,
-      "y": 11274
-    },
-    {
-      "id": "230E3338-D040-459F-A88C-47CD38B6BD39",
-      "type": "IfElseBlock",
-      "disabled": false,
-      "name": "condition22",
-      "displayName": "Condition 22",
-      "comment": "If a managed space is not found, create it.",
-      "childId": "F4D0DE07-AD02-4C58-9CEA-A3409E738389",
-      "inputs": [
-        {
-          "id": "conditions",
-          "value": {
-            "mode": "all",
-            "conditions": [
-              {
-                "input1": "{$.managedSpaceId}",
-                "input2": null,
-                "operator": "empty"
-              }
-            ]
-          },
-          "type": "custom",
-          "structure": []
-        }
-      ],
-      "settings": [],
-      "collapsed": [
-        {
-          "name": "yes",
-          "isCollapsed": false
-        },
-        {
-          "name": "no",
-          "isCollapsed": false
-        },
-        {
-          "name": "both",
-          "isCollapsed": false
-        }
-      ],
-      "x": -2922,
-      "y": 11474,
-      "childTrueId": "ED0FFFF7-7BA3-4BC5-B2CC-37F2AE4C0408",
-      "childFalseId": null
-    },
-    {
-      "id": "ED0FFFF7-7BA3-4BC5-B2CC-37F2AE4C0408",
-      "type": "EndpointBlock",
-      "disabled": false,
-      "name": "createSpace2",
-      "displayName": "Qlik Cloud Services - Create Space 2",
-      "comment": "Create managed space.",
-      "childId": "74016C4D-50A2-4FE0-AB21-3021ED1C263F",
-      "inputs": [
-        {
-          "id": "f0de69a0-6d24-11eb-8c07-ebadb5af2511",
-          "value": "{$.managedSpaceName}",
-          "type": "string",
-          "structure": []
-        },
-        {
-          "id": "79771850-6d25-11eb-8021-177e65e81ac9",
-          "value": "managed",
-          "type": "select",
-          "structure": []
-        },
-        {
-          "id": "f0ecac30-6d24-11eb-a7b6-d15be2d36858",
-          "value": "This space is managed by the Qlik Cloud monitoring app deployer automation. It contains published monitoring applications for analysis. It is not recommended to manually modify the contents of this space.",
-          "type": "string",
-          "structure": []
-        }
-      ],
-      "settings": [
-        {
-          "id": "blendr_on_error",
-          "value": "stop",
-          "type": "select",
-          "structure": []
-        },
-        {
-          "id": "automations_censor_data",
-          "value": false,
-          "type": "checkbox",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2802,
-      "y": 11554,
-      "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
-      "endpoint_guid": "f0c14620-6d24-11eb-aa67-c519e2671d3d",
-      "endpoint_role": "create"
-    },
-    {
-      "id": "74016C4D-50A2-4FE0-AB21-3021ED1C263F",
-      "type": "VariableBlock",
-      "disabled": false,
-      "name": "managedSpaceId",
-      "displayName": "Variable - managedSpaceId",
-      "comment": "Store the newly created managed space ID in this variable.",
-      "childId": "8EA716DA-A818-45D1-8D97-92171239EAE3",
-      "inputs": [],
-      "settings": [],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2802,
-      "y": 11674,
-      "variableGuid": "B6C34135-EF0E-42EF-AC0D-621D8A8A165D",
-      "operations": [
-        {
-          "id": "set_value",
-          "key": "FF599B67-45E6-44E2-9966-4EEEE9F474D4",
-          "name": "Set value of { variable }",
-          "value": "{$.createSpace2.id}"
-        }
-      ]
-    },
-    {
-      "id": "8EA716DA-A818-45D1-8D97-92171239EAE3",
-      "type": "ShowBlock",
-      "disabled": false,
-      "name": "output17",
-      "displayName": "Output 17",
-      "comment": "Status output.",
-      "childId": null,
-      "inputs": [
-        {
-          "id": "input",
-          "value": "| Managed space created | Created space [{$.managedSpaceName}]({$.tenantHostname}analytics/catalog?space_filter={$.managedSpaceId}). |",
-          "type": "string",
-          "structure": []
-        }
-      ],
-      "settings": [
-        {
-          "id": "display_mode",
-          "value": "add",
-          "type": "select",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2802,
-      "y": 11794
-    },
-    {
-      "id": "4BE16981-95D8-4418-B598-B26CA6843820",
-      "type": "VariableBlock",
-      "disabled": false,
-      "name": "cleanupCounter",
-      "displayName": "Variable - cleanupCounter",
-      "comment": "Variable to get the number of deployed apps in the shared space. Initially set the value of this variable to 0.",
-      "childId": "5006AC77-27D1-4EA3-AF11-DA559F907DB8",
-      "inputs": [],
-      "settings": [],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2682,
-      "y": 23554,
-      "variableGuid": "F6ED0768-9852-46AF-B822-2172586824B7",
-      "operations": [
-        {
-          "id": "set_value",
-          "key": "0AA127FF-539F-4311-BF88-189CFE16CC39",
-          "name": "Set value of { variable }",
-          "value": "0"
-        }
-      ]
-    },
-    {
-      "id": "5006AC77-27D1-4EA3-AF11-DA559F907DB8",
-      "type": "EndpointBlock",
-      "disabled": false,
-      "name": "searchItems",
-      "displayName": "Qlik Cloud Services - Search Items",
-      "comment": "Find apps in the shared space with the app tag.",
-      "childId": null,
-      "inputs": [
-        {
-          "id": "84bbcd50-6f72-11eb-8452-c12329f7d1be",
-          "value": "-createdAt",
-          "type": "select",
-          "structure": []
-        },
-        {
-          "id": "b9c76ec0-6f72-11eb-ba14-4f34b1e4e6b4",
-          "value": "app",
-          "type": "string",
-          "structure": []
-        },
-        {
-          "id": "49786610-6f73-11eb-8f0a-2348e669c251",
-          "value": null,
-          "type": "string",
-          "structure": []
-        },
-        {
-          "id": "58fafe70-6f73-11eb-a310-696500e924d6",
-          "value": null,
-          "type": "string",
-          "structure": []
-        },
-        {
-          "id": "6eb0af00-6f73-11eb-9663-9f0b522e183f",
-          "value": "{$.sharedSpaceId}",
-          "type": "string",
-          "structure": []
-        },
-        {
-          "id": "a80dbc80-6f76-11eb-9648-4d8865fc84c1",
-          "value": null,
-          "type": "select",
-          "structure": []
-        },
-        {
-          "id": "964119b0-6f77-11eb-a576-3bf4b006d432",
-          "value": "{ $.taggerIds.appTag }",
-          "type": "string",
-          "structure": []
-        },
-        {
-          "id": "a7cd85c0-6f77-11eb-8511-2ba53a2a2998",
-          "value": null,
-          "type": "string",
-          "structure": []
-        },
-        {
-          "id": "d9032100-6f77-11eb-bffb-9bf794dfe9c7",
-          "value": null,
-          "type": "string",
-          "structure": []
-        },
-        {
-          "id": "fe391860-6f77-11eb-9529-afce50ac48a4",
-          "value": null,
-          "type": "string",
-          "structure": []
-        },
-        {
-          "id": "212f52c0-6f78-11eb-b09f-1f3e59290268",
-          "value": null,
-          "type": "string",
-          "structure": []
-        },
-        {
-          "id": "338287a0-6f78-11eb-a90c-152f5cce262e",
-          "value": null,
-          "type": "string",
-          "structure": []
-        },
-        {
-          "id": "41938660-6f78-11eb-94e2-8b5fb7dad158",
-          "value": null,
-          "type": "string",
-          "structure": []
-        },
-        {
-          "id": "4dc17010-6f78-11eb-9894-abf8a46a596a",
-          "value": null,
-          "type": "string",
-          "structure": []
-        }
-      ],
-      "settings": [
-        {
-          "id": "maxitemcount",
-          "value": "",
-          "type": "string",
-          "structure": []
-        },
-        {
-          "id": "blendr_on_error",
-          "value": "stop",
-          "type": "select",
-          "structure": []
-        },
-        {
-          "id": "automations_censor_data",
-          "value": false,
-          "type": "checkbox",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": false
-        }
-      ],
-      "x": -2682,
-      "y": 23674,
-      "loopBlockId": "1B323E62-40BB-40D7-AD9A-D04DA4A5FFB6",
-      "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
-      "endpoint_guid": "84ad9050-6f72-11eb-aa08-a1dda4364ef5",
-      "endpoint_role": "search"
-    },
-    {
-      "id": "1B323E62-40BB-40D7-AD9A-D04DA4A5FFB6",
-      "type": "IfElseBlock",
-      "disabled": false,
-      "name": "condition33",
-      "displayName": "Condition 33",
-      "comment": "Delete if cleanupCounter value is greater than versionsToKeep value.",
-      "childId": "D5570044-9796-4DC7-81B6-C6D2F937FB1F",
-      "inputs": [
-        {
-          "id": "conditions",
-          "value": {
-            "mode": "all",
-            "conditions": [
-              {
-                "input1": "{$.cleanupCounter}",
-                "input2": "{$.versionsToKeep}",
-                "operator": ">="
-              }
-            ]
-          },
-          "type": "custom",
-          "structure": []
-        }
-      ],
-      "settings": [],
-      "collapsed": [
-        {
-          "name": "yes",
-          "isCollapsed": false
-        },
-        {
-          "name": "no",
-          "isCollapsed": false
-        },
-        {
-          "name": "both",
-          "isCollapsed": false
-        }
-      ],
-      "x": -2562,
-      "y": 23774,
-      "childTrueId": "1C69733A-CADE-4901-9BC2-4CDA59A50DA2",
-      "childFalseId": null
-    },
-    {
-      "id": "1C69733A-CADE-4901-9BC2-4CDA59A50DA2",
-      "type": "EndpointBlock",
-      "disabled": false,
-      "name": "deleteApp",
-      "displayName": "Qlik Cloud Services - Delete App",
-      "comment": "Delete older version of app from the shared space.",
-      "childId": "27388F0E-6FFB-4D16-B4E5-08174412BC75",
-      "inputs": [
-        {
-          "id": "fcd14a20-67b2-11eb-9f5e-9113990ec3b6",
-          "value": "{$.searchItems.item.resourceAttributes.id}",
-          "type": "string",
-          "structure": []
-        }
-      ],
-      "settings": [
-        {
-          "id": "blendr_on_error",
-          "value": "stop",
-          "type": "select",
-          "structure": []
-        },
-        {
-          "id": "automations_censor_data",
-          "value": false,
-          "type": "checkbox",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2442,
-      "y": 23854,
-      "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
-      "endpoint_guid": "fcc108b0-67b2-11eb-806a-3957ec36f31b",
-      "endpoint_role": "delete"
-    },
-    {
-      "id": "27388F0E-6FFB-4D16-B4E5-08174412BC75",
-      "type": "ShowBlock",
-      "disabled": false,
-      "name": "output44",
-      "displayName": "Output 44",
-      "comment": "Status output.",
-      "childId": null,
-      "inputs": [
-        {
-          "id": "input",
-          "value": "| {$.loop2.item.name} - Cleanup | > Configured to keep {$.versionsToKeep} apps, deleted app {add: {$.cleanupCounter}, 1} from shared space: [{$.searchItems.item.resourceAttributes.name}]. |",
-          "type": "string",
-          "structure": []
-        }
-      ],
-      "settings": [
-        {
-          "id": "display_mode",
-          "value": "add",
-          "type": "select",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2442,
-      "y": 23974
-    },
-    {
-      "id": "D5570044-9796-4DC7-81B6-C6D2F937FB1F",
-      "type": "VariableBlock",
-      "disabled": false,
-      "name": "cleanupCounter",
-      "displayName": "Variable - cleanupCounter",
-      "comment": "Increment the variable by 1 to get the total count of apps that have been backed up in the shared space.",
-      "childId": null,
-      "inputs": [],
-      "settings": [],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2562,
-      "y": 24174,
-      "variableGuid": "F6ED0768-9852-46AF-B822-2172586824B7",
-      "operations": [
-        {
-          "id": "add",
-          "key": "5B03057A-3746-4B90-83B6-69A9F037542C",
-          "name": "Add to { variable }",
-          "value": "1"
-        }
-      ]
-    },
-    {
-      "id": "BE7F53B8-B1FD-48DF-A8A5-D6638F74FA2C",
-      "type": "VariableBlock",
-      "disabled": false,
-      "name": "errorTitle",
-      "displayName": "Variable - errorTitle",
-      "comment": "Set error title for standard error output.",
-      "childId": "A8F7B895-B7BB-4F7A-9189-B757D5A85B52",
-      "inputs": [],
-      "settings": [],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2802,
-      "y": -426,
-      "variableGuid": "407730A6-EC96-4337-BE80-CF4C0D552F08",
-      "operations": [
-        {
-          "id": "set_value",
-          "key": "1BC10F4C-68C2-42E9-9000-25865B076073",
-          "name": "Set value of { variable }",
-          "value": "Missing TenantAdmin role on executing user. Assign this role to your user and try again."
-        }
-      ]
-    },
-    {
-      "id": "A8F7B895-B7BB-4F7A-9189-B757D5A85B52",
-      "type": "VariableBlock",
-      "disabled": false,
-      "name": "errorDetail",
-      "displayName": "Variable - errorDetail",
-      "comment": "Variable to store detailed error message.",
-      "childId": "1D1FB21E-ADAA-4284-8526-5C849D304B59",
-      "inputs": [],
-      "settings": [],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2802,
-      "y": -306,
-      "variableGuid": "1BF2068B-106E-4D58-BC51-884F1810F03C",
-      "operations": [
-        {
-          "id": "set_value",
-          "key": "1BC10F4C-68C2-42E9-9000-25865B076073",
-          "name": "Set value of { variable }",
-          "value": "Exiting, could not find TenantAdmin role assigned to current user either via direct or group assignment."
-        }
-      ]
-    },
-    {
-      "id": "1D1FB21E-ADAA-4284-8526-5C849D304B59",
-      "type": "GotoBlock",
-      "disabled": false,
-      "name": "goToLabel2",
-      "displayName": "Go To Label 2",
-      "comment": "Go to the label named error.",
-      "childId": null,
-      "inputs": [
-        {
-          "id": "label",
-          "value": "EF82AD29-E2CF-44C9-A7DB-24C784618756",
-          "type": "select",
-          "displayValue": "error",
-          "structure": []
-        }
-      ],
-      "settings": [],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2802,
-      "y": -186
-    },
-    {
-      "id": "D46F6E49-3856-430B-A685-0A07984CDAEB",
-      "type": "ShowBlock",
-      "disabled": false,
-      "name": "output54",
-      "displayName": "Output 54",
-      "comment": "Exit output.",
-      "childId": "D7265A2B-A82F-47D4-B7CA-83E0EA902FCF",
-      "inputs": [
-        {
-          "id": "input",
-          "value": "Error: { $.errorDetail }",
-          "type": "string",
-          "structure": []
-        }
-      ],
-      "settings": [
-        {
-          "id": "display_mode",
-          "value": "add",
-          "type": "select",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -1219,
-      "y": -2795
-    },
-    {
-      "id": "D7265A2B-A82F-47D4-B7CA-83E0EA902FCF",
-      "type": "UpdateJobBlock",
-      "disabled": false,
-      "name": "updateRunTitle2",
-      "displayName": "Update Run Title 2",
-      "comment": "Update run title with the error message.",
-      "childId": "EA734A3A-B6F0-47F4-BB88-4D3C1DCADBE2",
-      "inputs": [
-        {
-          "id": "title",
-          "value": "Error: { $.errorTitle }",
-          "type": "string",
-          "structure": []
-        }
-      ],
-      "settings": [
-        {
-          "id": "automations_censor_data",
-          "value": false,
-          "type": "checkbox",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -1219,
-      "y": -2675
-    },
-    {
-      "id": "43D8ED19-F455-48F9-9CC4-7FE2A93B1884",
-      "type": "EndpointBlock",
-      "disabled": false,
-      "name": "getCurrentTenantInfo",
-      "displayName": "Qlik Cloud Services - Get Current Tenant Info",
-      "comment": "Get record for the current tenant.",
-      "childId": "DD6471AE-35D5-4348-819C-90FB501F35CD",
-      "inputs": [],
-      "settings": [
-        {
-          "id": "blendr_on_error",
-          "value": "stop",
-          "type": "select",
-          "structure": []
-        },
-        {
-          "id": "cache",
-          "value": "0",
-          "type": "select",
-          "structure": []
-        },
-        {
-          "id": "automations_censor_data",
-          "value": false,
-          "type": "checkbox",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": false
-        }
-      ],
-      "x": -2922,
-      "y": -2346,
-      "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
-      "endpoint_guid": "55051480-cb86-11ec-b746-892c1d04114e",
-      "endpoint_role": "get"
-    },
-    {
-      "id": "DD6471AE-35D5-4348-819C-90FB501F35CD",
-      "type": "VariableBlock",
-      "disabled": false,
-      "name": "tenantHostname",
-      "displayName": "Variable - tenantHostname",
-      "comment": "Determine tenant hostname. Use alias if available.",
-      "childId": "82CEC2F2-0C2A-438F-8D85-41BF9C90E37B",
-      "inputs": [],
-      "settings": [],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": false
-        }
-      ],
-      "x": -2922,
-      "y": -2226,
-      "variableGuid": "3723D829-3B14-4B68-AAFE-63966A7025E6",
-      "operations": [
-        {
-          "id": "set_value",
-          "key": "552A5562-F8C8-4C4C-AB89-C90BD892542E",
-          "name": "Set value of { variable }",
-          "value": "https://{if: { $.getCurrentTenantInfo.hostnames[1] } empty , $.getCurrentTenantInfo.hostnames[0], $.getCurrentTenantInfo.hostnames[1]}/"
-        }
-      ]
-    },
-    {
-      "id": "AABAC2BF-30E8-49FC-982B-52BD9707DAE0",
-      "type": "VariableBlock",
-      "disabled": false,
-      "name": "refreshConnectorCredentials",
-      "displayName": "Variable - refreshConnectorCredentials",
-      "comment": "Configure whether to refresh the REST credentials on every run. By default, it is set to 1, which will recreate the credentials each time. Set to 0 to leave the API keys unchanged.",
-      "childId": "2E61A575-F621-4713-B446-C1BAC52D8834",
-      "inputs": [],
-      "settings": [],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2802,
-      "y": -3386,
-      "variableGuid": "64E41053-153C-41E1-8E96-441CE6CCC379",
-      "operations": [
-        {
-          "id": "set_value",
-          "key": "2A53EE0E-A13C-45CD-9E07-D012532B33CA",
-          "name": "Set value of { variable }",
-          "value": "1"
-        }
-      ]
-    },
-    {
-      "id": "82CEC2F2-0C2A-438F-8D85-41BF9C90E37B",
-      "type": "VariableBlock",
-      "disabled": false,
-      "name": "currentTemplateVersionNum",
-      "displayName": "Variable - currentTemplateVersionNum",
-      "comment": "The current version number of this template",
-      "childId": "D7D4A126-BDC4-41D8-AB46-9D581AAE2FED",
-      "inputs": [],
-      "settings": [],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": false
-        }
-      ],
-      "x": -2922,
-      "y": -2106,
-      "variableGuid": "69E3DE89-62A4-4A45-A797-81D480D8BBC9",
-      "operations": [
-        {
-          "id": "set_value",
-          "key": "F54109D0-B3B3-4AB8-AB22-1E1379CCFA98",
-          "name": "Set value of { variable }",
-          "value": "3"
-        }
-      ]
-    },
-    {
-      "id": "D7D4A126-BDC4-41D8-AB46-9D581AAE2FED",
-      "type": "CallUrlBlock",
-      "disabled": false,
-      "name": "callURL",
-      "displayName": "Call URL",
-      "comment": "Retrieve installer manifest from Qlik to determine latest version of this automation.",
-      "childId": "E9A1664E-7B3A-4333-9DCA-65E34A43AD2D",
-      "inputs": [
-        {
-          "id": "url",
-          "value": "https://raw.githubusercontent.com/qlik-oss/qlik-cloud-monitoring-apps/main/manifests/installers.json",
-          "type": "string",
-          "structure": []
-        },
-        {
-          "id": "method",
-          "value": "GET",
-          "type": "select",
-          "structure": []
-        },
-        {
-          "id": "timeout",
-          "value": "",
-          "type": "string",
-          "structure": []
-        },
-        {
-          "id": "params",
-          "value": null,
-          "type": "object",
-          "mode": "keyValue",
-          "structure": []
-        },
-        {
-          "id": "headers",
-          "value": null,
-          "type": "object",
-          "mode": "keyValue",
-          "structure": []
-        },
-        {
-          "id": "encoding",
-          "value": "",
-          "type": "string",
-          "structure": []
-        }
-      ],
-      "settings": [
-        {
-          "id": "blendr_on_error",
-          "value": "stop",
-          "type": "select",
-          "structure": []
-        },
-        {
-          "id": "full_response",
-          "value": null,
-          "type": "checkbox",
-          "structure": []
-        },
-        {
-          "id": "capitalize_headers",
-          "value": true,
-          "type": "checkbox",
-          "structure": []
-        },
-        {
-          "id": "automations_censor_data",
-          "value": false,
-          "type": "checkbox",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": false
-        }
-      ],
-      "x": -2922,
-      "y": -1986
-    },
-    {
-      "id": "C199B1F5-97A8-493A-BA22-0632702923FD",
-      "type": "IfElseBlock",
-      "disabled": false,
-      "name": "condition2",
-      "displayName": "Condition 2",
-      "comment": "If the automation version is greater than or equal to the manifest version.",
-      "childId": "D0E7DF6C-C216-4DB6-8502-1F3C4ADF5AFE",
-      "inputs": [
-        {
-          "id": "conditions",
-          "value": {
-            "mode": "all",
-            "conditions": [
-              {
-                "input1": "{ $.currentTemplateVersionNum }",
-                "operator": ">=",
-                "input2": "{ $.callURL.installers[?(@.template=='qcmad')].version }"
-              },
-              {
-                "input1": "{ $.callURL.installers[?(@.template=='qcmad')].version }",
-                "operator": "notEmpty",
-                "input2": null
-              }
-            ]
-          },
-          "type": "custom",
-          "structure": []
-        }
-      ],
-      "settings": [],
-      "collapsed": [
-        {
-          "name": "both",
-          "isCollapsed": false
-        },
-        {
-          "name": "yes",
-          "isCollapsed": false
-        },
-        {
-          "name": "no",
-          "isCollapsed": false
-        }
-      ],
-      "x": -2922,
-      "y": -1746,
-      "childTrueId": null,
-      "childFalseId": "8F006B7D-F5B6-4BAA-8BFB-76D2B794E8AF"
-    },
-    {
-      "id": "8C8FFCA6-849B-49E7-9852-7B0C074D6F65",
-      "type": "EndpointBlock",
-      "disabled": false,
-      "name": "rawAPIRequest",
-      "displayName": "Qlik Cloud Services - Raw API Request",
-      "comment": "Look up user by subject.",
-      "childId": "9C6779A3-FFA8-49D8-B3AE-ADA3D57BA1D5",
-      "inputs": [
-        {
-          "id": "734cbcc0-bbb0-11f0-b998-f73920377683",
-          "value": "v1/licenses/assignments",
-          "type": "string",
-          "structure": []
-        },
-        {
-          "id": "7322a550-bbb0-11f0-9c8c-43f143a32456",
-          "value": "7341e840-bbb0-11f0-9bb8-11c201f87b6d",
-          "type": "select",
-          "displayValue": "GET",
-          "structure": []
-        },
-        {
-          "id": "73000fe0-bbb0-11f0-8a80-59ece3571bd9",
-          "value": null,
-          "type": "object",
-          "mode": "keyValue",
-          "structure": []
-        },
-        {
-          "id": "736fae60-bbb0-11f0-ad62-c98a0046f418",
-          "value": [
-            {
-              "key": "filter",
-              "value": "subject eq \"{regexreplace: { $.getUser.subject }, '(\\\\)', '\\\\\\\\'}\""
-            }
           ],
-          "type": "object",
-          "mode": "keyValue",
-          "structure": []
-        }
-      ],
-      "settings": [
-        {
-          "id": "blendr_on_error",
-          "value": "stop",
-          "type": "select",
-          "structure": []
-        },
-        {
-          "id": "automations_censor_data",
-          "value": false,
-          "type": "checkbox",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": false
-        }
-      ],
-      "x": -2922,
-      "y": 1814,
-      "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
-      "endpoint_guid": "72d48530-bbb0-11f0-875a-b322bf237aeb",
-      "endpoint_role": "create"
-    },
-    {
-      "id": "F893CB46-17A5-4082-BB7B-5564538B5F8B",
-      "type": "IfElseBlock",
-      "disabled": false,
-      "name": "condition5",
-      "displayName": "Condition 5",
-      "comment": "If not a capacity product, fail if user doesn't have a professional license as we cannot guarantee these can be auto assigned.",
-      "childId": "6DA24FBE-A1C7-4EF8-85CA-9C796A00B84D",
-      "inputs": [
-        {
-          "id": "conditions",
-          "value": {
-            "mode": "all",
-            "conditions": [
+          "settings": [],
+          "collapsed": [
               {
-                "input1": "{ $.rawAPIRequest.data[*].type }",
-                "input2": "professional",
-                "operator": "notInList"
-              },
-              {
-                "input1": "{ $.isCapacityTenant }",
-                "input2": "0",
-                "operator": "="
+                  "name": "loop",
+                  "isCollapsed": false
               }
-            ]
-          },
-          "type": "custom",
-          "structure": []
-        }
-      ],
-      "settings": [],
-      "collapsed": [
-        {
-          "name": "both",
-          "isCollapsed": false
-        },
-        {
-          "name": "yes",
-          "isCollapsed": false
-        },
-        {
-          "name": "no",
-          "isCollapsed": false
-        }
-      ],
-      "x": -2922,
-      "y": 2174,
-      "childTrueId": "D115A0F9-A1B3-4483-8169-145D1F47A9B1",
-      "childFalseId": null
-    },
-    {
-      "id": "D115A0F9-A1B3-4483-8169-145D1F47A9B1",
-      "type": "VariableBlock",
-      "disabled": false,
-      "name": "errorTitle",
-      "displayName": "Variable - errorTitle",
-      "comment": "Set error title for standard error output.",
-      "childId": "6064DA9A-04D6-49DD-B223-C3752D3769F4",
-      "inputs": [],
-      "settings": [],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2802,
-      "y": 2254,
-      "variableGuid": "407730A6-EC96-4337-BE80-CF4C0D552F08",
-      "operations": [
-        {
-          "id": "set_value",
-          "key": "1BC10F4C-68C2-42E9-9000-25865B076073",
-          "name": "Set value of { variable }",
-          "value": "Missing professional entitlement on executing user. Ensure a professional entitlement is assigned to your user and try again."
-        }
-      ]
-    },
-    {
-      "id": "6064DA9A-04D6-49DD-B223-C3752D3769F4",
-      "type": "VariableBlock",
-      "disabled": false,
-      "name": "errorDetail",
-      "displayName": "Variable - errorDetail",
-      "comment": "Variable to store detailed error message.",
-      "childId": "F81EA66B-BC74-4856-AE46-4B9C1D64A6AE",
-      "inputs": [],
-      "settings": [],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2802,
-      "y": 2374,
-      "variableGuid": "1BF2068B-106E-4D58-BC51-884F1810F03C",
-      "operations": [
-        {
-          "id": "set_value",
-          "key": "1BC10F4C-68C2-42E9-9000-25865B076073",
-          "name": "Set value of { variable }",
-          "value": "Exiting, could not find a professional entitlement assigned to current user. Please assign a professional entitlement to your user. A log out may be required to clear caches."
-        }
-      ]
-    },
-    {
-      "id": "F81EA66B-BC74-4856-AE46-4B9C1D64A6AE",
-      "type": "GotoBlock",
-      "disabled": false,
-      "name": "goToLabel4",
-      "displayName": "Go To Label 4",
-      "comment": "Go to the label named error.",
-      "childId": null,
-      "inputs": [
-        {
-          "id": "label",
-          "value": "EF82AD29-E2CF-44C9-A7DB-24C784618756",
-          "type": "select",
-          "displayValue": "error",
-          "structure": []
-        }
-      ],
-      "settings": [],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2802,
-      "y": 2494
-    },
-    {
-      "id": "948CF475-AF52-4C8B-AF9E-07DD7DE82F45",
-      "type": "VariableBlock",
-      "disabled": false,
-      "name": "userRoles",
-      "displayName": "Variable - userRoles",
-      "comment": "Collect all roles for API key access checks.",
-      "childId": "D93CC85B-1E1E-4EE9-A2C4-D60FB7E19A92",
-      "inputs": [],
-      "settings": [],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": false
-        }
-      ],
-      "x": -2922,
-      "y": 14,
-      "variableGuid": "CD9F0C76-28B4-482E-A218-EDE5763F6807",
-      "operations": [
-        {
-          "id": "merge",
-          "key": "1835DD18-E922-44C8-B5B7-CE7182E56679",
-          "name": "Merge other list into { variable }",
-          "value": "{ $.getUser.assignedRoles }"
-        }
-      ]
-    },
-    {
-      "id": "3F9D73BE-55D6-406B-B9DE-D518B12BAA4E",
-      "type": "FilterListBlock",
-      "disabled": false,
-      "name": "filterList",
-      "displayName": "Filter List",
-      "comment": "Loop over custom roles to build list of permissions.",
-      "childId": "4D28FE57-54CB-4FA9-A5EE-A7C65992D3FD",
-      "inputs": [
-        {
-          "id": "list",
-          "value": "{ $.userRoles }",
-          "type": "string",
-          "structure": []
-        },
-        {
-          "id": "conditions",
-          "value": {
-            "mode": "all",
-            "conditions": [
-              {
-                "input1": "type",
-                "input2": "custom",
-                "operator": "="
-              }
-            ]
-          },
-          "type": "custom",
-          "structure": []
-        }
-      ],
-      "settings": [
-        {
-          "id": "automations_censor_data",
-          "value": false,
-          "type": "checkbox",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": false
-        }
-      ],
-      "x": -2922,
-      "y": 654,
-      "loopBlockId": "73CC9998-44BE-4947-9526-54DE0D4A39C4"
-    },
-    {
-      "id": "73CC9998-44BE-4947-9526-54DE0D4A39C4",
-      "type": "EndpointBlock",
-      "disabled": false,
-      "name": "getRole",
-      "displayName": "Qlik Cloud Services - Get Role",
-      "comment": "Get details of a specific role.",
-      "childId": "652F5F89-37E7-4AB8-96DA-F3A3A9242C95",
-      "inputs": [
-        {
-          "id": "b537b230-3702-11f0-a5a5-6dd4cd401495",
-          "value": "{ $.filterList.item.id }",
-          "type": "string",
-          "structure": []
-        }
-      ],
-      "settings": [
-        {
-          "id": "blendr_on_error",
-          "value": "stop",
-          "type": "select",
-          "structure": []
-        },
-        {
-          "id": "cache",
-          "value": "0",
-          "type": "select",
-          "structure": []
-        },
-        {
-          "id": "automations_censor_data",
-          "value": false,
-          "type": "checkbox",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2802,
-      "y": 754,
-      "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
-      "endpoint_guid": "76c4e5d0-3702-11f0-bd5c-8b8be373d450",
-      "endpoint_role": "get"
-    },
-    {
-      "id": "CD1DE6F6-8F1B-43EE-9B1A-E1ED8E200416",
-      "type": "VariableBlock",
-      "disabled": false,
-      "name": "userPermissions",
-      "displayName": "Variable - userPermissions",
-      "comment": "Empty user permissions list.",
-      "childId": "3F9D73BE-55D6-406B-B9DE-D518B12BAA4E",
-      "inputs": [],
-      "settings": [],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": false
-        }
-      ],
-      "x": -2922,
-      "y": 534,
-      "variableGuid": "4283B5F6-E6C0-492F-AA5B-21195FFF74DF",
-      "operations": [
-        {
-          "id": "empty",
-          "key": "5CA3D3DF-A8A6-4787-BE09-8DC63ADBF31C",
-          "name": "Empty { variable }",
-          "value": null
-        }
-      ]
-    },
-    {
-      "id": "652F5F89-37E7-4AB8-96DA-F3A3A9242C95",
-      "type": "VariableBlock",
-      "disabled": false,
-      "name": "userPermissions",
-      "displayName": "Variable - userPermissions",
-      "comment": "Add to user permissions list.",
-      "childId": null,
-      "inputs": [],
-      "settings": [],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2802,
-      "y": 874,
-      "variableGuid": "4283B5F6-E6C0-492F-AA5B-21195FFF74DF",
-      "operations": [
-        {
-          "id": "merge",
-          "key": "E08C7C2C-0351-4834-9C2B-8621AA9CCFB0",
-          "name": "Merge other list into { variable }",
-          "value": "{ $.getRole.assignedScopes }"
-        }
-      ]
-    },
-    {
-      "id": "192CAC57-0476-4EA6-9E3B-44900026EB88",
-      "type": "IfElseBlock",
-      "disabled": false,
-      "name": "condition4",
-      "displayName": "Condition 4",
-      "comment": "If api-keys permission not present, exit.",
-      "childId": "8C8FFCA6-849B-49E7-9852-7B0C074D6F65",
-      "inputs": [
-        {
-          "id": "conditions",
-          "value": {
-            "mode": "all",
-            "conditions": [
-              {
-                "input1": "{ $.userPermissions }",
-                "input2": "api-keys",
-                "operator": "doesntContain"
-              }
-            ]
-          },
-          "type": "custom",
-          "structure": []
-        }
-      ],
-      "settings": [],
-      "collapsed": [
-        {
-          "name": "both",
-          "isCollapsed": false
-        },
-        {
-          "name": "yes",
-          "isCollapsed": false
-        },
-        {
-          "name": "no",
-          "isCollapsed": false
-        }
-      ],
-      "x": -2922,
-      "y": 1294,
-      "childTrueId": "85BD0C04-9778-4A9E-A153-DE2A74C1CE3B",
-      "childFalseId": null
-    },
-    {
-      "id": "85BD0C04-9778-4A9E-A153-DE2A74C1CE3B",
-      "type": "VariableBlock",
-      "disabled": false,
-      "name": "errorTitle",
-      "displayName": "Variable - errorTitle",
-      "comment": "Set error title for standard error output.",
-      "childId": "0C31D3FC-EAF9-4A51-B843-F7E4F7817619",
-      "inputs": [],
-      "settings": [],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2802,
-      "y": 1374,
-      "variableGuid": "407730A6-EC96-4337-BE80-CF4C0D552F08",
-      "operations": [
-        {
-          "id": "set_value",
-          "key": "1BC10F4C-68C2-42E9-9000-25865B076073",
-          "name": "Set value of { variable }",
-          "value": "Missing api-keys permission on executing user. Assign this permission and try again."
-        }
-      ]
-    },
-    {
-      "id": "0C31D3FC-EAF9-4A51-B843-F7E4F7817619",
-      "type": "VariableBlock",
-      "disabled": false,
-      "name": "errorDetail",
-      "displayName": "Variable - errorDetail",
-      "comment": "Variable to store detailed error message.",
-      "childId": "EBC4167E-EF3B-4828-B452-457EB4B11613",
-      "inputs": [],
-      "settings": [],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2802,
-      "y": 1494,
-      "variableGuid": "1BF2068B-106E-4D58-BC51-884F1810F03C",
-      "operations": [
-        {
-          "id": "set_value",
-          "key": "1BC10F4C-68C2-42E9-9000-25865B076073",
-          "name": "Set value of { variable }",
-          "value": "Exiting, could not find the `api-keys` permission assigned to current user. Please either add this permission to a custom role and assign that to your user, or allow this permission for all users. Formerly, access to API keys was controlled by the `Developer` role, which is deprecated. A log out may be required to clear caches."
-        }
-      ]
-    },
-    {
-      "id": "EBC4167E-EF3B-4828-B452-457EB4B11613",
-      "type": "GotoBlock",
-      "disabled": false,
-      "name": "goToLabel3",
-      "displayName": "Go To Label 3",
-      "comment": "Go to the label named error.",
-      "childId": null,
-      "inputs": [
-        {
-          "id": "label",
-          "value": "EF82AD29-E2CF-44C9-A7DB-24C784618756",
-          "type": "select",
-          "displayValue": "error",
-          "structure": []
-        }
-      ],
-      "settings": [],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2802,
-      "y": 1614
-    },
-    {
-      "id": "6DA24FBE-A1C7-4EF8-85CA-9C796A00B84D",
-      "type": "EndpointBlock",
-      "disabled": false,
-      "name": "rawAPIRequest2",
-      "displayName": "Qlik Cloud Services - Raw API Request 2",
-      "comment": "Get API key settings for max expiry.",
-      "childId": "60DC4193-EAC7-4353-86C5-C9233AF169EA",
-      "inputs": [
-        {
-          "id": "734cbcc0-bbb0-11f0-b998-f73920377683",
-          "value": "v1/api-keys/configs/{$.getCurrentTenantInfo.id}",
-          "type": "string",
-          "structure": []
-        },
-        {
-          "id": "7322a550-bbb0-11f0-9c8c-43f143a32456",
-          "value": "7341e840-bbb0-11f0-9bb8-11c201f87b6d",
-          "type": "select",
-          "displayValue": "GET",
-          "structure": []
-        },
-        {
-          "id": "73000fe0-bbb0-11f0-8a80-59ece3571bd9",
-          "value": null,
-          "type": "object",
-          "mode": "keyValue",
-          "structure": []
-        },
-        {
-          "id": "736fae60-bbb0-11f0-ad62-c98a0046f418",
-          "value": null,
-          "type": "object",
-          "mode": "keyValue",
-          "structure": []
-        }
-      ],
-      "settings": [
-        {
-          "id": "blendr_on_error",
-          "value": "stop",
-          "type": "select",
-          "structure": []
-        },
-        {
-          "id": "automations_censor_data",
-          "value": false,
-          "type": "checkbox",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": false
-        }
-      ],
-      "x": -2922,
-      "y": 2694,
-      "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
-      "endpoint_guid": "72d48530-bbb0-11f0-875a-b322bf237aeb",
-      "endpoint_role": "create"
-    },
-    {
-      "id": "E98AA699-4CAD-416D-81EF-A97EB737FD6C",
-      "type": "IfElseBlock",
-      "disabled": false,
-      "name": "condition6",
-      "displayName": "Condition 6",
-      "comment": "For tenants using the deprecated API key toggle, are API keys enabled on the tenant? (Qlik internal reference: TLV-750)",
-      "childId": "F959E5AA-4EC0-4284-AA66-F59C788B6B08",
-      "inputs": [
-        {
-          "id": "conditions",
-          "value": {
-            "mode": "some",
-            "conditions": [
-              {
-                "input1": "{$.rawAPIRequest2.api_keys_enabled}",
-                "input2": "true",
-                "operator": "isTrue"
-              },
-              {
-                "input1": "{ textlength: {$.rawAPIRequest2.api_keys_enabled} }",
-                "input2": "0",
-                "operator": "="
-              }
-            ]
-          },
-          "type": "custom",
-          "structure": []
-        }
-      ],
-      "settings": [],
-      "collapsed": [
-        {
-          "name": "both",
-          "isCollapsed": false
-        },
-        {
-          "name": "yes",
-          "isCollapsed": false
-        },
-        {
-          "name": "no",
-          "isCollapsed": false
-        }
-      ],
-      "x": -2922,
-      "y": 2934,
-      "childTrueId": null,
-      "childFalseId": "D31546CE-90C1-43CA-9A5E-10B35DDE0BFE"
-    },
-    {
-      "id": "D31546CE-90C1-43CA-9A5E-10B35DDE0BFE",
-      "type": "VariableBlock",
-      "disabled": false,
-      "name": "errorTitle",
-      "displayName": "Variable - errorTitle",
-      "comment": "Set error title for standard error output.",
-      "childId": "D25BBAB7-8646-46AC-BC9B-D512B163DE2A",
-      "inputs": [],
-      "settings": [],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2802,
-      "y": 3094,
-      "variableGuid": "407730A6-EC96-4337-BE80-CF4C0D552F08",
-      "operations": [
-        {
-          "id": "set_value",
-          "key": "1BC10F4C-68C2-42E9-9000-25865B076073",
-          "name": "Set value of { variable }",
-          "value": "API keys are not enabled on the tenant. Please enable API keys and try again."
-        }
-      ]
-    },
-    {
-      "id": "D25BBAB7-8646-46AC-BC9B-D512B163DE2A",
-      "type": "VariableBlock",
-      "disabled": false,
-      "name": "errorDetail",
-      "displayName": "Variable - errorDetail",
-      "comment": "Variable to store detailed error message.",
-      "childId": "2C6FA9CF-3DE8-45CE-B24E-0979C9A78584",
-      "inputs": [],
-      "settings": [],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2802,
-      "y": 3214,
-      "variableGuid": "1BF2068B-106E-4D58-BC51-884F1810F03C",
-      "operations": [
-        {
-          "id": "set_value",
-          "key": "1BC10F4C-68C2-42E9-9000-25865B076073",
-          "name": "Set value of { variable }",
-          "value": "Exiting, API keys must be enabled on the tenant to use the monitoring apps since they rely on an API key for the REST data connections used for loading data from Qlik Cloud. Please enable API keys and try again."
-        }
-      ]
-    },
-    {
-      "id": "2C6FA9CF-3DE8-45CE-B24E-0979C9A78584",
-      "type": "GotoBlock",
-      "disabled": false,
-      "name": "goToLabel5",
-      "displayName": "Go To Label 5",
-      "comment": "Go to the label named error.",
-      "childId": null,
-      "inputs": [
-        {
-          "id": "label",
-          "value": "EF82AD29-E2CF-44C9-A7DB-24C784618756",
-          "type": "select",
-          "displayValue": "error",
-          "structure": []
-        }
-      ],
-      "settings": [],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2802,
-      "y": 3334
-    },
-    {
-      "id": "60DC4193-EAC7-4353-86C5-C9233AF169EA",
-      "type": "VariableBlock",
-      "disabled": false,
-      "name": "apiKeyDuration",
-      "displayName": "Variable - apiKeyDuration",
-      "comment": "Variable to store API key expiry.",
-      "childId": "E98AA699-4CAD-416D-81EF-A97EB737FD6C",
-      "inputs": [],
-      "settings": [],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": false
-        }
-      ],
-      "x": -2922,
-      "y": 2814,
-      "variableGuid": "51DCB139-A5E7-427D-8E9C-9382DB8A530C",
-      "operations": [
-        {
-          "id": "set_value",
-          "key": "F7907433-1824-49AD-AECA-0367D48E77E5",
-          "name": "Set value of { variable }",
-          "value": "{ $.rawAPIRequest2.max_api_key_expiry }"
-        }
-      ]
-    },
-    {
-      "id": "7BB23A76-A47D-4859-AE1D-D5532E49031D",
-      "type": "CallUrlBlock",
-      "disabled": false,
-      "name": "callURL2",
-      "displayName": "Call URL 2",
-      "comment": "Fetch monitoring applications manifest.",
-      "childId": "D68D0C47-8D62-4ADC-AC47-553E8E9A05ED",
-      "inputs": [
-        {
-          "id": "url",
-          "value": "https://raw.githubusercontent.com/qlik-oss/qlik-cloud-monitoring-apps/main/manifests/resources.json",
-          "type": "string",
-          "structure": []
-        },
-        {
-          "id": "method",
-          "value": "GET",
-          "type": "select",
-          "structure": []
-        },
-        {
-          "id": "timeout",
-          "value": "",
-          "type": "string",
-          "structure": []
-        },
-        {
-          "id": "params",
-          "value": null,
-          "type": "object",
-          "mode": "keyValue",
-          "structure": []
-        },
-        {
-          "id": "headers",
-          "value": null,
-          "type": "object",
-          "mode": "keyValue",
-          "structure": []
-        },
-        {
-          "id": "encoding",
-          "value": "",
-          "type": "string",
-          "structure": []
-        }
-      ],
-      "settings": [
-        {
-          "id": "blendr_on_error",
-          "value": "stop",
-          "type": "select",
-          "structure": []
-        },
-        {
-          "id": "full_response",
-          "value": null,
-          "type": "checkbox",
-          "structure": []
-        },
-        {
-          "id": "capitalize_headers",
-          "value": true,
-          "type": "checkbox",
-          "structure": []
-        },
-        {
-          "id": "automations_censor_data",
-          "value": false,
-          "type": "checkbox",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": false
-        }
-      ],
-      "x": -2922,
-      "y": 3774
-    },
-    {
-      "id": "D68D0C47-8D62-4ADC-AC47-553E8E9A05ED",
-      "type": "VariableBlock",
-      "disabled": false,
-      "name": "manifest",
-      "displayName": "Variable - manifest",
-      "comment": "Store the manifest.",
-      "childId": "66C7B574-5D06-4B85-BCEB-A11CBD175283",
-      "inputs": [],
-      "settings": [],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": false
-        }
-      ],
-      "x": -2922,
-      "y": 3894,
-      "variableGuid": "4FCFD564-CA0B-4516-AD61-A1A2EE9CF38C",
-      "operations": [
-        {
-          "id": "set",
-          "key": "FB81147D-D0D3-4B9B-B21C-AEB7DAE251AD",
-          "name": "Set { variable } equal to object ",
-          "value": "{$.callURL2}"
-        }
-      ]
-    },
-    {
-      "id": "9BC2CF3D-A602-4940-A86B-73BA20439C0F",
-      "type": "IfElseBlock",
-      "disabled": false,
-      "name": "condition7",
-      "displayName": "Condition 7",
-      "comment": "Is this a user-based tenant?",
-      "childId": "0BC5D2A0-7566-4F59-BA2B-078480075F4E",
-      "inputs": [
-        {
-          "id": "conditions",
-          "value": {
-            "mode": "all",
-            "conditions": [
-              {
-                "input1": "{ $.isCapacityTenant }",
-                "input2": "0",
-                "operator": "="
-              }
-            ]
-          },
-          "type": "custom",
-          "structure": []
-        }
-      ],
-      "settings": [],
-      "collapsed": [
-        {
-          "name": "both",
-          "isCollapsed": false
-        },
-        {
-          "name": "yes",
-          "isCollapsed": false
-        },
-        {
-          "name": "no",
-          "isCollapsed": false
-        }
-      ],
-      "x": -2922,
-      "y": 4134,
-      "childTrueId": "FBD838AA-F63C-4948-B755-00F8F6F2CDCF",
-      "childFalseId": "8968628A-54FC-4578-98FD-32FAE0B1454F"
-    },
-    {
-      "id": "FBD838AA-F63C-4948-B755-00F8F6F2CDCF",
-      "type": "FilterListBlock",
-      "disabled": false,
-      "name": "filterList2",
-      "displayName": "Filter List 2",
-      "comment": "Filter to just user-supported applications.",
-      "childId": null,
-      "inputs": [
-        {
-          "id": "list",
-          "value": "{$.manifest}",
-          "type": "string",
-          "structure": []
-        },
-        {
-          "id": "conditions",
-          "value": {
-            "mode": "all",
-            "conditions": [
-              {
-                "input1": "subscriptionTypes",
-                "input2": "user",
-                "operator": "inList"
-              },
-              {
-                "input1": "qcmaInstaller",
-                "input2": null,
-                "operator": "isTrue"
-              }
-            ]
-          },
-          "type": "custom",
-          "structure": []
-        }
-      ],
-      "settings": [
-        {
-          "id": "automations_censor_data",
-          "value": false,
-          "type": "checkbox",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": false
-        }
-      ],
-      "x": -2802,
-      "y": 4214,
-      "loopBlockId": "D3F1FBD1-BEBC-4148-92AF-528D93FE1B8A"
-    },
-    {
-      "id": "8C37F961-8477-4705-A167-CACE4E579177",
-      "type": "VariableBlock",
-      "disabled": false,
-      "name": "monitoringAppsToInstall",
-      "displayName": "Variable - monitoringAppsToInstall",
-      "comment": "Add monitoring apps to list.",
-      "childId": null,
-      "inputs": [],
-      "settings": [],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2562,
-      "y": 4394,
-      "variableGuid": "1ECFDB29-BC7A-4B7A-AE5F-2A2DBE77B1E0",
-      "operations": [
-        {
-          "id": "add_item",
-          "key": "5167867F-4931-4E4C-BDBA-28A2270E3E98",
-          "name": "Add item to { variable }",
-          "value": "{ $.filterList2.item }"
-        }
-      ]
-    },
-    {
-      "id": "8968628A-54FC-4578-98FD-32FAE0B1454F",
-      "type": "FilterListBlock",
-      "disabled": false,
-      "name": "filterList3",
-      "displayName": "Filter List 3",
-      "comment": "Filter to just capacity-supported applications.",
-      "childId": null,
-      "inputs": [
-        {
-          "id": "list",
-          "value": "{$.manifest}",
-          "type": "string",
-          "structure": []
-        },
-        {
-          "id": "conditions",
-          "value": {
-            "mode": "all",
-            "conditions": [
-              {
-                "input1": "subscriptionTypes",
-                "input2": "capacity",
-                "operator": "inList"
-              },
-              {
-                "input1": "qcmaInstaller",
-                "input2": null,
-                "operator": "isTrue"
-              }
-            ]
-          },
-          "type": "custom",
-          "structure": []
-        }
-      ],
-      "settings": [
-        {
-          "id": "automations_censor_data",
-          "value": false,
-          "type": "checkbox",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": false
-        }
-      ],
-      "x": -2802,
-      "y": 4714,
-      "loopBlockId": "619BAD5D-8B64-4866-9E4B-A6E8108FF386"
-    },
-    {
-      "id": "D5F81616-F18E-481D-8254-DC54513F20A3",
-      "type": "VariableBlock",
-      "disabled": false,
-      "name": "monitoringAppsToInstall",
-      "displayName": "Variable - monitoringAppsToInstall",
-      "comment": "Add monitoring apps to list.",
-      "childId": null,
-      "inputs": [],
-      "settings": [],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2562,
-      "y": 4894,
-      "variableGuid": "1ECFDB29-BC7A-4B7A-AE5F-2A2DBE77B1E0",
-      "operations": [
-        {
-          "id": "add_item",
-          "key": "EA1F052D-3E48-4CB3-A200-3FE04BFB5F56",
-          "name": "Add item to { variable }",
-          "value": "{ $.filterList3.item }"
-        }
-      ]
-    },
-    {
-      "id": "6AB100F2-DB70-49EC-AA91-33C3F4639953",
-      "type": "VariableBlock",
-      "disabled": false,
-      "name": "isCapacityTenant",
-      "displayName": "Variable - isCapacityTenant",
-      "comment": "Check for presence of \"QLIK SMT\" for capacity tenants.",
-      "childId": "F893CB46-17A5-4082-BB7B-5564538B5F8B",
-      "inputs": [],
-      "settings": [],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": false
-        }
-      ],
-      "x": -2922,
-      "y": 2054,
-      "variableGuid": "AD716F55-666C-4730-B830-F2D97A502F6B",
-      "operations": [
-        {
-          "id": "set_value",
-          "key": "D3F822AC-2E03-45D7-9C6E-7C5CB897D3A1",
-          "name": "Set value of { variable }",
-          "value": "{ if: { $.getLicenseOverview.product } contain 'QLIK SMT', 1, 0 }"
-        }
-      ]
-    },
-    {
-      "id": "66C7B574-5D06-4B85-BCEB-A11CBD175283",
-      "type": "VariableBlock",
-      "disabled": false,
-      "name": "monitoringAppsToInstall",
-      "displayName": "Variable - monitoringAppsToInstall",
-      "comment": "Clear monitoring app list.",
-      "childId": "9BC2CF3D-A602-4940-A86B-73BA20439C0F",
-      "inputs": [],
-      "settings": [],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": false
-        }
-      ],
-      "x": -2922,
-      "y": 4014,
-      "variableGuid": "1ECFDB29-BC7A-4B7A-AE5F-2A2DBE77B1E0",
-      "operations": [
-        {
-          "id": "empty",
-          "key": "422812C6-BD65-40D2-B175-AD2E1BBA5969",
-          "name": "Empty { variable }",
-          "value": null
-        }
-      ]
-    },
-    {
-      "id": "2E327220-1609-47A0-8385-6B40E70A7CFB",
-      "type": "VariableBlock",
-      "disabled": false,
-      "name": "configuredMonitoringApps",
-      "displayName": "Variable - configuredMonitoringApps",
-      "comment": "Configure which monitoring apps to install & maintain. Delete the record to skip installing/updating it. Must be a case sensitive match with the app names in the manifest.",
-      "childId": "AABAC2BF-30E8-49FC-982B-52BD9707DAE0",
-      "inputs": [],
-      "settings": [],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2802,
-      "y": -3506,
-      "variableGuid": "8E1D15E6-7269-4E6B-A87E-AF56400A2F7A",
-      "operations": [
-        {
-          "id": "add_item",
-          "key": "7FB0497F-6787-4032-A558-9F703F088CF4",
-          "name": "Add item to { variable }",
-          "value": "Access Evaluator"
-        },
-        {
-          "id": "add_item",
-          "key": "6716C27F-4A80-44FE-8CEC-DF73FD5FF17A",
-          "name": "Add item to { variable }",
-          "value": "Answers Analyzer"
-        },
-        {
-          "id": "add_item",
-          "key": "E4B393A2-E344-4A32-B6F4-B78C39896B9B",
-          "name": "Add item to { variable }",
-          "value": "App Analyzer"
-        },
-        {
-          "id": "add_item",
-          "key": "350EAF4C-9327-4C1E-BA2F-58C0C043E8E4",
-          "name": "Add item to { variable }",
-          "value": "Automation Analyzer"
-        },
-        {
-          "id": "add_item",
-          "key": "9FC73D37-6D3C-4BCB-B683-D527BB11E438",
-          "name": "Add item to { variable }",
-          "value": "Entitlement Analyzer"
-        },
-        {
-          "id": "add_item",
-          "key": "068D740C-BF98-42FE-AC99-397782586B6D",
-          "name": "Add item to { variable }",
-          "value": "Reload Analyzer"
-        },
-        {
-          "id": "add_item",
-          "key": "DE2D215A-30D2-4D17-956D-27940C0F46DF",
-          "name": "Add item to { variable }",
-          "value": "Report Analyzer"
-        }
-      ]
-    },
-    {
-      "id": "D3F1FBD1-BEBC-4148-92AF-528D93FE1B8A",
-      "type": "IfElseBlock",
-      "disabled": false,
-      "name": "condition8",
-      "displayName": "Condition 8",
-      "comment": "If in configured list.",
-      "childId": null,
-      "inputs": [
-        {
-          "id": "conditions",
-          "value": {
-            "mode": "all",
-            "conditions": [
-              {
-                "input1": "{ $.configuredMonitoringApps }",
-                "input2": "{ $.filterList2.item.name }",
-                "operator": "inList"
-              }
-            ]
-          },
-          "type": "custom",
-          "structure": []
-        }
-      ],
-      "settings": [],
-      "collapsed": [
-        {
-          "name": "both",
-          "isCollapsed": false
-        },
-        {
-          "name": "yes",
-          "isCollapsed": false
-        },
-        {
-          "name": "no",
-          "isCollapsed": false
-        }
-      ],
-      "x": -2682,
-      "y": 4314,
-      "childTrueId": "8C37F961-8477-4705-A167-CACE4E579177",
-      "childFalseId": null
-    },
-    {
-      "id": "619BAD5D-8B64-4866-9E4B-A6E8108FF386",
-      "type": "IfElseBlock",
-      "disabled": false,
-      "name": "condition9",
-      "displayName": "Condition 9",
-      "comment": "If in configured list.",
-      "childId": null,
-      "inputs": [
-        {
-          "id": "conditions",
-          "value": {
-            "mode": "all",
-            "conditions": [
-              {
-                "input1": "{ $.configuredMonitoringApps }",
-                "input2": "{ $.filterList3.item.name }",
-                "operator": "inList"
-              }
-            ]
-          },
-          "type": "custom",
-          "structure": []
-        }
-      ],
-      "settings": [],
-      "collapsed": [
-        {
-          "name": "both",
-          "isCollapsed": false
-        },
-        {
-          "name": "yes",
-          "isCollapsed": false
-        },
-        {
-          "name": "no",
-          "isCollapsed": false
-        }
-      ],
-      "x": -2682,
-      "y": 4814,
-      "childTrueId": "D5F81616-F18E-481D-8254-DC54513F20A3",
-      "childFalseId": null
-    },
-    {
-      "id": "0BC5D2A0-7566-4F59-BA2B-078480075F4E",
-      "type": "ShowBlock",
-      "disabled": false,
-      "name": "output4",
-      "displayName": "Output 4",
-      "comment": "Status output.",
-      "childId": "B67C3598-6171-40D5-87CE-E7CBA1D58E16",
-      "inputs": [
-        {
-          "id": "input",
-          "value": "| Confirmed apps in scope | Will load the following monitoring apps based on license & application availability: **{implode: { $.monitoringAppsToInstall[*].name }, ','}** |",
-          "type": "string",
-          "structure": []
-        }
-      ],
-      "settings": [
-        {
-          "id": "display_mode",
-          "value": "add",
-          "type": "select",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": false
-        }
-      ],
-      "x": -2922,
-      "y": 5214
-    },
-    {
-      "id": "F211A56A-FBCB-4413-BA12-91144F38B722",
-      "type": "ShowBlock",
-      "disabled": false,
-      "name": "output5",
-      "displayName": "Output 5",
-      "comment": "Status output.",
-      "childId": "00B11FD2-3490-4643-B8E8-F03547EB32B3",
-      "inputs": [
-        {
-          "id": "input",
-          "value": "| Missing role | User is missing required role `{ $.loop.item }`. Please assign to your user and re-run. |",
-          "type": "string",
-          "structure": []
-        }
-      ],
-      "settings": [
-        {
-          "id": "display_mode",
-          "value": "add",
-          "type": "select",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2682,
-      "y": 5754
-    },
-    {
-      "id": "B67C3598-6171-40D5-87CE-E7CBA1D58E16",
-      "type": "VariableBlock",
-      "disabled": false,
-      "name": "requiredRoles",
-      "displayName": "Variable - requiredRoles",
-      "comment": "Collate required roles from monitoringAppsToInstall.",
-      "childId": "432F3D61-2AEC-471B-8837-04AB4F56B9DB",
-      "inputs": [],
-      "settings": [],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": false
-        }
-      ],
-      "x": -2922,
-      "y": 5334,
-      "variableGuid": "09C608F2-CF67-4C9A-983E-F39019D443B9",
-      "operations": [
-        {
-          "id": "merge",
-          "key": "D773C6E0-4087-4487-945D-FCEC9A0C00F9",
-          "name": "Merge other list into { variable }",
-          "value": "{$.monitoringAppsToInstall[*].requiredRoles[*]}"
-        }
-      ]
-    },
-    {
-      "id": "F364D449-B628-4325-9617-1B04B7DBFB6A",
-      "type": "ForEachBlock",
-      "disabled": false,
-      "name": "loop",
-      "displayName": "Loop",
-      "comment": "Loop over required roles.",
-      "childId": "E6D1BA8E-24D6-4602-9400-9A74031E1EAB",
-      "inputs": [
-        {
-          "id": "input",
-          "value": "{ $.requiredRoles }",
-          "type": "string",
-          "structure": []
-        }
-      ],
-      "settings": [
-        {
-          "id": "automations_censor_data",
-          "value": false,
-          "type": "checkbox",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": false
-        }
-      ],
-      "x": -2922,
-      "y": 5574,
-      "loopBlockId": "7CE340D0-20D9-4B6B-80C0-9295582D1CF9"
-    },
-    {
-      "id": "7CE340D0-20D9-4B6B-80C0-9295582D1CF9",
-      "type": "IfElseBlock",
-      "disabled": false,
-      "name": "condition10",
-      "displayName": "Condition 10",
-      "comment": "If role isn't assigned.",
-      "childId": null,
-      "inputs": [
-        {
-          "id": "conditions",
-          "value": {
-            "mode": "all",
-            "conditions": [
-              {
-                "input1": "{ $.userRoles[*].name }",
-                "input2": "{ $.loop.item }",
-                "operator": "notInList"
-              }
-            ]
-          },
-          "type": "custom",
-          "structure": []
-        }
-      ],
-      "settings": [],
-      "collapsed": [
-        {
-          "name": "both",
-          "isCollapsed": false
-        },
-        {
-          "name": "yes",
-          "isCollapsed": false
-        },
-        {
-          "name": "no",
-          "isCollapsed": false
-        }
-      ],
-      "x": -2802,
-      "y": 5674,
-      "childTrueId": "F211A56A-FBCB-4413-BA12-91144F38B722",
-      "childFalseId": null
-    },
-    {
-      "id": "E6D1BA8E-24D6-4602-9400-9A74031E1EAB",
-      "type": "IfElseBlock",
-      "disabled": false,
-      "name": "condition11",
-      "displayName": "Condition 11",
-      "comment": "If missing roles, exit.",
-      "childId": "ECCD6D36-805D-44EF-A411-A73316586DD1",
-      "inputs": [
-        {
-          "id": "conditions",
-          "value": {
-            "mode": "all",
-            "conditions": [
-              {
-                "input1": "{count: { $.missingRoles }}",
-                "input2": "0",
-                "operator": ">"
-              }
-            ]
-          },
-          "type": "custom",
-          "structure": []
-        }
-      ],
-      "settings": [],
-      "collapsed": [
-        {
-          "name": "both",
-          "isCollapsed": false
-        },
-        {
-          "name": "yes",
-          "isCollapsed": false
-        },
-        {
-          "name": "no",
-          "isCollapsed": false
-        }
-      ],
-      "x": -2922,
-      "y": 6154,
-      "childTrueId": "EBDE966E-F544-46BF-89EA-FB5A671494B7",
-      "childFalseId": null
-    },
-    {
-      "id": "EBDE966E-F544-46BF-89EA-FB5A671494B7",
-      "type": "VariableBlock",
-      "disabled": false,
-      "name": "errorTitle",
-      "displayName": "Variable - errorTitle",
-      "comment": "Set error title for standard error output.",
-      "childId": "D13F1BD0-95CE-4118-B875-7DC61E17AA1E",
-      "inputs": [],
-      "settings": [],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2802,
-      "y": 6234,
-      "variableGuid": "407730A6-EC96-4337-BE80-CF4C0D552F08",
-      "operations": [
-        {
-          "id": "set_value",
-          "key": "1BC10F4C-68C2-42E9-9000-25865B076073",
-          "name": "Set value of { variable }",
-          "value": "User is missing required roles: { implode: { $.missingRoles }, ',' }."
-        }
-      ]
-    },
-    {
-      "id": "D13F1BD0-95CE-4118-B875-7DC61E17AA1E",
-      "type": "VariableBlock",
-      "disabled": false,
-      "name": "errorDetail",
-      "displayName": "Variable - errorDetail",
-      "comment": "Variable to store detailed error message.",
-      "childId": "69F43DAF-28FE-44A5-8D0F-5BF0E066A618",
-      "inputs": [],
-      "settings": [],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2802,
-      "y": 6354,
-      "variableGuid": "1BF2068B-106E-4D58-BC51-884F1810F03C",
-      "operations": [
-        {
-          "id": "set_value",
-          "key": "1BC10F4C-68C2-42E9-9000-25865B076073",
-          "name": "Set value of { variable }",
-          "value": "Exiting, user is missing one or more roles required by one of the monitoring apps: `{ implode: { $.missingRoles }, ',' }`. Review the output for the missing role, assign to your user, and try again."
-        }
-      ]
-    },
-    {
-      "id": "69F43DAF-28FE-44A5-8D0F-5BF0E066A618",
-      "type": "GotoBlock",
-      "disabled": false,
-      "name": "goToLabel6",
-      "displayName": "Go To Label 6",
-      "comment": "Go to the label named error.",
-      "childId": null,
-      "inputs": [
-        {
-          "id": "label",
-          "value": "EF82AD29-E2CF-44C9-A7DB-24C784618756",
-          "type": "select",
-          "displayValue": "error",
-          "structure": []
-        }
-      ],
-      "settings": [],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2802,
-      "y": 6474
-    },
-    {
-      "id": "ECCD6D36-805D-44EF-A411-A73316586DD1",
-      "type": "EndpointBlock",
-      "disabled": false,
-      "name": "rawAPIRequest3",
-      "displayName": "Qlik Cloud Services - Raw API Request 3",
-      "comment": "Get REST connector settings.",
-      "childId": "2CE857A5-5770-4230-B4A7-E64B4B777B22",
-      "inputs": [
-        {
-          "id": "734cbcc0-bbb0-11f0-b998-f73920377683",
-          "value": "v1/data-sources/rest/settings",
-          "type": "string",
-          "structure": []
-        },
-        {
-          "id": "7322a550-bbb0-11f0-9c8c-43f143a32456",
-          "value": "7341e840-bbb0-11f0-9bb8-11c201f87b6d",
-          "type": "select",
-          "displayValue": "GET",
-          "structure": []
-        },
-        {
-          "id": "73000fe0-bbb0-11f0-8a80-59ece3571bd9",
-          "value": null,
-          "type": "object",
-          "mode": "keyValue",
-          "structure": []
-        },
-        {
-          "id": "736fae60-bbb0-11f0-ad62-c98a0046f418",
-          "value": null,
-          "type": "object",
-          "mode": "keyValue",
-          "structure": []
-        }
-      ],
-      "settings": [
-        {
-          "id": "blendr_on_error",
-          "value": "stop",
-          "type": "select",
-          "structure": []
-        },
-        {
-          "id": "automations_censor_data",
-          "value": false,
-          "type": "checkbox",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": false
-        }
-      ],
-      "x": -2922,
-      "y": 6674,
-      "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
-      "endpoint_guid": "72d48530-bbb0-11f0-875a-b322bf237aeb",
-      "endpoint_role": "create"
-    },
-    {
-      "id": "00B11FD2-3490-4643-B8E8-F03547EB32B3",
-      "type": "VariableBlock",
-      "disabled": false,
-      "name": "missingRoles",
-      "displayName": "Variable - missingRoles",
-      "comment": "Add missing role to list.",
-      "childId": null,
-      "inputs": [],
-      "settings": [],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2682,
-      "y": 5874,
-      "variableGuid": "CB55538C-0F1A-4871-98DD-C68EC5B00D84",
-      "operations": [
-        {
-          "id": "add_item",
-          "key": "9172C800-C9AE-419C-B411-DC1D4D65C8A0",
-          "name": "Add item to { variable }",
-          "value": "{ $.loop.item }"
-        }
-      ]
-    },
-    {
-      "id": "432F3D61-2AEC-471B-8837-04AB4F56B9DB",
-      "type": "VariableBlock",
-      "disabled": false,
-      "name": "missingRoles",
-      "displayName": "Variable - missingRoles",
-      "comment": "Empty missing role list.",
-      "childId": "F364D449-B628-4325-9617-1B04B7DBFB6A",
-      "inputs": [],
-      "settings": [],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": false
-        }
-      ],
-      "x": -2922,
-      "y": 5454,
-      "variableGuid": "CB55538C-0F1A-4871-98DD-C68EC5B00D84",
-      "operations": [
-        {
-          "id": "empty",
-          "key": "0D2CE328-09DF-41C6-9021-02ED68132F13",
-          "name": "Empty { variable }",
-          "value": null
-        }
-      ]
-    },
-    {
-      "id": "7151B1C7-58CC-49D0-AE62-51CBB945D6D4",
-      "type": "EndpointBlock",
-      "disabled": false,
-      "name": "listApps",
-      "displayName": "Qlik Cloud Services - List Apps",
-      "comment": "List apps in managed space.",
-      "childId": "E68DA53C-EC7E-4FB7-9D95-FBD9050E0659",
-      "inputs": [
-        {
-          "id": "8cd8db50-107b-11ec-8082-edc45dd151ef",
-          "value": null,
-          "type": "select",
-          "structure": []
-        },
-        {
-          "id": "8ce4fad0-107b-11ec-a6ac-2bd407ad134b",
-          "value": "{ $.managedSpaceId }",
-          "type": "string",
-          "structure": []
-        }
-      ],
-      "settings": [
-        {
-          "id": "maxitemcount",
-          "value": "",
-          "type": "string",
-          "structure": []
-        },
-        {
-          "id": "blendr_on_error",
-          "value": "stop",
-          "type": "select",
-          "structure": []
-        },
-        {
-          "id": "cache",
-          "value": "0",
-          "type": "select",
-          "structure": []
-        },
-        {
-          "id": "automations_censor_data",
-          "value": false,
-          "type": "checkbox",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": false
-        }
-      ],
-      "x": -2922,
-      "y": 15014,
-      "loopBlockId": "DAD45F04-D485-42E3-B7DD-D8C3106EA5FC",
-      "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
-      "endpoint_guid": "8cc63340-107b-11ec-ab5d-f9b221ed2dc5",
-      "endpoint_role": "list"
-    },
-    {
-      "id": "DAD45F04-D485-42E3-B7DD-D8C3106EA5FC",
-      "type": "EndpointBlock",
-      "disabled": false,
-      "name": "rawAPIRequest9",
-      "displayName": "Qlik Cloud Services - Raw API Request 9",
-      "comment": "Retrieve item so we can get the tags.",
-      "childId": "4F40CB60-2782-41D7-BFA4-FF2A709B137F",
-      "inputs": [
-        {
-          "id": "734cbcc0-bbb0-11f0-b998-f73920377683",
-          "value": "v1/items/{$.listApps.item.itemId}",
-          "type": "string",
-          "structure": []
-        },
-        {
-          "id": "7322a550-bbb0-11f0-9c8c-43f143a32456",
-          "value": "7341e840-bbb0-11f0-9bb8-11c201f87b6d",
-          "type": "select",
-          "displayValue": "GET",
-          "structure": []
-        },
-        {
-          "id": "73000fe0-bbb0-11f0-8a80-59ece3571bd9",
-          "value": null,
-          "type": "object",
-          "mode": "keyValue",
-          "structure": []
-        },
-        {
-          "id": "736fae60-bbb0-11f0-ad62-c98a0046f418",
-          "value": null,
-          "type": "object",
-          "mode": "keyValue",
-          "structure": []
-        }
-      ],
-      "settings": [
-        {
-          "id": "blendr_on_error",
-          "value": "stop",
-          "type": "select",
-          "structure": []
-        },
-        {
-          "id": "automations_censor_data",
-          "value": false,
-          "type": "checkbox",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2802,
-      "y": 15114,
-      "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
-      "endpoint_guid": "72d48530-bbb0-11f0-875a-b322bf237aeb",
-      "endpoint_role": "create"
-    },
-    {
-      "id": "D2C679AD-2434-474C-9ACC-B95C8232BA8A",
-      "type": "VariableBlock",
-      "disabled": false,
-      "name": "existingAppList",
-      "displayName": "Variable - existingAppList",
-      "comment": "Empty app list.",
-      "childId": "7151B1C7-58CC-49D0-AE62-51CBB945D6D4",
-      "inputs": [],
-      "settings": [],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": false
-        }
-      ],
-      "x": -2922,
-      "y": 14894,
-      "variableGuid": "2E37F6E5-BE30-44ED-B0B6-B544ECEAAB9E",
-      "operations": [
-        {
-          "id": "empty",
-          "key": "6B0A6464-4A87-49C7-B4C8-667C17C9CEB9",
-          "name": "Empty { variable }",
-          "value": null
-        }
-      ]
-    },
-    {
-      "id": "E68DA53C-EC7E-4FB7-9D95-FBD9050E0659",
-      "type": "ForEachBlock",
-      "disabled": false,
-      "name": "loop2",
-      "displayName": "Loop 2",
-      "comment": "Loop over list of monitoring apps we want to install.",
-      "childId": "9745F8DD-9BEC-4E02-B0B9-B275B8BCFCB1",
-      "inputs": [
-        {
-          "id": "input",
-          "value": "{ $.monitoringAppsToInstall }",
-          "type": "string",
-          "structure": []
-        }
-      ],
-      "settings": [
-        {
-          "id": "automations_censor_data",
-          "value": false,
-          "type": "checkbox",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": false
-        }
-      ],
-      "x": -2922,
-      "y": 15394,
-      "loopBlockId": "0DBF0B78-A809-4DDE-B02F-EF043A628D39"
-    },
-    {
-      "id": "FB709E97-66EC-46E2-BFD4-25C11DAA5112",
-      "type": "IfElseBlock",
-      "disabled": false,
-      "name": "condition29",
-      "displayName": "Condition 29",
-      "comment": "If no app was found, or existing apps need update.",
-      "childId": null,
-      "inputs": [
-        {
-          "id": "conditions",
-          "value": {
-            "mode": "some",
-            "conditions": [
-              {
-                "input1": "{ $.workingAppExists }",
-                "input2": "0",
-                "operator": "="
-              },
-              {
-                "input1": "{ count: { $.workingAppList } }",
-                "input2": "0",
-                "operator": ">"
-              }
-            ]
-          },
-          "type": "custom",
-          "structure": []
-        }
-      ],
-      "settings": [],
-      "collapsed": [
-        {
-          "name": "both",
-          "isCollapsed": false
-        },
-        {
-          "name": "yes",
-          "isCollapsed": false
-        },
-        {
-          "name": "no",
-          "isCollapsed": false
-        }
-      ],
-      "x": -2802,
-      "y": 18114,
-      "childTrueId": "40EC15FE-C25F-442B-8CD9-5C87150436B3",
-      "childFalseId": null
-    },
-    {
-      "id": "4F40CB60-2782-41D7-BFA4-FF2A709B137F",
-      "type": "VariableBlock",
-      "disabled": false,
-      "name": "existingAppList",
-      "displayName": "Variable - existingAppList",
-      "comment": "Add app to applist.",
-      "childId": null,
-      "inputs": [],
-      "settings": [],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2802,
-      "y": 15234,
-      "variableGuid": "2E37F6E5-BE30-44ED-B0B6-B544ECEAAB9E",
-      "operations": [
-        {
-          "id": "add_item",
-          "key": "80C831BF-1F3C-4F48-87A0-60205A2325C0",
-          "name": "Add item to { variable }",
-          "value": "{ $.rawAPIRequest9 }"
-        }
-      ]
-    },
-    {
-      "id": "6D0F022E-164E-4CE3-B955-5961AA02A540",
-      "type": "ForEachBlock",
-      "disabled": false,
-      "name": "loop3",
-      "displayName": "Loop 3",
-      "comment": "Loop over existing apps.",
-      "childId": "FB709E97-66EC-46E2-BFD4-25C11DAA5112",
-      "inputs": [
-        {
-          "id": "input",
-          "value": "{ $.existingAppList }",
-          "type": "string",
-          "structure": []
-        }
-      ],
-      "settings": [
-        {
-          "id": "automations_censor_data",
-          "value": false,
-          "type": "checkbox",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": false
-        }
-      ],
-      "x": -2802,
-      "y": 15974,
-      "loopBlockId": "5BD148B9-BDD1-4C37-8EB3-73641F532BB3"
-    },
-    {
-      "id": "5BD148B9-BDD1-4C37-8EB3-73641F532BB3",
-      "type": "IfElseBlock",
-      "disabled": false,
-      "name": "condition25",
-      "displayName": "Condition 25",
-      "comment": "If the apps match, it means we need to check to upgrade it.",
-      "childId": null,
-      "inputs": [
-        {
-          "id": "conditions",
-          "value": {
-            "mode": "all",
-            "conditions": [
-              {
-                "input1": "{ $.loop3.item.meta.tags[*].name }",
-                "input2": "{ $.workingAppTagName }",
-                "operator": "inList"
-              }
-            ]
-          },
-          "type": "custom",
-          "structure": []
-        }
-      ],
-      "settings": [],
-      "collapsed": [
-        {
-          "name": "both",
-          "isCollapsed": false
-        },
-        {
-          "name": "yes",
-          "isCollapsed": false
-        },
-        {
-          "name": "no",
-          "isCollapsed": false
-        }
-      ],
-      "x": -2682,
-      "y": 16074,
-      "childTrueId": "0C03554A-88E9-4987-8DA7-2707C33613B5",
-      "childFalseId": null
-    },
-    {
-      "id": "0DBF0B78-A809-4DDE-B02F-EF043A628D39",
-      "type": "VariableBlock",
-      "disabled": false,
-      "name": "workingAppList",
-      "displayName": "Variable - workingAppList",
-      "comment": "Empty working list. This will be used to build a list of apps which need upgrading for this specific monitoring app template.",
-      "childId": "981978BE-431B-4AF5-BD0D-451A3885B024",
-      "inputs": [],
-      "settings": [],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2802,
-      "y": 15494,
-      "variableGuid": "B762B4A7-25F9-4764-BECA-D4461377CE04",
-      "operations": [
-        {
-          "id": "empty",
-          "key": "7CA93272-5204-449B-845A-AD9E8281F303",
-          "name": "Empty { variable }",
-          "value": null
-        }
-      ]
-    },
-    {
-      "id": "5181CCB7-03EB-4C0C-83CC-FD647E7EF358",
-      "type": "VariableBlock",
-      "disabled": false,
-      "name": "workingAppList",
-      "displayName": "Variable - workingAppList",
-      "comment": "Add app to working list.",
-      "childId": "0C14812A-A344-4903-9697-1426DB5C5DFA",
-      "inputs": [],
-      "settings": [],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2202,
-      "y": 16674,
-      "variableGuid": "B762B4A7-25F9-4764-BECA-D4461377CE04",
-      "operations": [
-        {
-          "id": "add_item",
-          "key": "D99F10CF-AAA9-4B94-A8DF-ABA631F2BA46",
-          "name": "Add item to { variable }",
-          "value": "{ $.loop3.item }"
-        }
-      ]
-    },
-    {
-      "id": "1D37B0B5-533A-4C98-8C0C-5D27CA83E613",
-      "type": "ShowBlock",
-      "disabled": false,
-      "name": "output29",
-      "displayName": "Output 29",
-      "comment": "Status output.",
-      "childId": null,
-      "inputs": [
-        {
-          "id": "input",
-          "value": "| {$.loop2.item.name} - Verify | Excluding existing app [{$.loop3.item.name}]({$.tenantHostname}sense/app/{$.loop3.item.resourceId}) in [{$.managedSpaceName}]({$.tenantHostname}analytics/catalog?space_filter={$.managedSpaceId}). **Cannot upgrade since it is missing a version tag. This may result in another copy of the app being deployed.** |",
-          "type": "string",
-          "structure": []
-        }
-      ],
-      "settings": [
-        {
-          "id": "display_mode",
-          "value": "add",
-          "type": "select",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2442,
-      "y": 17754
-    },
-    {
-      "id": "0C03554A-88E9-4987-8DA7-2707C33613B5",
-      "type": "FilterListBlock",
-      "disabled": false,
-      "name": "filterList8",
-      "displayName": "Filter List 8",
-      "comment": "Attempt to extract the version from tags.",
-      "childId": "2D10B51D-A303-4112-95D3-722117C7AAC3",
-      "inputs": [
-        {
-          "id": "list",
-          "value": "{ $.loop3.item.meta.tags }",
-          "type": "string",
-          "structure": []
-        },
-        {
-          "id": "conditions",
-          "value": {
-            "mode": "all",
-            "conditions": [
-              {
-                "input1": "name",
-                "input2": "QCMA - v",
-                "operator": "contain"
-              }
-            ]
-          },
-          "type": "custom",
-          "structure": []
-        }
-      ],
-      "settings": [
-        {
-          "id": "automations_censor_data",
-          "value": false,
-          "type": "checkbox",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": false
-        }
-      ],
-      "x": -2562,
-      "y": 16154,
-      "loopBlockId": null
-    },
-    {
-      "id": "2D10B51D-A303-4112-95D3-722117C7AAC3",
-      "type": "IfElseBlock",
-      "disabled": false,
-      "name": "condition26",
-      "displayName": "Condition 26",
-      "comment": "If versions were found, continue.",
-      "childId": null,
-      "inputs": [
-        {
-          "id": "conditions",
-          "value": {
-            "mode": "all",
-            "conditions": [
-              {
-                "input1": "{ count: { $.filterList8 } }",
-                "input2": "0",
-                "operator": ">"
-              }
-            ]
-          },
-          "type": "custom",
-          "structure": []
-        }
-      ],
-      "settings": [],
-      "collapsed": [
-        {
-          "name": "both",
-          "isCollapsed": false
-        },
-        {
-          "name": "yes",
-          "isCollapsed": false
-        },
-        {
-          "name": "no",
-          "isCollapsed": false
-        }
-      ],
-      "x": -2562,
-      "y": 16314,
-      "childTrueId": "7FC2859A-CB6D-4A81-B1B7-8DA4C1DF9E27",
-      "childFalseId": "1D37B0B5-533A-4C98-8C0C-5D27CA83E613"
-    },
-    {
-      "id": "7FC2859A-CB6D-4A81-B1B7-8DA4C1DF9E27",
-      "type": "IfElseBlock",
-      "disabled": false,
-      "name": "condition27",
-      "displayName": "Condition 27",
-      "comment": "If a single version was found.",
-      "childId": null,
-      "inputs": [
-        {
-          "id": "conditions",
-          "value": {
-            "mode": "all",
-            "conditions": [
-              {
-                "input1": "{ count: { $.filterList8 } }",
-                "input2": "1",
-                "operator": "="
-              }
-            ]
-          },
-          "type": "custom",
-          "structure": []
-        }
-      ],
-      "settings": [],
-      "collapsed": [
-        {
-          "name": "both",
-          "isCollapsed": false
-        },
-        {
-          "name": "yes",
-          "isCollapsed": false
-        },
-        {
-          "name": "no",
-          "isCollapsed": false
-        }
-      ],
-      "x": -2442,
-      "y": 16394,
-      "childTrueId": "C1A9C7CC-6DAC-4E03-B987-F44C2C040BF9",
-      "childFalseId": "A6B5E4EE-819B-4767-AE9A-2E127BD6DC6C"
-    },
-    {
-      "id": "8A8AB1EE-BE5B-46F6-981A-5ABB5FA348D9",
-      "type": "VariableBlock",
-      "disabled": false,
-      "name": "workingAppTagVersion",
-      "displayName": "Variable - workingAppTagVersion",
-      "comment": "Set the QMCA tag for version.",
-      "childId": "6D0F022E-164E-4CE3-B955-5961AA02A540",
-      "inputs": [],
-      "settings": [],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2802,
-      "y": 15854,
-      "variableGuid": "4CFD6FDB-6937-45CE-8677-203A280087D1",
-      "operations": [
-        {
-          "id": "set_value",
-          "key": "B91BCBEA-54E0-41DF-81C7-D893EA467F77",
-          "name": "Set value of { variable }",
-          "value": "QCMA - { $.loop2.item.version }"
-        }
-      ]
-    },
-    {
-      "id": "6035B77C-4061-44DD-B0B4-BA016EF2F537",
-      "type": "VariableBlock",
-      "disabled": false,
-      "name": "workingAppTagName",
-      "displayName": "Variable - workingAppTagName",
-      "comment": "Set the QMCA tag for name.",
-      "childId": "8A8AB1EE-BE5B-46F6-981A-5ABB5FA348D9",
-      "inputs": [],
-      "settings": [],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2802,
-      "y": 15734,
-      "variableGuid": "12A37AC8-CD9C-41FC-9626-508B24997C86",
-      "operations": [
-        {
-          "id": "set_value",
-          "key": "B91BCBEA-54E0-41DF-81C7-D893EA467F77",
-          "name": "Set value of { variable }",
-          "value": "QCMA - { $.loop2.item.name }"
-        }
-      ]
-    },
-    {
-      "id": "A6B5E4EE-819B-4767-AE9A-2E127BD6DC6C",
-      "type": "ShowBlock",
-      "disabled": false,
-      "name": "output28",
-      "displayName": "Output 28",
-      "comment": "Status output.",
-      "childId": null,
-      "inputs": [
-        {
-          "id": "input",
-          "value": "| {$.loop2.item.name} - Verify | Excluding existing app [{$.loop3.item.name}]({$.tenantHostname}sense/app/{$.loop3.item.resourceId}) in [{$.managedSpaceName}]({$.tenantHostname}analytics/catalog?space_filter={$.managedSpaceId}). **Cannot upgrade since it has multiple version tags. This may result in another copy of the app being deployed.** |",
-          "type": "string",
-          "structure": []
-        }
-      ],
-      "settings": [
-        {
-          "id": "display_mode",
-          "value": "add",
-          "type": "select",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2322,
-      "y": 17514
-    },
-    {
-      "id": "EE2B05F0-E29D-4EF4-8016-AD92050B6D2D",
-      "type": "ShowBlock",
-      "disabled": false,
-      "name": "output26",
-      "displayName": "Output 26",
-      "comment": "Status output.",
-      "childId": "5181CCB7-03EB-4C0C-83CC-FD647E7EF358",
-      "inputs": [
-        {
-          "id": "input",
-          "value": "| {$.loop2.item.name} - Verify | Found existing app [{$.loop3.item.name}]({$.tenantHostname}sense/app/{$.loop3.item.resourceId}) in [{$.managedSpaceName}]({$.tenantHostname}analytics/catalog?space_filter={$.managedSpaceId}). **Will be updated from {replace: { $.filterList8[0].name }, 'QCMA - '} to {$.loop2.item.version}.** |",
-          "type": "string",
-          "structure": []
-        }
-      ],
-      "settings": [
-        {
-          "id": "display_mode",
-          "value": "add",
-          "type": "select",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2202,
-      "y": 16554
-    },
-    {
-      "id": "C1A9C7CC-6DAC-4E03-B987-F44C2C040BF9",
-      "type": "IfElseBlock",
-      "disabled": false,
-      "name": "condition28",
-      "displayName": "Condition 28",
-      "comment": "Check if redeploy needed. This is done on a plain string comparison.",
-      "childId": "CA3E018B-042B-421C-9FFE-B53DFA5E392A",
-      "inputs": [
-        {
-          "id": "conditions",
-          "value": {
-            "mode": "all",
-            "conditions": [
-              {
-                "input1": "{ $.workingAppTagVersion }",
-                "input2": "{ $.filterList8[0].name }",
-                "operator": "!="
-              }
-            ]
-          },
-          "type": "custom",
-          "structure": []
-        }
-      ],
-      "settings": [],
-      "collapsed": [
-        {
-          "name": "both",
-          "isCollapsed": false
-        },
-        {
-          "name": "yes",
-          "isCollapsed": false
-        },
-        {
-          "name": "no",
-          "isCollapsed": false
-        }
-      ],
-      "x": -2322,
-      "y": 16474,
-      "childTrueId": "EE2B05F0-E29D-4EF4-8016-AD92050B6D2D",
-      "childFalseId": "6E0F226F-5497-4493-9201-8FB2CFE66C25"
-    },
-    {
-      "id": "981978BE-431B-4AF5-BD0D-451A3885B024",
-      "type": "VariableBlock",
-      "disabled": false,
-      "name": "workingAppExists",
-      "displayName": "Variable - workingAppExists",
-      "comment": "Reset the workingAppExists var, used for determining if there's already an up to date app.",
-      "childId": "6035B77C-4061-44DD-B0B4-BA016EF2F537",
-      "inputs": [],
-      "settings": [],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2802,
-      "y": 15614,
-      "variableGuid": "D8F8BD27-8FF5-42FF-82ED-0EE947E55327",
-      "operations": [
-        {
-          "id": "set_value",
-          "key": "8475B0B8-FEAB-437B-A7D1-3889CBBD80AC",
-          "name": "Set value of { variable }",
-          "value": "0"
-        }
-      ]
-    },
-    {
-      "id": "7BE1652F-2F1F-462E-9EAF-12AD879C8340",
-      "type": "VariableBlock",
-      "disabled": false,
-      "name": "workingAppExists",
-      "displayName": "Variable - workingAppExists",
-      "comment": "Set to 1 to skip new app import.",
-      "childId": null,
-      "inputs": [],
-      "settings": [],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2202,
-      "y": 17074,
-      "variableGuid": "D8F8BD27-8FF5-42FF-82ED-0EE947E55327",
-      "operations": [
-        {
-          "id": "set_value",
-          "key": "8475B0B8-FEAB-437B-A7D1-3889CBBD80AC",
-          "name": "Set value of { variable }",
-          "value": "1"
-        }
-      ]
-    },
-    {
-      "id": "6E0F226F-5497-4493-9201-8FB2CFE66C25",
-      "type": "ShowBlock",
-      "disabled": false,
-      "name": "output27",
-      "displayName": "Output 27",
-      "comment": "Status output.",
-      "childId": "7BE1652F-2F1F-462E-9EAF-12AD879C8340",
-      "inputs": [
-        {
-          "id": "input",
-          "value": "| {$.loop2.item.name} - Verify | Skipping existing app [{$.loop3.item.name}]({$.tenantHostname}sense/app/{$.loop3.item.resourceId}) in [{$.managedSpaceName}]({$.tenantHostname}analytics/catalog?space_filter={$.managedSpaceId}) as it is already at version {$.loop2.item.version}.  |",
-          "type": "string",
-          "structure": []
-        }
-      ],
-      "settings": [
-        {
-          "id": "display_mode",
-          "value": "add",
-          "type": "select",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2202,
-      "y": 16954
-    },
-    {
-      "id": "0C14812A-A344-4903-9697-1426DB5C5DFA",
-      "type": "VariableBlock",
-      "disabled": false,
-      "name": "workingAppExists",
-      "displayName": "Variable - workingAppExists",
-      "comment": "Set to 1 to skip new app import.",
-      "childId": null,
-      "inputs": [],
-      "settings": [],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2202,
-      "y": 16794,
-      "variableGuid": "D8F8BD27-8FF5-42FF-82ED-0EE947E55327",
-      "operations": [
-        {
-          "id": "set_value",
-          "key": "8475B0B8-FEAB-437B-A7D1-3889CBBD80AC",
-          "name": "Set value of { variable }",
-          "value": "1"
-        }
-      ]
-    },
-    {
-      "id": "7FF48E4E-FF7E-4BE2-B5E2-5178171BC9CF",
-      "type": "ShowBlock",
-      "disabled": false,
-      "name": "output31",
-      "displayName": "Output 31",
-      "comment": "Status output.",
-      "childId": "4F36612D-0B32-4DA5-9803-85D5EEB3EDCB",
-      "inputs": [
-        {
-          "id": "input",
-          "value": "| {$.loop2.item.name} - Prepare | > Pulling and importing version {$.loop2.item.version} of {$.loop2.item.name} from manifest to shared space. |",
-          "type": "string",
-          "structure": []
-        }
-      ],
-      "settings": [
-        {
-          "id": "display_mode",
-          "value": "add",
-          "type": "select",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2682,
-      "y": 18474
-    },
-    {
-      "id": "4F36612D-0B32-4DA5-9803-85D5EEB3EDCB",
-      "type": "CallUrlBlock",
-      "disabled": false,
-      "name": "callURL3",
-      "displayName": "Call URL 3",
-      "comment": "Get the qvf.",
-      "childId": "9E937365-2524-466B-95E9-309B3293FF8D",
-      "inputs": [
-        {
-          "id": "url",
-          "value": "{ $.loop2.item.source }",
-          "type": "string",
-          "structure": []
-        },
-        {
-          "id": "method",
-          "value": "GET",
-          "type": "select",
-          "structure": []
-        },
-        {
-          "id": "timeout",
-          "value": "",
-          "type": "string",
-          "structure": []
-        },
-        {
-          "id": "params",
-          "value": null,
-          "type": "object",
-          "mode": "keyValue",
-          "structure": []
-        },
-        {
-          "id": "headers",
-          "value": null,
-          "type": "object",
-          "mode": "keyValue",
-          "structure": []
-        },
-        {
-          "id": "encoding",
-          "value": "",
-          "type": "string",
-          "structure": []
-        }
-      ],
-      "settings": [
-        {
-          "id": "blendr_on_error",
-          "value": "stop",
-          "type": "select",
-          "structure": []
-        },
-        {
-          "id": "full_response",
-          "value": null,
-          "type": "checkbox",
-          "structure": []
-        },
-        {
-          "id": "capitalize_headers",
-          "value": true,
-          "type": "checkbox",
-          "structure": []
-        },
-        {
-          "id": "automations_censor_data",
-          "value": false,
-          "type": "checkbox",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2682,
-      "y": 18594
-    },
-    {
-      "id": "9E937365-2524-466B-95E9-309B3293FF8D",
-      "type": "VariableBlock",
-      "disabled": false,
-      "name": "workingAppBinary",
-      "displayName": "Variable - workingAppBinary",
-      "comment": "Variable to store base64 encoded value of the qvf.",
-      "childId": "8E819B1F-C085-4394-B9FA-537D1A20F440",
-      "inputs": [],
-      "settings": [],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2682,
-      "y": 18714,
-      "variableGuid": "996190EC-165A-4CF1-A3B6-363B8F0DDF31",
-      "operations": [
-        {
-          "id": "set_value",
-          "key": "DDDC649C-D1BB-490B-B4E1-926F95F3B0C2",
-          "name": "Set value of { variable }",
-          "value": "{ base64encode: { $.callURL3 } }"
-        }
-      ]
-    },
-    {
-      "id": "8E819B1F-C085-4394-B9FA-537D1A20F440",
-      "type": "EndpointBlock",
-      "disabled": false,
-      "name": "importAppFromBase64EncodedFile",
-      "displayName": "Qlik Cloud Services - Import App From Base 64 Encoded File",
-      "comment": "Import monitoring app to the shared space.",
-      "childId": "B6ED8700-7AB0-4251-9DFF-93B9ACBF7CD3",
-      "inputs": [
-        {
-          "id": "09b520a0-7aa4-11eb-8143-cde65e595ead",
-          "value": "{ $.workingAppBinary }",
-          "type": "string",
-          "structure": []
-        },
-        {
-          "id": "19661000-67b1-11eb-b4c6-fb30d89c586f",
-          "value": "{ $.loop2.item.name } - { $.loop2.item.version }",
-          "type": "string",
-          "structure": []
-        },
-        {
-          "id": "197675a0-67b1-11eb-b6f6-9ff3bc51ddbf",
-          "value": "{ $.sharedSpaceId }",
-          "type": "string",
-          "structure": []
-        },
-        {
-          "id": "4d3a3300-67b1-11eb-99af-3d55175faa9a",
-          "value": null,
-          "type": "select",
-          "structure": []
-        },
-        {
-          "id": "ac4b58f0-67b1-11eb-8126-89d0cf328adb",
-          "value": null,
-          "type": "string",
-          "structure": []
-        }
-      ],
-      "settings": [
-        {
-          "id": "blendr_on_error",
-          "value": "stop",
-          "type": "select",
-          "structure": []
-        },
-        {
-          "id": "automations_censor_data",
-          "value": false,
-          "type": "checkbox",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2682,
-      "y": 18834,
-      "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
-      "endpoint_guid": "194b9430-67b1-11eb-9e04-6dbde84bea83",
-      "endpoint_role": "create"
-    },
-    {
-      "id": "13CAF0D2-CA0F-41DE-BC1C-1E48738ED4C3",
-      "type": "ShowBlock",
-      "disabled": false,
-      "name": "output32",
-      "displayName": "Output 32",
-      "comment": "Status output.",
-      "childId": "142A4710-D6DC-4919-BE1C-54A699EED20A",
-      "inputs": [
-        {
-          "id": "input",
-          "value": "| {$.loop2.item.name} - Import | > Imported version {$.loop2.item.version} of [{ $.importAppFromBase64EncodedFile.attributes.name }]({$.tenantHostname}sense/app/{ $.importAppFromBase64EncodedFile.attributes.id }) to [{$.sharedSpaceName}]({$.tenantHostname}analytics/catalog?space_filter={$.sharedSpaceId}). |",
-          "type": "string",
-          "structure": []
-        }
-      ],
-      "settings": [
-        {
-          "id": "display_mode",
-          "value": "add",
-          "type": "select",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2682,
-      "y": 19194
-    },
-    {
-      "id": "40EC15FE-C25F-442B-8CD9-5C87150436B3",
-      "type": "IfElseBlock",
-      "disabled": false,
-      "name": "condition30",
-      "displayName": "Condition 30",
-      "comment": "If new app needed, show notification in the timeline.",
-      "childId": "7FF48E4E-FF7E-4BE2-B5E2-5178171BC9CF",
-      "inputs": [
-        {
-          "id": "conditions",
-          "value": {
-            "mode": "all",
-            "conditions": [
-              {
-                "input1": "{ $.workingAppExists }",
-                "input2": "0",
-                "operator": "="
-              }
-            ]
-          },
-          "type": "custom",
-          "structure": []
-        }
-      ],
-      "settings": [],
-      "collapsed": [
-        {
-          "name": "both",
-          "isCollapsed": false
-        },
-        {
-          "name": "yes",
-          "isCollapsed": false
-        },
-        {
-          "name": "no",
-          "isCollapsed": false
-        }
-      ],
-      "x": -2682,
-      "y": 18194,
-      "childTrueId": "BC596D9A-38F8-4F9A-8DC9-1D0DC81A57C4",
-      "childFalseId": null
-    },
-    {
-      "id": "BC596D9A-38F8-4F9A-8DC9-1D0DC81A57C4",
-      "type": "ShowBlock",
-      "disabled": false,
-      "name": "output30",
-      "displayName": "Output 30",
-      "comment": "Status output.",
-      "childId": null,
-      "inputs": [
-        {
-          "id": "input",
-          "value": "| {$.loop2.item.name} - Verify | The {$.loop2.item.name} was not found in [{$.managedSpaceName}]({$.tenantHostname}analytics/catalog?space_filter={$.managedSpaceId}). **Will be imported.** |",
-          "type": "string",
-          "structure": []
-        }
-      ],
-      "settings": [
-        {
-          "id": "display_mode",
-          "value": "add",
-          "type": "select",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2562,
-      "y": 18274
-    },
-    {
-      "id": "15A91B88-3C31-400B-A2C8-D697AB8F175E",
-      "type": "ShowBlock",
-      "disabled": false,
-      "name": "output38",
-      "displayName": "Output 38",
-      "comment": "Status output.",
-      "childId": "00332E92-9B25-4849-B799-0A68E5F4931B",
-      "inputs": [
-        {
-          "id": "input",
-          "value": "| {$.loop2.item.name} - Publish | > Deployed [{$.loop3.item.name}]({$.tenantHostname}sense/app/{$.publishAppToManagedSpace.attributes.id}) to [{$.managedSpaceName}]({$.tenantHostname}analytics/catalog?space_filter={$.managedSpaceId}). |",
-          "type": "string",
-          "structure": []
-        }
-      ],
-      "settings": [
-        {
-          "id": "display_mode",
-          "value": "add",
-          "type": "select",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2562,
-      "y": 21494
-    },
-    {
-      "id": "ECB7B639-F151-4B44-A89E-491B20BE66F3",
-      "type": "IfElseBlock",
-      "disabled": false,
-      "name": "condition32",
-      "displayName": "Condition 32",
-      "comment": "If new app needed, publish it.",
-      "childId": "4BE16981-95D8-4418-B598-B26CA6843820",
-      "inputs": [
-        {
-          "id": "conditions",
-          "value": {
-            "mode": "all",
-            "conditions": [
-              {
-                "input1": "{ $.workingAppExists }",
-                "input2": "0",
-                "operator": "="
-              }
-            ]
-          },
-          "type": "custom",
-          "structure": []
-        }
-      ],
-      "settings": [],
-      "collapsed": [
-        {
-          "name": "both",
-          "isCollapsed": false
-        },
-        {
-          "name": "yes",
-          "isCollapsed": false
-        },
-        {
-          "name": "no",
-          "isCollapsed": false
-        }
-      ],
-      "x": -2682,
-      "y": 21174,
-      "childTrueId": "35EFB375-D90C-4F76-A966-47EDB1EAFAD2",
-      "childFalseId": "9EE0A5EF-EE84-4F46-811E-312073C232C6"
-    },
-    {
-      "id": "35EFB375-D90C-4F76-A966-47EDB1EAFAD2",
-      "type": "SnippetBlock",
-      "disabled": false,
-      "name": "publishAppToManagedSpace",
-      "displayName": "Qlik Cloud Services - Publish App To Managed Space",
-      "comment": "Publish monitoring app to managed space.",
-      "childId": "F8D411D5-6606-4BC1-BA09-2A24611D4B6A",
-      "inputs": [
-        {
-          "id": "a0ab6dc0-00e2-11ec-92c0-fb834a93ff56",
-          "value": "{ $.importAppFromBase64EncodedFile.attributes.id }",
-          "type": "string",
-          "structure": []
-        },
-        {
-          "id": "a0ad09d0-00e2-11ec-b2c8-8587b72a110a",
-          "value": "{ $.managedSpaceId }",
-          "type": "string",
-          "structure": []
-        },
-        {
-          "id": "a0ad4d20-00e2-11ec-8cad-07ca8dd4b022",
-          "value": "source",
-          "type": "select",
-          "displayValue": "source",
-          "structure": []
-        },
-        {
-          "id": "03f6be80-22bf-11ec-bd94-cfe02119d15e",
-          "value": "Always publish",
-          "type": "select",
-          "displayValue": "Always publish",
-          "structure": []
-        },
-        {
-          "id": "e5b375a0-83ec-11ec-83cd-6d152b88c9ae",
-          "value": "{ $.loop2.item.name }",
-          "type": "string",
-          "structure": []
-        },
-        {
-          "id": "e5b45230-83ec-11ec-8c07-d9449d54e6ff",
-          "value": null,
-          "type": "string",
-          "structure": []
-        }
-      ],
-      "settings": [
-        {
-          "id": "blendr_on_error",
-          "value": "stop",
-          "type": "select",
-          "structure": []
-        },
-        {
-          "id": "automations_censor_data",
-          "value": false,
-          "type": "checkbox",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2562,
-      "y": 21254,
-      "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
-      "snippet_guid": "76a45090-00e1-11ec-ad85-b3b86b5b9a24"
-    },
-    {
-      "id": "FF63005B-73C8-4593-8609-AC99855C7167",
-      "type": "EndpointBlock",
-      "disabled": false,
-      "name": "rawAPIRequest10",
-      "displayName": "Qlik Cloud Services - Raw API Request 10",
-      "comment": "Get item ID of app",
-      "childId": "13CAF0D2-CA0F-41DE-BC1C-1E48738ED4C3",
-      "inputs": [
-        {
-          "id": "734cbcc0-bbb0-11f0-b998-f73920377683",
-          "value": "v1/items",
-          "type": "string",
-          "structure": []
-        },
-        {
-          "id": "7322a550-bbb0-11f0-9c8c-43f143a32456",
-          "value": "7341e840-bbb0-11f0-9bb8-11c201f87b6d",
-          "type": "select",
-          "displayValue": "GET",
-          "structure": []
-        },
-        {
-          "id": "73000fe0-bbb0-11f0-8a80-59ece3571bd9",
-          "value": null,
-          "type": "object",
-          "mode": "keyValue",
-          "structure": []
-        },
-        {
-          "id": "736fae60-bbb0-11f0-ad62-c98a0046f418",
-          "value": [
-            {
-              "key": "resourceId",
-              "value": "{$.importAppFromBase64EncodedFile.attributes.id}"
-            },
-            {
-              "key": "resourceType",
-              "value": "app"
-            }
           ],
-          "type": "object",
-          "mode": "keyValue",
-          "structure": []
-        }
-      ],
-      "settings": [
-        {
-          "id": "blendr_on_error",
-          "value": "stop",
-          "type": "select",
-          "structure": []
-        },
-        {
-          "id": "automations_censor_data",
-          "value": false,
-          "type": "checkbox",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2682,
-      "y": 19074,
-      "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
-      "endpoint_guid": "72d48530-bbb0-11f0-875a-b322bf237aeb",
-      "endpoint_role": "create"
-    },
-    {
-      "id": "B6ED8700-7AB0-4251-9DFF-93B9ACBF7CD3",
-      "type": "SleepBlock",
-      "disabled": false,
-      "name": "sleep",
-      "displayName": "Sleep",
-      "comment": "Wait for items to be aware of app.",
-      "childId": "FF63005B-73C8-4593-8609-AC99855C7167",
-      "inputs": [
-        {
-          "id": "time",
-          "value": "5",
-          "type": "string",
-          "structure": []
-        }
-      ],
-      "settings": [],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2682,
-      "y": 18954
-    },
-    {
-      "id": "9F37EC62-2694-40D2-8DB1-7F5265D9EB9F",
-      "type": "VariableBlock",
-      "disabled": false,
-      "name": "workingAppTags",
-      "displayName": "Variable - workingAppTags",
-      "comment": "Create object for assigning tags.",
-      "childId": "22D8A6B4-A055-40DE-BA67-0638D6005250",
-      "inputs": [],
-      "settings": [],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2682,
-      "y": 19794,
-      "variableGuid": "AE6C347F-BAAD-4FD0-A820-80AFEE588B29",
-      "operations": [
-        {
-          "id": "empty",
-          "key": "D2338734-D49E-498C-A550-01B971BAC5C1",
-          "name": "Empty { variable }",
-          "value": null
-        },
-        {
-          "id": "set_key_value",
-          "key": "4FFB7E92-7F6F-4A27-ADA6-FBC6DF13C3B3",
-          "name": "Set key/values of { variable }",
-          "value": [
-            {
-              "key": "appTag",
-              "value": "{ $.workingAppTagName }"
-            },
-            {
-              "key": "versionTag",
-              "value": "{ $.workingAppTagVersion }"
-            }
+          "x": -2922,
+          "y": -3826
+      },
+      {
+          "id": "E71CFD36-7B6D-4CFC-8F5F-AF73409624B4",
+          "type": "ShowBlock",
+          "disabled": false,
+          "name": "output",
+          "displayName": "Output",
+          "comment": "README: Check the variables below, perform a manual run to successfully deploy all apps the first time, and then schedule this automation to run weekly or monthly.",
+          "childId": "A9BBBC6E-49FE-4819-BE22-504FC54335F2",
+          "inputs": [
+              {
+                  "id": "input",
+                  "value": "## Qlik Cloud Monitoring App deployer\n\nThe Qlik Cloud monitoring app deployer automates the installation and update of the monitoring apps from the [Qlik Cloud monitoring apps repository](https://github.com/qlik-oss/qlik-cloud-monitoring-apps). Check the variables below, then run manually, or schedule for when you'd like your apps updated.\n\n**Some apps require specific license entitlements and will not be installed if these criteria are not met.**",
+                  "type": "string",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "display_mode",
+                  "value": "add",
+                  "type": "select",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": false
+              }
+          ],
+          "x": -2922,
+          "y": -3706
+      },
+      {
+          "id": "6AC0239B-01A8-47F9-AD4C-ED09CCB2B83F",
+          "type": "VariableBlock",
+          "disabled": false,
+          "name": "sharedSpaceName",
+          "displayName": "Variable - sharedSpaceName",
+          "comment": "Enter a space name to use as the staging space. A space will be created if it does not exist.",
+          "childId": "816EE781-6447-4CB2-AE71-07512C23A11E",
+          "inputs": [],
+          "settings": [],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2802,
+          "y": -3026,
+          "variableGuid": "E3084D5D-4DE7-428E-BDE0-440DCD055EDD",
+          "operations": [
+              {
+                  "id": "set_value",
+                  "key": "14252438-DA6C-489E-BA9F-97F75C4BF373",
+                  "name": "Set value of { variable }",
+                  "value": "Monitoring - staging"
+              }
           ]
-        }
-      ]
-    },
-    {
-      "id": "22D8A6B4-A055-40DE-BA67-0638D6005250",
-      "type": "ForEachBlock",
-      "disabled": false,
-      "name": "loop4",
-      "displayName": "Loop 4",
-      "comment": "Loop over tags.",
-      "childId": "ECB7B639-F151-4B44-A89E-491B20BE66F3",
-      "inputs": [
-        {
-          "id": "input",
-          "value": "{ $.workingAppTags }",
-          "type": "string",
-          "structure": []
-        }
-      ],
-      "settings": [
-        {
-          "id": "automations_censor_data",
-          "value": false,
-          "type": "checkbox",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": false
-        }
-      ],
-      "x": -2682,
-      "y": 19914,
-      "loopBlockId": "AFD7305E-B419-4128-95D3-1A9EAF98F9C8"
-    },
-    {
-      "id": "AFD7305E-B419-4128-95D3-1A9EAF98F9C8",
-      "type": "EndpointBlock",
-      "disabled": false,
-      "name": "rawAPIRequest11",
-      "displayName": "Qlik Cloud Services - Raw API Request 11",
-      "comment": "Filter the collection by name.",
-      "childId": "487F3340-7989-4675-9B60-AE93E556E5CD",
-      "inputs": [
-        {
-          "id": "734cbcc0-bbb0-11f0-b998-f73920377683",
-          "value": "v1/collections",
-          "type": "string",
-          "structure": []
-        },
-        {
-          "id": "7322a550-bbb0-11f0-9c8c-43f143a32456",
-          "value": "7341e840-bbb0-11f0-9bb8-11c201f87b6d",
-          "type": "select",
-          "displayValue": "GET",
-          "structure": []
-        },
-        {
-          "id": "73000fe0-bbb0-11f0-8a80-59ece3571bd9",
-          "value": null,
-          "type": "object",
-          "mode": "keyValue",
-          "structure": []
-        },
-        {
-          "id": "736fae60-bbb0-11f0-ad62-c98a0046f418",
-          "value": [
-            {
-              "key": "name",
-              "value": "{ $.loop4.item }"
-            },
-            {
-              "key": "type",
-              "value": "public"
-            }
-          ],
-          "type": "object",
-          "mode": "keyValue",
-          "structure": []
-        }
-      ],
-      "settings": [
-        {
-          "id": "blendr_on_error",
-          "value": "stop",
-          "type": "select",
-          "structure": []
-        },
-        {
-          "id": "automations_censor_data",
-          "value": false,
-          "type": "checkbox",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2562,
-      "y": 20014,
-      "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
-      "endpoint_guid": "72d48530-bbb0-11f0-875a-b322bf237aeb",
-      "endpoint_role": "create"
-    },
-    {
-      "id": "487F3340-7989-4675-9B60-AE93E556E5CD",
-      "type": "IfElseBlock",
-      "disabled": false,
-      "name": "condition31",
-      "displayName": "Condition 31",
-      "comment": "Check if tag exists",
-      "childId": "B8418877-08D1-44AE-BCD4-B5FBA442AFDC",
-      "inputs": [
-        {
-          "id": "conditions",
-          "value": {
-            "mode": "all",
-            "conditions": [
+      },
+      {
+          "id": "816EE781-6447-4CB2-AE71-07512C23A11E",
+          "type": "VariableBlock",
+          "disabled": false,
+          "name": "managedSpaceName",
+          "displayName": "Variable - managedSpaceName",
+          "comment": "Enter a space name to use as the managed space. A space will be created if it does not exist.",
+          "childId": "749BB890-520A-4E81-8C75-5738241F7586",
+          "inputs": [],
+          "settings": [],
+          "collapsed": [
               {
-                "input1": "{count: {$.rawAPIRequest11.data}}",
-                "input2": "0",
-                "operator": ">"
+                  "name": "loop",
+                  "isCollapsed": true
               }
-            ]
-          },
-          "type": "custom",
-          "structure": []
-        }
-      ],
-      "settings": [],
-      "collapsed": [
-        {
-          "name": "both",
-          "isCollapsed": false
-        },
-        {
-          "name": "yes",
-          "isCollapsed": false
-        },
-        {
-          "name": "no",
-          "isCollapsed": false
-        }
-      ],
-      "x": -2562,
-      "y": 20134,
-      "childTrueId": "814E1A6D-6BCB-47DD-BD1D-39EC0CA9C101",
-      "childFalseId": "4DA2DA61-2BB9-41DB-B354-3A2B8C5F2F2E"
-    },
-    {
-      "id": "B8418877-08D1-44AE-BCD4-B5FBA442AFDC",
-      "type": "EndpointBlock",
-      "disabled": false,
-      "name": "rawAPIRequest13",
-      "displayName": "Qlik Cloud Services - Raw API Request 13",
-      "comment": "Add the tag to the item.",
-      "childId": "E3272B0B-EA20-485E-BAF3-E24EDF5D1931",
-      "inputs": [
-        {
-          "id": "734cbcc0-bbb0-11f0-b998-f73920377683",
-          "value": "v1/collections/{$.taggerIds.{ $.loop4.index }}/items",
-          "type": "string",
-          "structure": []
-        },
-        {
-          "id": "7322a550-bbb0-11f0-9c8c-43f143a32456",
-          "value": "7347ee10-bbb0-11f0-8cdc-59311dd108b3",
-          "type": "select",
-          "displayValue": "POST",
-          "structure": []
-        },
-        {
-          "id": "73000fe0-bbb0-11f0-8a80-59ece3571bd9",
-          "value": "{\n  \"id\": \"{ $.rawAPIRequest10.data[0].id }\"\n}",
-          "type": "object",
-          "mode": "raw",
-          "structure": []
-        },
-        {
-          "id": "736fae60-bbb0-11f0-ad62-c98a0046f418",
-          "value": null,
-          "type": "object",
-          "mode": "keyValue",
-          "structure": []
-        }
-      ],
-      "settings": [
-        {
-          "id": "blendr_on_error",
-          "value": "stop",
-          "type": "select",
-          "structure": []
-        },
-        {
-          "id": "automations_censor_data",
-          "value": false,
-          "type": "checkbox",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2562,
-      "y": 20894,
-      "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
-      "endpoint_guid": "72d48530-bbb0-11f0-875a-b322bf237aeb",
-      "endpoint_role": "create"
-    },
-    {
-      "id": "E3272B0B-EA20-485E-BAF3-E24EDF5D1931",
-      "type": "ShowBlock",
-      "disabled": false,
-      "name": "output37",
-      "displayName": "Output 37",
-      "comment": "Tag added.",
-      "childId": null,
-      "inputs": [
-        {
-          "id": "input",
-          "value": "| {$.loop2.item.name} - Tags (shared) | > Tag `{$.loop4.item}` added to shared space app. |",
-          "type": "string",
-          "structure": []
-        }
-      ],
-      "settings": [
-        {
-          "id": "display_mode",
-          "value": "add",
-          "type": "select",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2562,
-      "y": 21014
-    },
-    {
-      "id": "814E1A6D-6BCB-47DD-BD1D-39EC0CA9C101",
-      "type": "ShowBlock",
-      "disabled": false,
-      "name": "output35",
-      "displayName": "Output 35",
-      "comment": "Tag exists.",
-      "childId": "E287D197-83E3-4C50-8598-34DDB03BD857",
-      "inputs": [
-        {
-          "id": "input",
-          "value": "| {$.loop2.item.name} - Tags | > Tag `{$.loop4.item}` exists. |",
-          "type": "string",
-          "structure": []
-        }
-      ],
-      "settings": [
-        {
-          "id": "display_mode",
-          "value": "add",
-          "type": "select",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2442,
-      "y": 20214
-    },
-    {
-      "id": "E287D197-83E3-4C50-8598-34DDB03BD857",
-      "type": "VariableBlock",
-      "disabled": false,
-      "name": "taggerIds",
-      "displayName": "Variable - taggerIds",
-      "comment": "Store the tag ID.",
-      "childId": null,
-      "inputs": [],
-      "settings": [],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2442,
-      "y": 20334,
-      "variableGuid": "FA7C823B-3AA8-41EA-990F-21837758447A",
-      "operations": [
-        {
-          "id": "set_key_value",
-          "key": "4C765E64-0A7C-4AFC-8301-E428E0E60E9B",
-          "name": "Set key/values of { variable }",
-          "value": [
-            {
-              "key": "{ $.loop4.index }",
-              "value": "{$.rawAPIRequest11.data[0].id}"
-            }
+          ],
+          "x": -2802,
+          "y": -2906,
+          "variableGuid": "247B71DE-30E7-4526-AC3D-BE5E17AA9194",
+          "operations": [
+              {
+                  "id": "set_value",
+                  "key": "14252438-DA6C-489E-BA9F-97F75C4BF373",
+                  "name": "Set value of { variable }",
+                  "value": "Monitoring"
+              }
           ]
-        }
-      ]
-    },
-    {
-      "id": "984029CA-4EC0-4912-880A-0FA2010E9747",
-      "type": "ShowBlock",
-      "disabled": false,
-      "name": "output36",
-      "displayName": "Output 36",
-      "comment": "Create tag.",
-      "childId": "240DE4BD-65CF-4B9F-BAEA-D6469B83CB50",
-      "inputs": [
-        {
-          "id": "input",
-          "value": "| {$.loop2.item.name} - Tags | > Tag does not exist. Created tag `{$.loop4.item}`. |",
-          "type": "string",
-          "structure": []
-        }
-      ],
-      "settings": [
-        {
-          "id": "display_mode",
-          "value": "add",
-          "type": "select",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2442,
-      "y": 20614
-    },
-    {
-      "id": "4DA2DA61-2BB9-41DB-B354-3A2B8C5F2F2E",
-      "type": "EndpointBlock",
-      "disabled": false,
-      "name": "rawAPIRequest12",
-      "displayName": "Qlik Cloud Services - Raw API Request 12",
-      "comment": "Create new collection",
-      "childId": "984029CA-4EC0-4912-880A-0FA2010E9747",
-      "inputs": [
-        {
-          "id": "734cbcc0-bbb0-11f0-b998-f73920377683",
-          "value": "v1/collections",
-          "type": "string",
-          "structure": []
-        },
-        {
-          "id": "7322a550-bbb0-11f0-9c8c-43f143a32456",
-          "value": "7347ee10-bbb0-11f0-8cdc-59311dd108b3",
-          "type": "select",
-          "displayValue": "POST",
-          "structure": []
-        },
-        {
-          "id": "73000fe0-bbb0-11f0-8a80-59ece3571bd9",
-          "value": "{\"type\":\"public\",\"name\":\"{ $.loop4.item }\"}",
-          "type": "object",
-          "mode": "raw",
-          "structure": []
-        },
-        {
-          "id": "736fae60-bbb0-11f0-ad62-c98a0046f418",
-          "value": null,
-          "type": "object",
-          "mode": "keyValue",
-          "structure": []
-        }
-      ],
-      "settings": [
-        {
-          "id": "blendr_on_error",
-          "value": "stop",
-          "type": "select",
-          "structure": []
-        },
-        {
-          "id": "automations_censor_data",
-          "value": false,
-          "type": "checkbox",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2442,
-      "y": 20494,
-      "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
-      "endpoint_guid": "72d48530-bbb0-11f0-875a-b322bf237aeb",
-      "endpoint_role": "create"
-    },
-    {
-      "id": "240DE4BD-65CF-4B9F-BAEA-D6469B83CB50",
-      "type": "VariableBlock",
-      "disabled": false,
-      "name": "taggerIds",
-      "displayName": "Variable - taggerIds",
-      "comment": "Store the tag ID.",
-      "childId": null,
-      "inputs": [],
-      "settings": [],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2442,
-      "y": 20734,
-      "variableGuid": "FA7C823B-3AA8-41EA-990F-21837758447A",
-      "operations": [
-        {
-          "id": "set_key_value",
-          "key": "4C765E64-0A7C-4AFC-8301-E428E0E60E9B",
-          "name": "Set key/values of { variable }",
-          "value": [
-            {
-              "key": "{ $.loop4.index }",
-              "value": "{ $.rawAPIRequest12.id }"
-            }
+      },
+      {
+          "id": "749BB890-520A-4E81-8C75-5738241F7586",
+          "type": "VariableBlock",
+          "disabled": false,
+          "name": "versionsToKeep",
+          "displayName": "Variable - versionsToKeep",
+          "comment": "If you wish to keep previously deployed apps in the staging space, enter a number of apps to keep. Set to 0 to always delete all apps from the shared space. Default = 0",
+          "childId": null,
+          "inputs": [],
+          "settings": [],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2802,
+          "y": -2786,
+          "variableGuid": "9679AB7C-F7EB-4A7F-A217-B2F9F14CE7E5",
+          "operations": [
+              {
+                  "id": "set_value",
+                  "key": "1CC6616E-100F-4B1E-AB18-98A204CBE862",
+                  "name": "Set value of { variable }",
+                  "value": "1"
+              }
           ]
-        }
-      ]
-    },
-    {
-      "id": "142A4710-D6DC-4919-BE1C-54A699EED20A",
-      "type": "ShowBlock",
-      "disabled": false,
-      "name": "output33",
-      "displayName": "Output 33",
-      "comment": "Altering load script.",
-      "childId": "73B15F09-DCC3-43F4-8DCB-9ACE58E3FACF",
-      "inputs": [
-        {
-          "id": "input",
-          "value": "| {$.loop2.item.name} - Load script | > Modifying the load script of the source app so that it can be reloaded using the 'monitoring_apps_REST' data connection within the managed space. |",
-          "type": "string",
-          "structure": []
-        }
-      ],
-      "settings": [
-        {
-          "id": "display_mode",
-          "value": "add",
-          "type": "select",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2682,
-      "y": 19314
-    },
-    {
-      "id": "73B15F09-DCC3-43F4-8DCB-9ACE58E3FACF",
-      "type": "SnippetBlock",
-      "disabled": false,
-      "name": "GetLoadScript",
-      "displayName": "Qlik Cloud Services - Get Load Script",
-      "comment": "Get the load script.",
-      "childId": "2A346057-D71F-4D36-87AA-DA1A1EEC1DA0",
-      "inputs": [
-        {
-          "id": "299dd6e0-7535-11eb-a1b1-8108a69d86b2",
-          "value": "{$.importAppFromBase64EncodedFile.attributes.id}",
-          "type": "string",
-          "structure": []
-        }
-      ],
-      "settings": [
-        {
-          "id": "blendr_on_error",
-          "value": "stop",
-          "type": "select",
-          "structure": []
-        },
-        {
-          "id": "automations_censor_data",
-          "value": false,
-          "type": "checkbox",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2682,
-      "y": 19434,
-      "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
-      "snippet_guid": "8d2f7da0-5028-11eb-8889-317a6c8ea7fc"
-    },
-    {
-      "id": "2A346057-D71F-4D36-87AA-DA1A1EEC1DA0",
-      "type": "EndpointBlock",
-      "disabled": false,
-      "name": "setLoadScript",
-      "displayName": "Qlik Cloud Services - Set Load Script",
-      "comment": "Modify vu_rest_connection to point to the managed space.",
-      "childId": "36997A20-8F70-47D6-88BD-91AC1E0DB2E1",
-      "inputs": [
-        {
-          "id": "917b8660-a12b-11ed-873f-fd156b9f0ebb",
-          "value": "{$.importAppFromBase64EncodedFile.attributes.id}",
-          "type": "string",
-          "structure": []
-        },
-        {
-          "id": "d31e0400-a12c-11ed-b43b-29c58fb1f869",
-          "value": "{replace: {$.GetLoadScript.qScript}, \"':{ $.dataConnectionName }'\", {if: {textlength: {regexparse: '{$.managedSpaceName}', \"(')\"}} > 0, `{ $.managedSpaceName }:{ $.dataConnectionName }`, \"'{ $.managedSpaceName }:monitoring_apps_REST'\"}}",
-          "type": "string",
-          "structure": []
-        },
-        {
-          "id": "0da08560-a12d-11ed-92bf-6146d9e01e80",
-          "value": "Updated REST connector reference to point to managed space.",
-          "type": "string",
-          "structure": []
-        }
-      ],
-      "settings": [
-        {
-          "id": "blendr_on_error",
-          "value": "stop",
-          "type": "select",
-          "structure": []
-        },
-        {
-          "id": "automations_censor_data",
-          "value": false,
-          "type": "checkbox",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2682,
-      "y": 19554,
-      "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
-      "endpoint_guid": "916661a0-a12b-11ed-882f-fb01a4e99b0a",
-      "endpoint_role": "create"
-    },
-    {
-      "id": "36997A20-8F70-47D6-88BD-91AC1E0DB2E1",
-      "type": "ShowBlock",
-      "disabled": false,
-      "name": "output34",
-      "displayName": "Output 34",
-      "comment": "Load script updated.",
-      "childId": "9F37EC62-2694-40D2-8DB1-7F5265D9EB9F",
-      "inputs": [
-        {
-          "id": "input",
-          "value": "| {$.loop2.item.name} - Load script | > Load script updated. |",
-          "type": "string",
-          "structure": []
-        }
-      ],
-      "settings": [
-        {
-          "id": "display_mode",
-          "value": "add",
-          "type": "select",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2682,
-      "y": 19674
-    },
-    {
-      "id": "9EE0A5EF-EE84-4F46-811E-312073C232C6",
-      "type": "ForEachBlock",
-      "disabled": false,
-      "name": "loop6",
-      "displayName": "Loop 6",
-      "comment": "Loop over existing apps to update them.",
-      "childId": null,
-      "inputs": [
-        {
-          "id": "input",
-          "value": "{ $.workingAppList }",
-          "type": "string",
-          "structure": []
-        }
-      ],
-      "settings": [
-        {
-          "id": "automations_censor_data",
-          "value": false,
-          "type": "checkbox",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": false
-        }
-      ],
-      "x": -2562,
-      "y": 22274,
-      "loopBlockId": "0D70200F-BF52-4CCD-8FB5-C81C9692D24B"
-    },
-    {
-      "id": "75038005-FF42-4CA7-B4C9-0CA9EE70631D",
-      "type": "EndpointBlock",
-      "disabled": false,
-      "name": "rawAPIRequest15",
-      "displayName": "Qlik Cloud Services - Raw API Request 15",
-      "comment": "Add the tag to the item.",
-      "childId": "9A5AE6AA-1CF8-4CD9-BD5B-1522FBC107EF",
-      "inputs": [
-        {
-          "id": "734cbcc0-bbb0-11f0-b998-f73920377683",
-          "value": "v1/collections/{$.loop5.item}/items",
-          "type": "string",
-          "structure": []
-        },
-        {
-          "id": "7322a550-bbb0-11f0-9c8c-43f143a32456",
-          "value": "7347ee10-bbb0-11f0-8cdc-59311dd108b3",
-          "type": "select",
-          "displayValue": "POST",
-          "structure": []
-        },
-        {
-          "id": "73000fe0-bbb0-11f0-8a80-59ece3571bd9",
-          "value": "{\n  \"id\": \"{ $.rawAPIRequest14.data[0].id }\"\n}",
-          "type": "object",
-          "mode": "raw",
-          "structure": []
-        },
-        {
-          "id": "736fae60-bbb0-11f0-ad62-c98a0046f418",
-          "value": null,
-          "type": "object",
-          "mode": "keyValue",
-          "structure": []
-        }
-      ],
-      "settings": [
-        {
-          "id": "blendr_on_error",
-          "value": "stop",
-          "type": "select",
-          "structure": []
-        },
-        {
-          "id": "automations_censor_data",
-          "value": false,
-          "type": "checkbox",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2442,
-      "y": 21954,
-      "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
-      "endpoint_guid": "72d48530-bbb0-11f0-875a-b322bf237aeb",
-      "endpoint_role": "create"
-    },
-    {
-      "id": "9A5AE6AA-1CF8-4CD9-BD5B-1522FBC107EF",
-      "type": "ShowBlock",
-      "disabled": false,
-      "name": "output39",
-      "displayName": "Output 39",
-      "comment": "Tag added.",
-      "childId": null,
-      "inputs": [
-        {
-          "id": "input",
-          "value": "| {$.loop2.item.name} - Tags (managed) | > Tag `{$.loop5.index}` added to new managed space app. |",
-          "type": "string",
-          "structure": []
-        }
-      ],
-      "settings": [
-        {
-          "id": "display_mode",
-          "value": "add",
-          "type": "select",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2442,
-      "y": 22074
-    },
-    {
-      "id": "292F6681-A0A3-4149-8900-B146F799C502",
-      "type": "ForEachBlock",
-      "disabled": false,
-      "name": "loop5",
-      "displayName": "Loop 5",
-      "comment": "Loop over the tags.",
-      "childId": null,
-      "inputs": [
-        {
-          "id": "input",
-          "value": "{ $.taggerIds }",
-          "type": "string",
-          "structure": []
-        }
-      ],
-      "settings": [
-        {
-          "id": "automations_censor_data",
-          "value": false,
-          "type": "checkbox",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": false
-        }
-      ],
-      "x": -2562,
-      "y": 21854,
-      "loopBlockId": "75038005-FF42-4CA7-B4C9-0CA9EE70631D"
-    },
-    {
-      "id": "00332E92-9B25-4849-B799-0A68E5F4931B",
-      "type": "SleepBlock",
-      "disabled": false,
-      "name": "sleep2",
-      "displayName": "Sleep 2",
-      "comment": "Wait for items to get publish notification.",
-      "childId": "D39D8A7B-718C-46EC-B3F1-24E2A2BF5185",
-      "inputs": [
-        {
-          "id": "time",
-          "value": "5",
-          "type": "string",
-          "structure": []
-        }
-      ],
-      "settings": [],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2562,
-      "y": 21614
-    },
-    {
-      "id": "D39D8A7B-718C-46EC-B3F1-24E2A2BF5185",
-      "type": "EndpointBlock",
-      "disabled": false,
-      "name": "rawAPIRequest14",
-      "displayName": "Qlik Cloud Services - Raw API Request 14",
-      "comment": "Get item ID of app",
-      "childId": "292F6681-A0A3-4149-8900-B146F799C502",
-      "inputs": [
-        {
-          "id": "734cbcc0-bbb0-11f0-b998-f73920377683",
-          "value": "v1/items",
-          "type": "string",
-          "structure": []
-        },
-        {
-          "id": "7322a550-bbb0-11f0-9c8c-43f143a32456",
-          "value": "7341e840-bbb0-11f0-9bb8-11c201f87b6d",
-          "type": "select",
-          "displayValue": "GET",
-          "structure": []
-        },
-        {
-          "id": "73000fe0-bbb0-11f0-8a80-59ece3571bd9",
-          "value": null,
-          "type": "object",
-          "mode": "keyValue",
-          "structure": []
-        },
-        {
-          "id": "736fae60-bbb0-11f0-ad62-c98a0046f418",
-          "value": [
-            {
-              "key": "resourceId",
-              "value": "{ $.publishAppToManagedSpace.attributes.id }"
-            },
-            {
-              "key": "resourceType",
-              "value": "app"
-            }
-          ],
-          "type": "object",
-          "mode": "keyValue",
-          "structure": []
-        }
-      ],
-      "settings": [
-        {
-          "id": "blendr_on_error",
-          "value": "stop",
-          "type": "select",
-          "structure": []
-        },
-        {
-          "id": "automations_censor_data",
-          "value": false,
-          "type": "checkbox",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2562,
-      "y": 21734,
-      "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
-      "endpoint_guid": "72d48530-bbb0-11f0-875a-b322bf237aeb",
-      "endpoint_role": "create"
-    },
-    {
-      "id": "F8D411D5-6606-4BC1-BA09-2A24611D4B6A",
-      "type": "VariableBlock",
-      "disabled": false,
-      "name": "liveApps",
-      "displayName": "Variable - liveApps",
-      "comment": "Add newly published app to live apps.",
-      "childId": "15A91B88-3C31-400B-A2C8-D697AB8F175E",
-      "inputs": [],
-      "settings": [],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2562,
-      "y": 21374,
-      "variableGuid": "A812E467-95BC-419E-B6A6-4341D6347C3A",
-      "operations": [
-        {
-          "id": "add_item",
-          "key": "D4AA6196-E54F-4E05-9292-ABBD3AAADBC6",
-          "name": "Add item to { variable }",
-          "value": "{ $.publishAppToManagedSpace }"
-        }
-      ]
-    },
-    {
-      "id": "F3CCCABB-3F06-47D2-B3A0-E018A8EAD140",
-      "type": "VariableBlock",
-      "disabled": false,
-      "name": "liveApps",
-      "displayName": "Variable - liveApps",
-      "comment": "Add app to live apps.",
-      "childId": null,
-      "inputs": [],
-      "settings": [],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2322,
-      "y": 17354,
-      "variableGuid": "A812E467-95BC-419E-B6A6-4341D6347C3A",
-      "operations": [
-        {
-          "id": "add_item",
-          "key": "D4AA6196-E54F-4E05-9292-ABBD3AAADBC6",
-          "name": "Add item to { variable }",
-          "value": "{ $.getApp }"
-        }
-      ]
-    },
-    {
-      "id": "CFCAD086-C1F2-4CCA-878B-5B6ABB27850F",
-      "type": "EndpointBlock",
-      "disabled": false,
-      "name": "rawAPIRequest16",
-      "displayName": "Qlik Cloud Services - Raw API Request 16",
-      "comment": "Republish app by ID in case there are multiple apps with same name in space.",
-      "childId": "CC7C8FB8-9B7E-448D-9D58-393F53575C99",
-      "inputs": [
-        {
-          "id": "734cbcc0-bbb0-11f0-b998-f73920377683",
-          "value": "v1/apps/{ $.importAppFromBase64EncodedFile.attributes.id }/publish",
-          "type": "string",
-          "structure": []
-        },
-        {
-          "id": "7322a550-bbb0-11f0-9c8c-43f143a32456",
-          "value": "734354a0-bbb0-11f0-93a2-75cc9ad6b2d6",
-          "type": "select",
-          "displayValue": "PUT",
-          "structure": []
-        },
-        {
-          "id": "73000fe0-bbb0-11f0-8a80-59ece3571bd9",
-          "value": "{\n  \"data\": \"target\",\n  \"targetId\": \"{$.loop6.item.resourceId}\",\n  \"checkOriginAppId\": false,\n  \"attributes\": {\"name\": \"{$.loop6.item.name}\"}\n}",
-          "type": "object",
-          "mode": "raw",
-          "structure": []
-        },
-        {
-          "id": "736fae60-bbb0-11f0-ad62-c98a0046f418",
-          "value": null,
-          "type": "object",
-          "mode": "keyValue",
-          "structure": []
-        }
-      ],
-      "settings": [
-        {
-          "id": "blendr_on_error",
-          "value": "stop",
-          "type": "select",
-          "structure": []
-        },
-        {
-          "id": "automations_censor_data",
-          "value": false,
-          "type": "checkbox",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2442,
-      "y": 22494,
-      "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
-      "endpoint_guid": "72d48530-bbb0-11f0-875a-b322bf237aeb",
-      "endpoint_role": "create"
-    },
-    {
-      "id": "CC7C8FB8-9B7E-448D-9D58-393F53575C99",
-      "type": "ShowBlock",
-      "disabled": false,
-      "name": "output41",
-      "displayName": "Output 41",
-      "comment": "Status output.",
-      "childId": "3ABDBFAA-8E94-4AA9-87C6-AC03B13D58F0",
-      "inputs": [
-        {
-          "id": "input",
-          "value": "| {$.loop2.item.name} - Republish | > Republished [{ $.loop6.item.name }]({$.tenantHostname}sense/app/{ $.loop6.item.resourceId }) to [{$.managedSpaceName}]({$.tenantHostname}analytics/catalog?space_filter={$.managedSpaceId}). |",
-          "type": "string",
-          "structure": []
-        }
-      ],
-      "settings": [
-        {
-          "id": "display_mode",
-          "value": "add",
-          "type": "select",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2442,
-      "y": 22614
-    },
-    {
-      "id": "0D70200F-BF52-4CCD-8FB5-C81C9692D24B",
-      "type": "ShowBlock",
-      "disabled": false,
-      "name": "output40",
-      "displayName": "Output 40",
-      "comment": "Status output.",
-      "childId": "CFCAD086-C1F2-4CCA-878B-5B6ABB27850F",
-      "inputs": [
-        {
-          "id": "input",
-          "value": "| {$.loop2.item.name} - Republish | > Attempting to republish { $.loop6.item.name } in [{$.managedSpaceName}]({$.tenantHostname}analytics/catalog?space_filter={$.managedSpaceId}). |",
-          "type": "string",
-          "structure": []
-        }
-      ],
-      "settings": [
-        {
-          "id": "display_mode",
-          "value": "add",
-          "type": "select",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2442,
-      "y": 22374
-    },
-    {
-      "id": "3ABDBFAA-8E94-4AA9-87C6-AC03B13D58F0",
-      "type": "EndpointBlock",
-      "disabled": false,
-      "name": "rawAPIRequest17",
-      "displayName": "Qlik Cloud Services - Raw API Request 17",
-      "comment": "Get item ID of app",
-      "childId": "AD01998A-BEE0-473B-99F7-E6CC8C4B60CF",
-      "inputs": [
-        {
-          "id": "734cbcc0-bbb0-11f0-b998-f73920377683",
-          "value": "v1/items",
-          "type": "string",
-          "structure": []
-        },
-        {
-          "id": "7322a550-bbb0-11f0-9c8c-43f143a32456",
-          "value": "7341e840-bbb0-11f0-9bb8-11c201f87b6d",
-          "type": "select",
-          "displayValue": "GET",
-          "structure": []
-        },
-        {
-          "id": "73000fe0-bbb0-11f0-8a80-59ece3571bd9",
-          "value": null,
-          "type": "object",
-          "mode": "keyValue",
-          "structure": []
-        },
-        {
-          "id": "736fae60-bbb0-11f0-ad62-c98a0046f418",
-          "value": [
-            {
-              "key": "resourceId",
-              "value": "{ $.loop6.item.resourceId }"
-            },
-            {
-              "key": "resourceType",
-              "value": "app"
-            }
-          ],
-          "type": "object",
-          "mode": "keyValue",
-          "structure": []
-        }
-      ],
-      "settings": [
-        {
-          "id": "blendr_on_error",
-          "value": "stop",
-          "type": "select",
-          "structure": []
-        },
-        {
-          "id": "automations_censor_data",
-          "value": false,
-          "type": "checkbox",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2442,
-      "y": 22734,
-      "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
-      "endpoint_guid": "72d48530-bbb0-11f0-875a-b322bf237aeb",
-      "endpoint_role": "create"
-    },
-    {
-      "id": "BA3377B4-6CA3-40CF-9915-DC98B9CBBE52",
-      "type": "EndpointBlock",
-      "disabled": false,
-      "name": "rawAPIRequest19",
-      "displayName": "Qlik Cloud Services - Raw API Request 19",
-      "comment": "Add the tag to the item.",
-      "childId": "7E0CB48E-DCF7-4EAE-B86B-02B2AE708592",
-      "inputs": [
-        {
-          "id": "734cbcc0-bbb0-11f0-b998-f73920377683",
-          "value": "v1/collections/{ $.taggerIds.versionTag }/items",
-          "type": "string",
-          "structure": []
-        },
-        {
-          "id": "7322a550-bbb0-11f0-9c8c-43f143a32456",
-          "value": "7347ee10-bbb0-11f0-8cdc-59311dd108b3",
-          "type": "select",
-          "displayValue": "POST",
-          "structure": []
-        },
-        {
-          "id": "73000fe0-bbb0-11f0-8a80-59ece3571bd9",
-          "value": "{\n  \"id\": \"{ $.rawAPIRequest17.data[0].id }\"\n}",
-          "type": "object",
-          "mode": "raw",
-          "structure": []
-        },
-        {
-          "id": "736fae60-bbb0-11f0-ad62-c98a0046f418",
-          "value": null,
-          "type": "object",
-          "mode": "keyValue",
-          "structure": []
-        }
-      ],
-      "settings": [
-        {
-          "id": "blendr_on_error",
-          "value": "stop",
-          "type": "select",
-          "structure": []
-        },
-        {
-          "id": "automations_censor_data",
-          "value": false,
-          "type": "checkbox",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2442,
-      "y": 23234,
-      "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
-      "endpoint_guid": "72d48530-bbb0-11f0-875a-b322bf237aeb",
-      "endpoint_role": "create"
-    },
-    {
-      "id": "7E0CB48E-DCF7-4EAE-B86B-02B2AE708592",
-      "type": "ShowBlock",
-      "disabled": false,
-      "name": "output43",
-      "displayName": "Output 43",
-      "comment": "Tag added.",
-      "childId": null,
-      "inputs": [
-        {
-          "id": "input",
-          "value": "| {$.loop2.item.name} - Tags (managed) | > Tag `{ $.workingAppTagVersion }` added to managed space app. |",
-          "type": "string",
-          "structure": []
-        }
-      ],
-      "settings": [
-        {
-          "id": "display_mode",
-          "value": "add",
-          "type": "select",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2442,
-      "y": 23354
-    },
-    {
-      "id": "AD01998A-BEE0-473B-99F7-E6CC8C4B60CF",
-      "type": "FilterListBlock",
-      "disabled": false,
-      "name": "filterList9",
-      "displayName": "Filter List 9",
-      "comment": "Filter to tags other than app name.",
-      "childId": "BA3377B4-6CA3-40CF-9915-DC98B9CBBE52",
-      "inputs": [
-        {
-          "id": "list",
-          "value": "{ $.rawAPIRequest17.data[0].meta.tags }",
-          "type": "string",
-          "structure": []
-        },
-        {
-          "id": "conditions",
-          "value": {
-            "mode": "all",
-            "conditions": [
+      },
+      {
+          "id": "F9DCB126-6ED4-4D9A-BF35-CFD7A6D9CECD",
+          "type": "EndpointBlock",
+          "disabled": false,
+          "name": "getCurrentUserId",
+          "displayName": "Qlik Cloud Services - Get Current User Id",
+          "comment": "RUN: Don't edit below this point.\nFind current user ID.",
+          "childId": "BB38C4E9-A2B4-428B-BAAF-903E14CB56B1",
+          "inputs": [],
+          "settings": [
               {
-                "input1": "name",
-                "input2": "{ $.workingAppTagName }",
-                "operator": "!="
-              }
-            ]
-          },
-          "type": "custom",
-          "structure": []
-        }
-      ],
-      "settings": [
-        {
-          "id": "automations_censor_data",
-          "value": false,
-          "type": "checkbox",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": false
-        }
-      ],
-      "x": -2442,
-      "y": 22854,
-      "loopBlockId": "151AA8FD-9389-44F0-8522-5AFF01889D68"
-    },
-    {
-      "id": "151AA8FD-9389-44F0-8522-5AFF01889D68",
-      "type": "EndpointBlock",
-      "disabled": false,
-      "name": "rawAPIRequest18",
-      "displayName": "Qlik Cloud Services - Raw API Request 18",
-      "comment": "Remove tag from item.",
-      "childId": "137C7CB4-181B-444B-B0E6-2FE3F7491940",
-      "inputs": [
-        {
-          "id": "734cbcc0-bbb0-11f0-b998-f73920377683",
-          "value": "v1/collections/{ $.filterList9.item.id }/items/{$.rawAPIRequest17.data[0].id}",
-          "type": "string",
-          "structure": []
-        },
-        {
-          "id": "7322a550-bbb0-11f0-9c8c-43f143a32456",
-          "value": "73465660-bbb0-11f0-b65a-eb94ca86d22a",
-          "type": "select",
-          "displayValue": "DELETE",
-          "structure": []
-        },
-        {
-          "id": "73000fe0-bbb0-11f0-8a80-59ece3571bd9",
-          "value": null,
-          "type": "object",
-          "mode": "keyValue",
-          "structure": []
-        },
-        {
-          "id": "736fae60-bbb0-11f0-ad62-c98a0046f418",
-          "value": null,
-          "type": "object",
-          "mode": "keyValue",
-          "structure": []
-        }
-      ],
-      "settings": [
-        {
-          "id": "blendr_on_error",
-          "value": "stop",
-          "type": "select",
-          "structure": []
-        },
-        {
-          "id": "automations_censor_data",
-          "value": false,
-          "type": "checkbox",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2322,
-      "y": 22954,
-      "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
-      "endpoint_guid": "72d48530-bbb0-11f0-875a-b322bf237aeb",
-      "endpoint_role": "create"
-    },
-    {
-      "id": "137C7CB4-181B-444B-B0E6-2FE3F7491940",
-      "type": "ShowBlock",
-      "disabled": false,
-      "name": "output42",
-      "displayName": "Output 42",
-      "comment": "Tag removed.",
-      "childId": null,
-      "inputs": [
-        {
-          "id": "input",
-          "value": "| {$.loop2.item.name} - Tags (managed) | > Tag `{ $.filterList9.item.name }` removed from managed space app. |",
-          "type": "string",
-          "structure": []
-        }
-      ],
-      "settings": [
-        {
-          "id": "display_mode",
-          "value": "add",
-          "type": "select",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2322,
-      "y": 23074
-    },
-    {
-      "id": "F959E5AA-4EC0-4284-AA66-F59C788B6B08",
-      "type": "EndpointBlock",
-      "disabled": false,
-      "name": "rawAPIListRequest",
-      "displayName": "Qlik Cloud Services - Raw API List Request",
-      "comment": "List API keys.",
-      "childId": "6C0A56A0-B3A3-4740-858E-57ABB5BF2CAC",
-      "inputs": [
-        {
-          "id": "9fd51350-bbb2-11f0-b2b4-c376cf7e2c04",
-          "value": "v1/api-keys",
-          "type": "string",
-          "structure": []
-        },
-        {
-          "id": "9ff92ee0-bbb2-11f0-8fb9-9146a99c6e2f",
-          "value": [],
-          "type": "object",
-          "mode": "keyValue",
-          "structure": []
-        }
-      ],
-      "settings": [
-        {
-          "id": "maxitemcount",
-          "value": "",
-          "type": "string",
-          "structure": []
-        },
-        {
-          "id": "blendr_on_error",
-          "value": "stop",
-          "type": "select",
-          "structure": []
-        },
-        {
-          "id": "cache",
-          "value": "0",
-          "type": "select",
-          "structure": []
-        },
-        {
-          "id": "automations_censor_data",
-          "value": false,
-          "type": "checkbox",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": false
-        }
-      ],
-      "x": -2922,
-      "y": 3494,
-      "loopBlockId": null,
-      "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
-      "endpoint_guid": "9f6166e0-bbb2-11f0-acdd-bd47067b5fbf",
-      "endpoint_role": "list"
-    },
-    {
-      "id": "81004D2F-88EF-4DAF-AD93-78CFFD551EB7",
-      "type": "EndpointBlock",
-      "disabled": false,
-      "name": "rawAPIRequest6",
-      "displayName": "Qlik Cloud Services - Raw API Request 6",
-      "comment": "Find existing data connection linked to the monitoring app.",
-      "childId": "1BDB1B6F-3959-4D57-B887-62D7AAABE6CB",
-      "inputs": [
-        {
-          "id": "734cbcc0-bbb0-11f0-b998-f73920377683",
-          "value": "v1/data-connections/{$.dataConnectionName}",
-          "type": "string",
-          "structure": []
-        },
-        {
-          "id": "7322a550-bbb0-11f0-9c8c-43f143a32456",
-          "value": "7341e840-bbb0-11f0-9bb8-11c201f87b6d",
-          "type": "select",
-          "displayValue": "GET",
-          "structure": []
-        },
-        {
-          "id": "73000fe0-bbb0-11f0-8a80-59ece3571bd9",
-          "value": [],
-          "type": "object",
-          "mode": "keyValue",
-          "structure": []
-        },
-        {
-          "id": "736fae60-bbb0-11f0-ad62-c98a0046f418",
-          "value": "{\n  \"spaceId\": \"{$.managedSpaceId}\",\n  \"type\": \"connectionname\"\n}",
-          "type": "object",
-          "mode": "raw",
-          "structure": []
-        }
-      ],
-      "settings": [
-        {
-          "id": "blendr_on_error",
-          "value": "ignore",
-          "type": "select",
-          "displayValue": "Ignore - Continue Automation and ignore errors",
-          "structure": []
-        },
-        {
-          "id": "automations_censor_data",
-          "value": false,
-          "type": "checkbox",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": false
-        }
-      ],
-      "x": -2922,
-      "y": 13894,
-      "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
-      "endpoint_guid": "72d48530-bbb0-11f0-875a-b322bf237aeb",
-      "endpoint_role": "create"
-    },
-    {
-      "id": "1BDB1B6F-3959-4D57-B887-62D7AAABE6CB",
-      "type": "IfElseBlock",
-      "disabled": false,
-      "name": "condition24",
-      "displayName": "Condition 24",
-      "comment": "If data connection exists, delete it.",
-      "childId": "3852BD8D-3C33-41F4-8BDA-7A000D4DC500",
-      "inputs": [
-        {
-          "id": "conditions",
-          "value": {
-            "mode": "all",
-            "conditions": [
-              {
-                "input1": "{ $.rawAPIRequest6.id }",
-                "input2": null,
-                "operator": "notEmpty"
-              }
-            ]
-          },
-          "type": "custom",
-          "structure": []
-        }
-      ],
-      "settings": [],
-      "collapsed": [
-        {
-          "name": "both",
-          "isCollapsed": false
-        },
-        {
-          "name": "yes",
-          "isCollapsed": false
-        },
-        {
-          "name": "no",
-          "isCollapsed": false
-        }
-      ],
-      "x": -2922,
-      "y": 14014,
-      "childTrueId": "D2202317-6AF5-42C3-A20F-5806BAEABEDA",
-      "childFalseId": null
-    },
-    {
-      "id": "5E99BD17-A9BC-4021-BDE0-F4EA60301C7F",
-      "type": "EndpointBlock",
-      "disabled": false,
-      "name": "rawAPIRequest8",
-      "displayName": "Qlik Cloud Services - Raw API Request 8",
-      "comment": "Create data connection",
-      "childId": "5E1CFE7D-C393-4315-85EF-086507112AC6",
-      "inputs": [
-        {
-          "id": "734cbcc0-bbb0-11f0-b998-f73920377683",
-          "value": "v1/data-connections",
-          "type": "string",
-          "structure": []
-        },
-        {
-          "id": "7322a550-bbb0-11f0-9c8c-43f143a32456",
-          "value": "7347ee10-bbb0-11f0-8cdc-59311dd108b3",
-          "type": "select",
-          "displayValue": "POST",
-          "structure": []
-        },
-        {
-          "id": "73000fe0-bbb0-11f0-8a80-59ece3571bd9",
-          "value": "{\n\"dataSourceId\": \"rest\",\n\"qName\": \"{$.dataConnectionName}\",\n\"space\":\"{$.managedSpaceId}\",\n\"connectionProperties\": {\n\"url\": \"https://{$.getCurrentTenantInfo.hostnames[0]}/api/v1/users\",\n\"retryCodes\": \"500,502,503,504\",\n\"retryFailedRequest\": true,\n\"timeout\": \"300\",\n\"readwritetimeout\": \"300\",\n\"queryHeaders\": [\n{\n\"name\": \"Authorization\",\n\"value\": \"Bearer {$.rawAPIRequest5.token}\",\n\"encrypt\": true\n}\n],\n\"allowWithConnection\": \"true\"\n}\n}",
-          "type": "object",
-          "mode": "raw",
-          "structure": []
-        },
-        {
-          "id": "736fae60-bbb0-11f0-ad62-c98a0046f418",
-          "value": null,
-          "type": "object",
-          "mode": "keyValue",
-          "structure": []
-        }
-      ],
-      "settings": [
-        {
-          "id": "blendr_on_error",
-          "value": "stop",
-          "type": "select",
-          "structure": []
-        },
-        {
-          "id": "automations_censor_data",
-          "value": true,
-          "type": "checkbox",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": false
-        }
-      ],
-      "x": -2922,
-      "y": 14654,
-      "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
-      "endpoint_guid": "72d48530-bbb0-11f0-875a-b322bf237aeb",
-      "endpoint_role": "create"
-    },
-    {
-      "id": "60F588B6-B33A-4275-ACF5-7D83B6A96411",
-      "type": "VariableBlock",
-      "disabled": false,
-      "name": "dataConnectionName",
-      "displayName": "Variable - dataConnectionName",
-      "comment": "Variable to store name of the data connection linked to the monitoring app.",
-      "childId": "81004D2F-88EF-4DAF-AD93-78CFFD551EB7",
-      "inputs": [],
-      "settings": [],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": false
-        }
-      ],
-      "x": -2922,
-      "y": 13774,
-      "variableGuid": "218D5568-BA73-49F2-9996-926C40E2AE08",
-      "operations": [
-        {
-          "id": "set_value",
-          "key": "49ABB8E7-9FA8-47C1-9212-0346190B156E",
-          "name": "Set value of { variable }",
-          "value": "monitoring_apps_REST"
-        }
-      ]
-    },
-    {
-      "id": "3852BD8D-3C33-41F4-8BDA-7A000D4DC500",
-      "type": "ShowBlock",
-      "disabled": false,
-      "name": "output24",
-      "displayName": "Output 24",
-      "comment": "Creating the data connection.",
-      "childId": "5E99BD17-A9BC-4021-BDE0-F4EA60301C7F",
-      "inputs": [
-        {
-          "id": "input",
-          "value": "| Data connection | Creating the data connection '{$.dataConnectionName}'. |",
-          "type": "string",
-          "structure": []
-        }
-      ],
-      "settings": [
-        {
-          "id": "display_mode",
-          "value": "add",
-          "type": "select",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": false
-        }
-      ],
-      "x": -2922,
-      "y": 14534
-    },
-    {
-      "id": "5E1CFE7D-C393-4315-85EF-086507112AC6",
-      "type": "ShowBlock",
-      "disabled": false,
-      "name": "output25",
-      "displayName": "Output 25",
-      "comment": "Data connection created.",
-      "childId": "D2C679AD-2434-474C-9ACC-B95C8232BA8A",
-      "inputs": [
-        {
-          "id": "input",
-          "value": "| Data connection | Data connection created in [{$.managedSpaceName}]({$.tenantHostname}spaces/{$.managedSpaceId}/dataconnections). |",
-          "type": "string",
-          "structure": []
-        }
-      ],
-      "settings": [
-        {
-          "id": "display_mode",
-          "value": "add",
-          "type": "select",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": false
-        }
-      ],
-      "x": -2922,
-      "y": 14774
-    },
-    {
-      "id": "C5498C80-2759-492A-A46F-58DEF52F8F9A",
-      "type": "EndpointBlock",
-      "disabled": false,
-      "name": "rawAPIRequest7",
-      "displayName": "Qlik Cloud Services - Raw API Request 7",
-      "comment": "Delete the data connection.",
-      "childId": "D5C5031D-9058-4671-A035-978DBB1DC8E4",
-      "inputs": [
-        {
-          "id": "734cbcc0-bbb0-11f0-b998-f73920377683",
-          "value": "v1/data-connections/{$.rawAPIRequest6.id}",
-          "type": "string",
-          "structure": []
-        },
-        {
-          "id": "7322a550-bbb0-11f0-9c8c-43f143a32456",
-          "value": "73465660-bbb0-11f0-b65a-eb94ca86d22a",
-          "type": "select",
-          "displayValue": "DELETE",
-          "structure": []
-        },
-        {
-          "id": "73000fe0-bbb0-11f0-8a80-59ece3571bd9",
-          "value": null,
-          "type": "object",
-          "mode": "keyValue",
-          "structure": []
-        },
-        {
-          "id": "736fae60-bbb0-11f0-ad62-c98a0046f418",
-          "value": null,
-          "type": "object",
-          "mode": "keyValue",
-          "structure": []
-        }
-      ],
-      "settings": [
-        {
-          "id": "blendr_on_error",
-          "value": "stop",
-          "type": "select",
-          "structure": []
-        },
-        {
-          "id": "automations_censor_data",
-          "value": false,
-          "type": "checkbox",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2802,
-      "y": 14214,
-      "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
-      "endpoint_guid": "72d48530-bbb0-11f0-875a-b322bf237aeb",
-      "endpoint_role": "create"
-    },
-    {
-      "id": "D2202317-6AF5-42C3-A20F-5806BAEABEDA",
-      "type": "ShowBlock",
-      "disabled": false,
-      "name": "output22",
-      "displayName": "Output 22",
-      "comment": "Deleting the data connection.",
-      "childId": "C5498C80-2759-492A-A46F-58DEF52F8F9A",
-      "inputs": [
-        {
-          "id": "input",
-          "value": "| Data connection | Deleting the data connection '{$.dataConnectionName}'. |",
-          "type": "string",
-          "structure": []
-        }
-      ],
-      "settings": [
-        {
-          "id": "display_mode",
-          "value": "add",
-          "type": "select",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2802,
-      "y": 14094
-    },
-    {
-      "id": "D5C5031D-9058-4671-A035-978DBB1DC8E4",
-      "type": "ShowBlock",
-      "disabled": false,
-      "name": "output23",
-      "displayName": "Output 23",
-      "comment": "Deleted the data connection.",
-      "childId": null,
-      "inputs": [
-        {
-          "id": "input",
-          "value": "| Data connection | Deleted the data connection. |",
-          "type": "string",
-          "structure": []
-        }
-      ],
-      "settings": [
-        {
-          "id": "display_mode",
-          "value": "add",
-          "type": "select",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2802,
-      "y": 14334
-    },
-    {
-      "id": "56DF743F-3565-4BB7-B484-27DB0E8E13F5",
-      "type": "FilterListBlock",
-      "disabled": false,
-      "name": "filterList7",
-      "displayName": "Filter over Qlik Cloud Services - Raw API List Request - Filter List 7",
-      "comment": "Filter API keys",
-      "childId": "C9CA459B-7C50-4EDF-BD71-300FF8437382",
-      "inputs": [
-        {
-          "id": "list",
-          "value": "{ $.rawAPIListRequest }",
-          "type": "string",
-          "structure": []
-        },
-        {
-          "id": "conditions",
-          "value": {
-            "mode": "all",
-            "conditions": [
-              {
-                "input1": "description",
-                "input2": "{ $.apiKeyName }",
-                "operator": "="
-              }
-            ]
-          },
-          "type": "custom",
-          "structure": []
-        }
-      ],
-      "settings": [
-        {
-          "id": "automations_censor_data",
-          "value": false,
-          "type": "checkbox",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": false
-        }
-      ],
-      "x": -2922,
-      "y": 12794,
-      "loopBlockId": "439A8A90-8CAD-4F2F-A673-90754BB6B0AD"
-    },
-    {
-      "id": "7C672EAB-B98A-4BBD-A807-3428671C2D3D",
-      "type": "EndpointBlock",
-      "disabled": false,
-      "name": "rawAPIRequest4",
-      "displayName": "Qlik Cloud Services - Raw API Request 4",
-      "comment": "Delete the API key.",
-      "childId": "848D7B98-1FE1-4584-BF60-F518D86E41F0",
-      "inputs": [
-        {
-          "id": "734cbcc0-bbb0-11f0-b998-f73920377683",
-          "value": "v1/api-keys/{$.filterList7.item.id}",
-          "type": "string",
-          "structure": []
-        },
-        {
-          "id": "7322a550-bbb0-11f0-9c8c-43f143a32456",
-          "value": "73465660-bbb0-11f0-b65a-eb94ca86d22a",
-          "type": "select",
-          "displayValue": "DELETE",
-          "structure": []
-        },
-        {
-          "id": "73000fe0-bbb0-11f0-8a80-59ece3571bd9",
-          "value": null,
-          "type": "object",
-          "mode": "keyValue",
-          "structure": []
-        },
-        {
-          "id": "736fae60-bbb0-11f0-ad62-c98a0046f418",
-          "value": null,
-          "type": "object",
-          "mode": "keyValue",
-          "structure": []
-        }
-      ],
-      "settings": [
-        {
-          "id": "blendr_on_error",
-          "value": "stop",
-          "type": "select",
-          "structure": []
-        },
-        {
-          "id": "automations_censor_data",
-          "value": false,
-          "type": "checkbox",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2802,
-      "y": 13014,
-      "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
-      "endpoint_guid": "72d48530-bbb0-11f0-875a-b322bf237aeb",
-      "endpoint_role": "create"
-    },
-    {
-      "id": "439A8A90-8CAD-4F2F-A673-90754BB6B0AD",
-      "type": "ShowBlock",
-      "disabled": false,
-      "name": "output18",
-      "displayName": "Output 18",
-      "comment": "Delete existing key",
-      "childId": "7C672EAB-B98A-4BBD-A807-3428671C2D3D",
-      "inputs": [
-        {
-          "id": "input",
-          "value": "| API keys | Deleting existing API key named '{ $.filterList7.item.description }'. |",
-          "type": "string",
-          "structure": []
-        }
-      ],
-      "settings": [
-        {
-          "id": "display_mode",
-          "value": "add",
-          "type": "select",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2802,
-      "y": 12894
-    },
-    {
-      "id": "848D7B98-1FE1-4584-BF60-F518D86E41F0",
-      "type": "ShowBlock",
-      "disabled": false,
-      "name": "output19",
-      "displayName": "Output 19",
-      "comment": "Existing key deleted",
-      "childId": null,
-      "inputs": [
-        {
-          "id": "input",
-          "value": "| API keys | API key deleted. |",
-          "type": "string",
-          "structure": []
-        }
-      ],
-      "settings": [
-        {
-          "id": "display_mode",
-          "value": "add",
-          "type": "select",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2802,
-      "y": 13134
-    },
-    {
-      "id": "C9CA459B-7C50-4EDF-BD71-300FF8437382",
-      "type": "ShowBlock",
-      "disabled": false,
-      "name": "output20",
-      "displayName": "Output 20",
-      "comment": "Generating new API key.",
-      "childId": "28997C80-CF89-4863-BAD6-DD9A15FC72EF",
-      "inputs": [
-        {
-          "id": "input",
-          "value": "| API keys | Generating new API key named '{ $.apiKeyName }'. |",
-          "type": "string",
-          "structure": []
-        }
-      ],
-      "settings": [
-        {
-          "id": "display_mode",
-          "value": "add",
-          "type": "select",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": false
-        }
-      ],
-      "x": -2922,
-      "y": 13294
-    },
-    {
-      "id": "28997C80-CF89-4863-BAD6-DD9A15FC72EF",
-      "type": "EndpointBlock",
-      "disabled": false,
-      "name": "rawAPIRequest5",
-      "displayName": "Qlik Cloud Services - Raw API Request 5",
-      "comment": "Generate API key.",
-      "childId": "A9FB2FA5-C29A-40C7-B008-73D7095910FC",
-      "inputs": [
-        {
-          "id": "734cbcc0-bbb0-11f0-b998-f73920377683",
-          "value": "v1/api-keys",
-          "type": "string",
-          "structure": []
-        },
-        {
-          "id": "7322a550-bbb0-11f0-9c8c-43f143a32456",
-          "value": "7347ee10-bbb0-11f0-8cdc-59311dd108b3",
-          "type": "select",
-          "displayValue": "POST",
-          "structure": []
-        },
-        {
-          "id": "73000fe0-bbb0-11f0-8a80-59ece3571bd9",
-          "value": "{\"description\":\"{ $.apiKeyName }\",\"expiry\":\"{ $.apiKeyDuration }\"}",
-          "type": "object",
-          "mode": "raw",
-          "structure": []
-        },
-        {
-          "id": "736fae60-bbb0-11f0-ad62-c98a0046f418",
-          "value": null,
-          "type": "object",
-          "mode": "keyValue",
-          "structure": []
-        }
-      ],
-      "settings": [
-        {
-          "id": "blendr_on_error",
-          "value": "stop",
-          "type": "select",
-          "structure": []
-        },
-        {
-          "id": "automations_censor_data",
-          "value": true,
-          "type": "checkbox",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": false
-        }
-      ],
-      "x": -2922,
-      "y": 13414,
-      "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
-      "endpoint_guid": "72d48530-bbb0-11f0-875a-b322bf237aeb",
-      "endpoint_role": "create"
-    },
-    {
-      "id": "A9FB2FA5-C29A-40C7-B008-73D7095910FC",
-      "type": "VariableBlock",
-      "disabled": false,
-      "name": "apiKeyExpiryDate",
-      "displayName": "Variable - apiKeyExpiryDate",
-      "comment": "Set the expiry to log later.",
-      "childId": "20C5CA2D-D4E9-453B-A275-37990DC61736",
-      "inputs": [],
-      "settings": [],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": false
-        }
-      ],
-      "x": -2922,
-      "y": 13534,
-      "variableGuid": "AABC69B3-4AB6-4777-A443-FCFCFDA805C4",
-      "operations": [
-        {
-          "id": "set_value",
-          "key": "4401AA06-FDCC-4053-AD20-B479DC6D056C",
-          "name": "Set value of { variable }",
-          "value": "{$.rawAPIRequest5.expiry}"
-        }
-      ]
-    },
-    {
-      "id": "20C5CA2D-D4E9-453B-A275-37990DC61736",
-      "type": "ShowBlock",
-      "disabled": false,
-      "name": "output21",
-      "displayName": "Output 21",
-      "comment": "API key generated",
-      "childId": "60F588B6-B33A-4275-ACF5-7D83B6A96411",
-      "inputs": [
-        {
-          "id": "input",
-          "value": "| API keys | API key generated, valid until { $.apiKeyExpiryDate }. |",
-          "type": "string",
-          "structure": []
-        }
-      ],
-      "settings": [
-        {
-          "id": "display_mode",
-          "value": "add",
-          "type": "select",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": false
-        }
-      ],
-      "x": -2922,
-      "y": 13654
-    },
-    {
-      "id": "F4D0DE07-AD02-4C58-9CEA-A3409E738389",
-      "type": "VariableBlock",
-      "disabled": false,
-      "name": "apiKeyName",
-      "displayName": "Variable - apiKeyName",
-      "comment": "Name for the installer's API key. Pattern is QCMA - <managedSpaceId>.",
-      "childId": "1724234E-1EE6-475F-9451-68D9482CC2FE",
-      "inputs": [],
-      "settings": [],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": false
-        }
-      ],
-      "x": -2922,
-      "y": 11994,
-      "variableGuid": "DB5AD6FD-CA6D-4BDB-B12B-91C248324EE1",
-      "operations": [
-        {
-          "id": "set_value",
-          "key": "3BC25283-EF15-41B0-9528-9DB4D9DDF3FB",
-          "name": "Set value of { variable }",
-          "value": "QCMA - { $.managedSpaceId }"
-        }
-      ]
-    },
-    {
-      "id": "1724234E-1EE6-475F-9451-68D9482CC2FE",
-      "type": "FilterListBlock",
-      "disabled": false,
-      "name": "filterList6",
-      "displayName": "Filter over Qlik Cloud Services - Raw API List Request - Filter List 6",
-      "comment": "Filter to user's API keys.",
-      "childId": "6306F3F3-BD9F-4E0B-8C41-EE8E21DD421C",
-      "inputs": [
-        {
-          "id": "list",
-          "value": "{ $.rawAPIListRequest }",
-          "type": "string",
-          "structure": []
-        },
-        {
-          "id": "conditions",
-          "value": {
-            "mode": "all",
-            "conditions": [
-              {
-                "input1": "sub",
-                "input2": "{ $.getCurrentUserId }",
-                "operator": "="
+                  "id": "blendr_on_error",
+                  "value": "stop",
+                  "type": "select",
+                  "structure": []
               },
               {
-                "input1": "description",
-                "input2": "{ $.apiKeyName }",
-                "operator": "!="
-              }
-            ]
-          },
-          "type": "custom",
-          "structure": []
-        }
-      ],
-      "settings": [
-        {
-          "id": "automations_censor_data",
-          "value": false,
-          "type": "checkbox",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": false
-        }
-      ],
-      "x": -2922,
-      "y": 12114,
-      "loopBlockId": null
-    },
-    {
-      "id": "6306F3F3-BD9F-4E0B-8C41-EE8E21DD421C",
-      "type": "IfElseBlock",
-      "disabled": false,
-      "name": "condition23",
-      "displayName": "Condition 23",
-      "comment": "If user has max number of API keys already, exit.",
-      "childId": "56DF743F-3565-4BB7-B484-27DB0E8E13F5",
-      "inputs": [
-        {
-          "id": "conditions",
-          "value": {
-            "mode": "all",
-            "conditions": [
+                  "id": "cache",
+                  "value": "0",
+                  "type": "select",
+                  "structure": []
+              },
               {
-                "input1": "{ count: { $.filterList6 } }",
-                "input2": "{ $.rawAPIRequest2.max_keys_per_user }",
-                "operator": ">="
+                  "id": "automations_censor_data",
+                  "value": false,
+                  "type": "checkbox",
+                  "structure": []
               }
-            ]
-          },
-          "type": "custom",
-          "structure": []
-        }
-      ],
-      "settings": [],
-      "collapsed": [
-        {
-          "name": "both",
-          "isCollapsed": false
-        },
-        {
-          "name": "yes",
-          "isCollapsed": false
-        },
-        {
-          "name": "no",
-          "isCollapsed": false
-        }
-      ],
-      "x": -2922,
-      "y": 12274,
-      "childTrueId": "1AEE9D36-5C63-4334-8758-ECD4056C36B3",
-      "childFalseId": null
-    },
-    {
-      "id": "1AEE9D36-5C63-4334-8758-ECD4056C36B3",
-      "type": "VariableBlock",
-      "disabled": false,
-      "name": "errorTitle",
-      "displayName": "Variable - errorTitle",
-      "comment": "Set error title for standard error output.",
-      "childId": "489D6F65-006C-4D20-81A8-578A09FE4E8E",
-      "inputs": [],
-      "settings": [],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2802,
-      "y": 12354,
-      "variableGuid": "407730A6-EC96-4337-BE80-CF4C0D552F08",
-      "operations": [
-        {
-          "id": "set_value",
-          "key": "1BC10F4C-68C2-42E9-9000-25865B076073",
-          "name": "Set value of { variable }",
-          "value": "User cannot create any more API keys."
-        }
-      ]
-    },
-    {
-      "id": "489D6F65-006C-4D20-81A8-578A09FE4E8E",
-      "type": "VariableBlock",
-      "disabled": false,
-      "name": "errorDetail",
-      "displayName": "Variable - errorDetail",
-      "comment": "Variable to store detailed error message.",
-      "childId": "5B590615-6F1A-4D9E-9A37-DB7042C17B13",
-      "inputs": [],
-      "settings": [],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2802,
-      "y": 12474,
-      "variableGuid": "1BF2068B-106E-4D58-BC51-884F1810F03C",
-      "operations": [
-        {
-          "id": "set_value",
-          "key": "1BC10F4C-68C2-42E9-9000-25865B076073",
-          "name": "Set value of { variable }",
-          "value": "Exiting, current user cannot create more API keys. Either delete some unused API keys, or increase the maximum keys per user."
-        }
-      ]
-    },
-    {
-      "id": "5B590615-6F1A-4D9E-9A37-DB7042C17B13",
-      "type": "GotoBlock",
-      "disabled": false,
-      "name": "goToLabel10",
-      "displayName": "Go To Label 10",
-      "comment": "Go to the label named error.",
-      "childId": null,
-      "inputs": [
-        {
-          "id": "label",
-          "value": "EF82AD29-E2CF-44C9-A7DB-24C784618756",
-          "type": "select",
-          "displayValue": "error",
-          "structure": []
-        }
-      ],
-      "settings": [],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2802,
-      "y": 12594
-    },
-    {
-      "id": "2E61A575-F621-4713-B446-C1BAC52D8834",
-      "type": "VariableBlock",
-      "disabled": false,
-      "name": "reloadNow",
-      "displayName": "Variable - reloadNow",
-      "comment": "Configure whether to run a reload on every run. By default, it is set to 1, which will reload every app. Set to 0 to skip a reload.",
-      "childId": "8151B3E3-471C-496B-BB87-F586C46E3CF4",
-      "inputs": [],
-      "settings": [],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2802,
-      "y": -3266,
-      "variableGuid": "12BED549-8F76-4D83-B484-F6121E71753E",
-      "operations": [
-        {
-          "id": "set_value",
-          "key": "2A53EE0E-A13C-45CD-9E07-D012532B33CA",
-          "name": "Set value of { variable }",
-          "value": "1"
-        }
-      ]
-    },
-    {
-      "id": "8151B3E3-471C-496B-BB87-F586C46E3CF4",
-      "type": "VariableBlock",
-      "disabled": false,
-      "name": "reloadScheduleHour",
-      "displayName": "Variable - reloadScheduleHour",
-      "comment": "Set to the hour of the day (UTC) when the apps should reload. Will create a schedule for each app at this time. Will replace any other schedules on the app. Leave empty to manage schedules yourself.",
-      "childId": "6AC0239B-01A8-47F9-AD4C-ED09CCB2B83F",
-      "inputs": [],
-      "settings": [],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2802,
-      "y": -3146,
-      "variableGuid": "3DA539EC-2C6E-4C2B-9985-6F5BDCA282B2",
-      "operations": [
-        {
-          "id": "set_value",
-          "key": "2A53EE0E-A13C-45CD-9E07-D012532B33CA",
-          "name": "Set value of { variable }",
-          "value": "06"
-        }
-      ]
-    },
-    {
-      "id": "9745F8DD-9BEC-4E02-B0B9-B275B8BCFCB1",
-      "type": "IfElseBlock",
-      "disabled": false,
-      "name": "condition34",
-      "displayName": "Condition 34",
-      "comment": "If reloadNow=1, reload",
-      "childId": "EC299E1F-F2CA-4149-B148-FC4319064F9D",
-      "inputs": [
-        {
-          "id": "conditions",
-          "value": {
-            "mode": "all",
-            "conditions": [
-              {
-                "input1": "{ $.reloadNow }",
-                "input2": "1",
-                "operator": "="
-              }
-            ]
-          },
-          "type": "custom",
-          "structure": []
-        }
-      ],
-      "settings": [],
-      "collapsed": [
-        {
-          "name": "both",
-          "isCollapsed": false
-        },
-        {
-          "name": "yes",
-          "isCollapsed": false
-        },
-        {
-          "name": "no",
-          "isCollapsed": false
-        }
-      ],
-      "x": -2922,
-      "y": 24494,
-      "childTrueId": "FB25A35E-49F7-4A93-951E-84B8CF244FC0",
-      "childFalseId": "1AC4CBD1-A4F2-4A7A-AAD8-E90C9F324004"
-    },
-    {
-      "id": "5D9D41EA-BC05-4138-83E8-9486E94834B9",
-      "type": "ForEachBlock",
-      "disabled": false,
-      "name": "loop7",
-      "displayName": "Loop 7",
-      "comment": "Loop over liveApps.",
-      "childId": null,
-      "inputs": [
-        {
-          "id": "input",
-          "value": "{ $.liveApps }",
-          "type": "string",
-          "structure": []
-        }
-      ],
-      "settings": [
-        {
-          "id": "automations_censor_data",
-          "value": false,
-          "type": "checkbox",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": false
-        }
-      ],
-      "x": -2802,
-      "y": 24694,
-      "loopBlockId": "3B9FCBAE-B4AD-491D-AA8C-95619A4C827C"
-    },
-    {
-      "id": "3B9FCBAE-B4AD-491D-AA8C-95619A4C827C",
-      "type": "SnippetBlock",
-      "disabled": false,
-      "name": "DoReload",
-      "displayName": "Qlik Cloud Services - Do Reload",
-      "comment": "Trigger app reload. Warn on failure since will fail if a reload is ongoing.",
-      "childId": "3F546BF0-1269-4DA8-A132-0F3DE54E86F4",
-      "inputs": [
-        {
-          "id": "29603390-e716-11ea-9e37-05e08ee32111",
-          "value": "{ $.loop7.item.attributes.id }",
-          "type": "string",
-          "structure": []
-        },
-        {
-          "id": "2ac9eef0-a677-11eb-aacc-8b755d0fe484",
-          "value": "Start reload and continue",
-          "type": "select",
-          "displayValue": "Start reload and continue",
-          "structure": []
-        },
-        {
-          "id": "6892c0c0-c795-11eb-9860-9dc8cb705e25",
-          "value": null,
-          "type": "select",
-          "structure": []
-        },
-        {
-          "id": "ecebf340-c797-11eb-8671-53658babb1a1",
-          "value": null,
-          "type": "select",
-          "structure": []
-        },
-        {
-          "id": "069de770-8277-11f0-a252-ad6769632a1c",
-          "value": null,
-          "type": "select",
-          "structure": []
-        },
-        {
-          "id": "06a02bd0-8277-11f0-b78b-f7910663702f",
-          "value": null,
-          "type": "object",
-          "mode": "keyValue",
-          "structure": []
-        },
-        {
-          "id": "cc8dd1c0-a438-11f0-9e17-c77404b63446",
-          "value": null,
-          "type": "select",
-          "structure": []
-        }
-      ],
-      "settings": [
-        {
-          "id": "blendr_on_error",
-          "value": "warning",
-          "type": "select",
-          "displayValue": "Warning - Continue Automation and report errors",
-          "structure": []
-        },
-        {
-          "id": "automations_censor_data",
-          "value": false,
-          "type": "checkbox",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2682,
-      "y": 24794,
-      "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
-      "snippet_guid": "b5dbb7a0-e715-11ea-b2bf-43bb35adee19"
-    },
-    {
-      "id": "FB25A35E-49F7-4A93-951E-84B8CF244FC0",
-      "type": "ShowBlock",
-      "disabled": false,
-      "name": "output45",
-      "displayName": "Output 45",
-      "comment": "Status output.",
-      "childId": "5D9D41EA-BC05-4138-83E8-9486E94834B9",
-      "inputs": [
-        {
-          "id": "input",
-          "value": "| Reload | Configured to reload all apps now, triggering reloads. |",
-          "type": "string",
-          "structure": []
-        }
-      ],
-      "settings": [
-        {
-          "id": "display_mode",
-          "value": "add",
-          "type": "select",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2802,
-      "y": 24574
-    },
-    {
-      "id": "3F546BF0-1269-4DA8-A132-0F3DE54E86F4",
-      "type": "ShowBlock",
-      "disabled": false,
-      "name": "output46",
-      "displayName": "Output 46",
-      "comment": "Status output.",
-      "childId": null,
-      "inputs": [
-        {
-          "id": "input",
-          "value": "| Reload | > Triggered reload of [{$.loop7.item.attributes.name}]({$.tenantHostname}sense/app/{ $.loop7.item.attributes.id }). |",
-          "type": "string",
-          "structure": []
-        }
-      ],
-      "settings": [
-        {
-          "id": "display_mode",
-          "value": "add",
-          "type": "select",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2682,
-      "y": 24914
-    },
-    {
-      "id": "3F25D3AA-32C6-4C4A-968D-7EA29AA29A76",
-      "type": "ShowBlock",
-      "disabled": false,
-      "name": "output51",
-      "displayName": "Output 51",
-      "comment": "Status output.",
-      "childId": null,
-      "inputs": [
-        {
-          "id": "input",
-          "value": "| Reload schedule | > Created task for [{$.loop8.item.attributes.name}]({$.tenantHostname}sense/app/{$.loop8.item.attributes.id}). |",
-          "type": "string",
-          "structure": []
-        }
-      ],
-      "settings": [
-        {
-          "id": "display_mode",
-          "value": "add",
-          "type": "select",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2682,
-      "y": 26614
-    },
-    {
-      "id": "CEEB9F64-6EF8-4820-AB01-EE03F916B81D",
-      "type": "ForEachBlock",
-      "disabled": false,
-      "name": "loop8",
-      "displayName": "Loop 8",
-      "comment": "Loop over liveApps.",
-      "childId": null,
-      "inputs": [
-        {
-          "id": "input",
-          "value": "{ $.liveApps }",
-          "type": "string",
-          "structure": []
-        }
-      ],
-      "settings": [
-        {
-          "id": "automations_censor_data",
-          "value": false,
-          "type": "checkbox",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": false
-        }
-      ],
-      "x": -2802,
-      "y": 25474,
-      "loopBlockId": "DBF1BB1B-4211-420D-8B2C-AC9A5EC74B31"
-    },
-    {
-      "id": "4F1E7C76-BDAF-4C71-A828-279277FEBEBC",
-      "type": "ShowBlock",
-      "disabled": false,
-      "name": "output48",
-      "displayName": "Output 48",
-      "comment": "Status output.",
-      "childId": "CEEB9F64-6EF8-4820-AB01-EE03F916B81D",
-      "inputs": [
-        {
-          "id": "input",
-          "value": "| Reload schedule | Creating or replacing reload schedules. |",
-          "type": "string",
-          "structure": []
-        }
-      ],
-      "settings": [
-        {
-          "id": "display_mode",
-          "value": "add",
-          "type": "select",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": false
-        }
-      ],
-      "x": -2802,
-      "y": 25354
-    },
-    {
-      "id": "EC299E1F-F2CA-4149-B148-FC4319064F9D",
-      "type": "IfElseBlock",
-      "disabled": false,
-      "name": "condition35",
-      "displayName": "Condition 35",
-      "comment": "If reloadScheduleHour is not empty, manage schedule.",
-      "childId": "FA1DC448-EC02-4CDB-9A20-8E042259A14C",
-      "inputs": [
-        {
-          "id": "conditions",
-          "value": {
-            "mode": "all",
-            "conditions": [
-              {
-                "input1": "{ $.reloadScheduleHour }",
-                "input2": "1",
-                "operator": "notEmpty"
-              }
-            ]
-          },
-          "type": "custom",
-          "structure": []
-        }
-      ],
-      "settings": [],
-      "collapsed": [
-        {
-          "name": "both",
-          "isCollapsed": false
-        },
-        {
-          "name": "yes",
-          "isCollapsed": false
-        },
-        {
-          "name": "no",
-          "isCollapsed": false
-        }
-      ],
-      "x": -2922,
-      "y": 25274,
-      "childTrueId": "4F1E7C76-BDAF-4C71-A828-279277FEBEBC",
-      "childFalseId": "0B7C9754-D191-41BC-A121-E09CEB1D1E0C"
-    },
-    {
-      "id": "1AC4CBD1-A4F2-4A7A-AAD8-E90C9F324004",
-      "type": "ShowBlock",
-      "disabled": false,
-      "name": "output47",
-      "displayName": "Output 47",
-      "comment": "Status output.",
-      "childId": null,
-      "inputs": [
-        {
-          "id": "input",
-          "value": "| Reload | Skipping reload step per configuration. |",
-          "type": "string",
-          "structure": []
-        }
-      ],
-      "settings": [
-        {
-          "id": "display_mode",
-          "value": "add",
-          "type": "select",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2802,
-      "y": 25114
-    },
-    {
-      "id": "0B7C9754-D191-41BC-A121-E09CEB1D1E0C",
-      "type": "ShowBlock",
-      "disabled": false,
-      "name": "output52",
-      "displayName": "Output 52",
-      "comment": "Status output.",
-      "childId": null,
-      "inputs": [
-        {
-          "id": "input",
-          "value": "| Reload schedule | Skipping reload schedule setup per configuration. |",
-          "type": "string",
-          "structure": []
-        }
-      ],
-      "settings": [
-        {
-          "id": "display_mode",
-          "value": "add",
-          "type": "select",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2802,
-      "y": 26814
-    },
-    {
-      "id": "DBF1BB1B-4211-420D-8B2C-AC9A5EC74B31",
-      "type": "EndpointBlock",
-      "disabled": false,
-      "name": "rawAPIListRequest2",
-      "displayName": "Qlik Cloud Services - Raw API List Request 2",
-      "comment": "List reload tasks (ignore error is set on this block as we expect this endpoint to be removed in future).",
-      "childId": "1F217AD2-7D2F-46C9-AA0B-CF650A95E1D4",
-      "inputs": [
-        {
-          "id": "9fd51350-bbb2-11f0-b2b4-c376cf7e2c04",
-          "value": "v1/reload-tasks",
-          "type": "string",
-          "structure": []
-        },
-        {
-          "id": "9ff92ee0-bbb2-11f0-8fb9-9146a99c6e2f",
-          "value": [
-            {
-              "key": "appId",
-              "value": "{ $.loop8.item.attributes.id }"
-            }
           ],
-          "type": "object",
-          "mode": "keyValue",
-          "structure": []
-        }
-      ],
-      "settings": [
-        {
-          "id": "maxitemcount",
-          "value": "",
-          "type": "string",
-          "structure": []
-        },
-        {
-          "id": "blendr_on_error",
-          "value": "ignore",
-          "type": "select",
-          "displayValue": "Ignore - Continue Automation and ignore errors",
-          "structure": []
-        },
-        {
-          "id": "cache",
-          "value": "0",
-          "type": "select",
-          "structure": []
-        },
-        {
-          "id": "automations_censor_data",
-          "value": false,
-          "type": "checkbox",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": false
-        }
-      ],
-      "x": -2682,
-      "y": 25574,
-      "loopBlockId": null,
-      "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
-      "endpoint_guid": "9f6166e0-bbb2-11f0-acdd-bd47067b5fbf",
-      "endpoint_role": "list"
-    },
-    {
-      "id": "FDC0A602-52CC-46BF-9DAC-9320101C6DE5",
-      "type": "EndpointBlock",
-      "disabled": false,
-      "name": "rawAPIRequest20",
-      "displayName": "Qlik Cloud Services - Raw API Request 20",
-      "comment": "Delete reload task (ignore error for future removal).",
-      "childId": "C78A84B1-7004-4B07-A0EC-9859F8143EC8",
-      "inputs": [
-        {
-          "id": "734cbcc0-bbb0-11f0-b998-f73920377683",
-          "value": "v1/reload-tasks/{ $.filterList10.item.id }",
-          "type": "string",
-          "structure": []
-        },
-        {
-          "id": "7322a550-bbb0-11f0-9c8c-43f143a32456",
-          "value": "73465660-bbb0-11f0-b65a-eb94ca86d22a",
-          "type": "select",
-          "displayValue": "DELETE",
-          "structure": []
-        },
-        {
-          "id": "73000fe0-bbb0-11f0-8a80-59ece3571bd9",
-          "value": null,
-          "type": "object",
-          "mode": "keyValue",
-          "structure": []
-        },
-        {
-          "id": "736fae60-bbb0-11f0-ad62-c98a0046f418",
-          "value": null,
-          "type": "object",
-          "mode": "keyValue",
-          "structure": []
-        }
-      ],
-      "settings": [
-        {
-          "id": "blendr_on_error",
-          "value": "ignore",
-          "type": "select",
-          "displayValue": "Ignore - Continue Automation and ignore errors",
-          "structure": []
-        },
-        {
-          "id": "automations_censor_data",
-          "value": false,
-          "type": "checkbox",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2562,
-      "y": 25834,
-      "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
-      "endpoint_guid": "72d48530-bbb0-11f0-875a-b322bf237aeb",
-      "endpoint_role": "create"
-    },
-    {
-      "id": "1F217AD2-7D2F-46C9-AA0B-CF650A95E1D4",
-      "type": "FilterListBlock",
-      "disabled": false,
-      "name": "filterList10",
-      "displayName": "Filter over Qlik Cloud Services - Raw API List Request 2 - Filter List 10",
-      "comment": "Filter to tasks which haven't been migrated. Migrated tasks can't be updated.",
-      "childId": "87CA29E5-FAC2-4E81-A611-555DD014D546",
-      "inputs": [
-        {
-          "id": "list",
-          "value": "{ $.rawAPIListRequest2 }",
-          "type": "string",
-          "structure": []
-        },
-        {
-          "id": "conditions",
-          "value": {
-            "mode": "all",
-            "conditions": [
+          "collapsed": [
               {
-                "input1": "migrated",
-                "input2": null,
-                "operator": "isFalse"
+                  "name": "loop",
+                  "isCollapsed": false
               }
-            ]
-          },
-          "type": "custom",
-          "structure": []
-        }
-      ],
-      "settings": [
-        {
-          "id": "automations_censor_data",
-          "value": false,
-          "type": "checkbox",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": false
-        }
-      ],
-      "x": -2682,
-      "y": 25734,
-      "loopBlockId": "FDC0A602-52CC-46BF-9DAC-9320101C6DE5"
-    },
-    {
-      "id": "C78A84B1-7004-4B07-A0EC-9859F8143EC8",
-      "type": "ShowBlock",
-      "disabled": false,
-      "name": "output49",
-      "displayName": "Output 49",
-      "comment": "Status output.",
-      "childId": null,
-      "inputs": [
-        {
-          "id": "input",
-          "value": "| Reload schedule | > Deleted legacy reload task from [{ $.loop8.item.attributes.name }]({$.tenantHostname}sense/app/{ $.loop8.item.attributes.id }). |",
-          "type": "string",
-          "structure": []
-        }
-      ],
-      "settings": [
-        {
-          "id": "display_mode",
-          "value": "add",
-          "type": "select",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2562,
-      "y": 25954
-    },
-    {
-      "id": "87CA29E5-FAC2-4E81-A611-555DD014D546",
-      "type": "EndpointBlock",
-      "disabled": false,
-      "name": "rawAPIListRequest3",
-      "displayName": "Qlik Cloud Services - Raw API List Request 3",
-      "comment": "List tasks.",
-      "childId": "BF1A16BF-5256-4500-953B-F576C3C6B651",
-      "inputs": [
-        {
-          "id": "9fd51350-bbb2-11f0-b2b4-c376cf7e2c04",
-          "value": "v1/tasks",
-          "type": "string",
-          "structure": []
-        },
-        {
-          "id": "9ff92ee0-bbb2-11f0-8fb9-9146a99c6e2f",
-          "value": [
-            {
-              "key": "resourceId",
-              "value": "{ $.loop8.item.attributes.id }"
-            }
           ],
-          "type": "object",
-          "mode": "keyValue",
-          "structure": []
-        }
-      ],
-      "settings": [
-        {
-          "id": "maxitemcount",
-          "value": "",
-          "type": "string",
-          "structure": []
-        },
-        {
-          "id": "blendr_on_error",
-          "value": "stop",
-          "type": "select",
-          "displayValue": "Stop - Stop Automation and set to failed",
-          "structure": []
-        },
-        {
-          "id": "cache",
-          "value": "0",
-          "type": "select",
-          "structure": []
-        },
-        {
-          "id": "automations_censor_data",
-          "value": false,
-          "type": "checkbox",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": false
-        }
-      ],
-      "x": -2682,
-      "y": 26114,
-      "loopBlockId": "34F8AAE5-2A39-4EA6-84DD-200050879981",
-      "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
-      "endpoint_guid": "9f6166e0-bbb2-11f0-acdd-bd47067b5fbf",
-      "endpoint_role": "list"
-    },
-    {
-      "id": "34F8AAE5-2A39-4EA6-84DD-200050879981",
-      "type": "EndpointBlock",
-      "disabled": false,
-      "name": "rawAPIRequest21",
-      "displayName": "Qlik Cloud Services - Raw API Request 21",
-      "comment": "Delete task.",
-      "childId": "E5158A1B-0875-4B56-849E-D1C48472B46B",
-      "inputs": [
-        {
-          "id": "734cbcc0-bbb0-11f0-b998-f73920377683",
-          "value": "v1/tasks/{ $.rawAPIListRequest3.item.id }",
-          "type": "string",
-          "structure": []
-        },
-        {
-          "id": "7322a550-bbb0-11f0-9c8c-43f143a32456",
-          "value": "73465660-bbb0-11f0-b65a-eb94ca86d22a",
-          "type": "select",
-          "displayValue": "DELETE",
-          "structure": []
-        },
-        {
-          "id": "73000fe0-bbb0-11f0-8a80-59ece3571bd9",
-          "value": null,
-          "type": "object",
-          "mode": "keyValue",
-          "structure": []
-        },
-        {
-          "id": "736fae60-bbb0-11f0-ad62-c98a0046f418",
-          "value": null,
-          "type": "object",
-          "mode": "keyValue",
-          "structure": []
-        }
-      ],
-      "settings": [
-        {
-          "id": "blendr_on_error",
-          "value": "stop",
-          "type": "select",
-          "displayValue": "Stop - Stop Automation and set to failed",
-          "structure": []
-        },
-        {
-          "id": "automations_censor_data",
-          "value": false,
-          "type": "checkbox",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2562,
-      "y": 26214,
-      "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
-      "endpoint_guid": "72d48530-bbb0-11f0-875a-b322bf237aeb",
-      "endpoint_role": "create"
-    },
-    {
-      "id": "E5158A1B-0875-4B56-849E-D1C48472B46B",
-      "type": "ShowBlock",
-      "disabled": false,
-      "name": "output50",
-      "displayName": "Output 50",
-      "comment": "Status output.",
-      "childId": null,
-      "inputs": [
-        {
-          "id": "input",
-          "value": "| Reload schedule | > Deleted task from [{$.loop8.item.attributes.name}]({$.tenantHostname}sense/app/{ $.loop8.item.attributes.id }). |",
-          "type": "string",
-          "structure": []
-        }
-      ],
-      "settings": [
-        {
-          "id": "display_mode",
-          "value": "add",
-          "type": "select",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2562,
-      "y": 26334
-    },
-    {
-      "id": "BF1A16BF-5256-4500-953B-F576C3C6B651",
-      "type": "EndpointBlock",
-      "disabled": false,
-      "name": "rawAPIRequest22",
-      "displayName": "Qlik Cloud Services - Raw API Request 22",
-      "comment": "Create scheduled task.",
-      "childId": "3F25D3AA-32C6-4C4A-968D-7EA29AA29A76",
-      "inputs": [
-        {
-          "id": "734cbcc0-bbb0-11f0-b998-f73920377683",
-          "value": "v1/tasks",
-          "type": "string",
-          "structure": []
-        },
-        {
-          "id": "7322a550-bbb0-11f0-9c8c-43f143a32456",
-          "value": "7347ee10-bbb0-11f0-8cdc-59311dd108b3",
-          "type": "select",
-          "displayValue": "POST",
-          "structure": []
-        },
-        {
-          "id": "73000fe0-bbb0-11f0-8a80-59ece3571bd9",
-          "value": "{\n  \"version\": \"1.0.0\",\n  \"specVersion\": \"1.12.0\",\n  \"name\": \"QCMA automated schedule\",\n  \"description\": \"Automatically deployed schedule by user ID {$.getCurrentUserId}, automation ID {automationid}, run ID {runid}.\",\n  \"enabled\": true,\n  \"states\": [\n    {\n      \"name\": \"init_state\",\n      \"type\": \"EVENT\",\n      \"onEvents\": [\n        {\n          \"eventRefs\": [],\n          \"actions\": [\n            {\n              \"name\": \"AppReload\",\n              \"functionRef\": {\n                \"refName\": \"app.reload\",\n                \"arguments\": {\n                  \"appId\": \"{ $.loop8.item.attributes.id }\",\n                  \"partial\": false\n                }\n              }\n            }\n          ]\n        }\n      ]\n    }\n  ],\n  \"resourceId\": \"{ $.loop8.item.attributes.id }\",\n  \"start\": {\n    \"schedule\": {\n      \"startDateTime\": \"2025-10-17T00:00:00\",\n      \"endDateTime\": null,\n      \"timezone\": \"Europe/London\",\n      \"recurrence\": \"RRULE:FREQ=WEEKLY;INTERVAL=1;BYDAY=MO,TU,WE,TH,FR,SA,SU;BYHOUR={ $.reloadScheduleHour };BYMINUTE=15;BYSECOND=0\"\n    }\n  }\n}",
-          "type": "object",
-          "mode": "raw",
-          "structure": []
-        },
-        {
-          "id": "736fae60-bbb0-11f0-ad62-c98a0046f418",
-          "value": null,
-          "type": "object",
-          "mode": "keyValue",
-          "structure": []
-        }
-      ],
-      "settings": [
-        {
-          "id": "blendr_on_error",
-          "value": "stop",
-          "type": "select",
-          "displayValue": "Stop - Stop Automation and set to failed",
-          "structure": []
-        },
-        {
-          "id": "automations_censor_data",
-          "value": false,
-          "type": "checkbox",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2682,
-      "y": 26494,
-      "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
-      "endpoint_guid": "72d48530-bbb0-11f0-875a-b322bf237aeb",
-      "endpoint_role": "create"
-    },
-    {
-      "id": "A9BBBC6E-49FE-4819-BE22-504FC54335F2",
-      "type": "IfElseBlock",
-      "disabled": false,
-      "name": "condition",
-      "displayName": "Condition",
-      "comment": "CONFIGURE: Workflow settings. Edit this section only.",
-      "childId": "F9DCB126-6ED4-4D9A-BF35-CFD7A6D9CECD",
-      "inputs": [
-        {
-          "id": "conditions",
-          "value": {
-            "mode": "all",
-            "conditions": [
+          "x": -2922,
+          "y": -2586,
+          "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
+          "endpoint_guid": "6e9dbaa0-c7a4-11ea-9bd3-0da55b4cbed9",
+          "endpoint_role": "get"
+      },
+      {
+          "id": "BB38C4E9-A2B4-428B-BAAF-903E14CB56B1",
+          "type": "EndpointBlock",
+          "disabled": false,
+          "name": "getUser",
+          "displayName": "Qlik Cloud Services - Get User",
+          "comment": "Get record for the current user.",
+          "childId": "43D8ED19-F455-48F9-9CC4-7FE2A93B1884",
+          "inputs": [
               {
-                "input1": "1",
-                "input2": null,
-                "operator": "isTrue"
+                  "id": "8eedf1d0-c7a5-11ea-9022-0fb2ce625902",
+                  "value": "{$.getCurrentUserId}",
+                  "type": "string",
+                  "structure": []
               }
-            ]
-          },
-          "type": "custom",
-          "structure": []
-        }
-      ],
-      "settings": [],
-      "collapsed": [
-        {
-          "name": "both",
-          "isCollapsed": false
-        },
-        {
-          "name": "yes",
-          "isCollapsed": false
-        },
-        {
-          "name": "no",
-          "isCollapsed": false
-        }
-      ],
-      "x": -2922,
-      "y": -3586,
-      "childTrueId": "2E327220-1609-47A0-8385-6B40E70A7CFB",
-      "childFalseId": null
-    },
-    {
-      "id": "A5B767E8-1450-43F7-9E7E-4471FBD5F282",
-      "type": "GotoBlock",
-      "disabled": false,
-      "name": "goToLabel7",
-      "displayName": "Go To Label 7",
-      "comment": "Go to the label named error.",
-      "childId": null,
-      "inputs": [
-        {
-          "id": "label",
-          "value": "EF82AD29-E2CF-44C9-A7DB-24C784618756",
-          "type": "select",
-          "displayValue": "error",
-          "structure": []
-        }
-      ],
-      "settings": [],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2802,
-      "y": 7114
-    },
-    {
-      "id": "D0CE93F3-2D1E-4F03-8384-E10EDA8D85F7",
-      "type": "VariableBlock",
-      "disabled": false,
-      "name": "errorDetail",
-      "displayName": "Variable - errorDetail",
-      "comment": "Variable to store detailed error message.",
-      "childId": "A5B767E8-1450-43F7-9E7E-4471FBD5F282",
-      "inputs": [],
-      "settings": [],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2802,
-      "y": 6994,
-      "variableGuid": "1BF2068B-106E-4D58-BC51-884F1810F03C",
-      "operations": [
-        {
-          "id": "set_value",
-          "key": "1BC10F4C-68C2-42E9-9000-25865B076073",
-          "name": "Set value of { variable }",
-          "value": "Exiting, data connections to REST data sources are disabled on the tenant. This prevents connectivity to tenant data. Enable REST data sources and then re-run the automation."
-        }
-      ]
-    },
-    {
-      "id": "71CF1DF2-EDD5-4BD0-859E-8B644FFA7552",
-      "type": "VariableBlock",
-      "disabled": false,
-      "name": "errorTitle",
-      "displayName": "Variable - errorTitle",
-      "comment": "Set error title for standard error output.",
-      "childId": "D0CE93F3-2D1E-4F03-8384-E10EDA8D85F7",
-      "inputs": [],
-      "settings": [],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2802,
-      "y": 6874,
-      "variableGuid": "407730A6-EC96-4337-BE80-CF4C0D552F08",
-      "operations": [
-        {
-          "id": "set_value",
-          "key": "1BC10F4C-68C2-42E9-9000-25865B076073",
-          "name": "Set value of { variable }",
-          "value": "REST connections are disabled on the tenant. Enable REST connector support and try again."
-        }
-      ]
-    },
-    {
-      "id": "2CE857A5-5770-4230-B4A7-E64B4B777B22",
-      "type": "IfElseBlock",
-      "disabled": false,
-      "name": "condition12",
-      "displayName": "Condition 12",
-      "comment": "If REST connector disabled, exit.",
-      "childId": "F718EF32-99B6-49C3-A5A5-6996F86B0B87",
-      "inputs": [
-        {
-          "id": "conditions",
-          "value": {
-            "mode": "all",
-            "conditions": [
+          ],
+          "settings": [
               {
-                "input1": "{ $.rawAPIRequest3.disabled }",
-                "input2": null,
-                "operator": "isTrue"
-              }
-            ]
-          },
-          "type": "custom",
-          "structure": []
-        }
-      ],
-      "settings": [],
-      "collapsed": [
-        {
-          "name": "both",
-          "isCollapsed": false
-        },
-        {
-          "name": "yes",
-          "isCollapsed": false
-        },
-        {
-          "name": "no",
-          "isCollapsed": false
-        }
-      ],
-      "x": -2922,
-      "y": 6794,
-      "childTrueId": "71CF1DF2-EDD5-4BD0-859E-8B644FFA7552",
-      "childFalseId": null
-    },
-    {
-      "id": "FA1DC448-EC02-4CDB-9A20-8E042259A14C",
-      "type": "ShowBlock",
-      "disabled": false,
-      "name": "output53",
-      "displayName": "Output 53",
-      "comment": "Status output.",
-      "childId": "215C3F93-2B59-4ADA-A98E-870483095D2C",
-      "inputs": [
-        {
-          "id": "input",
-          "value": "Complete!",
-          "type": "string",
-          "structure": []
-        }
-      ],
-      "settings": [
-        {
-          "id": "display_mode",
-          "value": "add",
-          "type": "select",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2922,
-      "y": 26974
-    },
-    {
-      "id": "215C3F93-2B59-4ADA-A98E-870483095D2C",
-      "type": "UpdateJobBlock",
-      "disabled": false,
-      "name": "updateRunTitle",
-      "displayName": "Update Run Title",
-      "comment": "Update the run title to include the monitoring app installation completion status.",
-      "childId": null,
-      "inputs": [
-        {
-          "id": "title",
-          "value": "Maintained apps: {implode: { $.monitoringAppsToInstall[*].name }, ', '}",
-          "type": "string",
-          "structure": []
-        }
-      ],
-      "settings": [
-        {
-          "id": "automations_censor_data",
-          "value": false,
-          "type": "checkbox",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2922,
-      "y": 27094
-    },
-    {
-      "id": "4D28FE57-54CB-4FA9-A5EE-A7C65992D3FD",
-      "type": "EndpointBlock",
-      "disabled": false,
-      "name": "listRoles",
-      "displayName": "Qlik Cloud Services - List Roles",
-      "comment": "Retrieve user default role configuration, required for checking for API key access.",
-      "childId": "192CAC57-0476-4EA6-9E3B-44900026EB88",
-      "inputs": [
-        {
-          "id": "61cc2ce0-eb31-11ed-8846-f774c9249948",
-          "value": "name eq \"UserDefault\"",
-          "type": "string",
-          "structure": []
-        }
-      ],
-      "settings": [
-        {
-          "id": "maxitemcount",
-          "value": "",
-          "type": "string",
-          "structure": []
-        },
-        {
-          "id": "blendr_on_error",
-          "value": "stop",
-          "type": "select",
-          "structure": []
-        },
-        {
-          "id": "cache",
-          "value": "0",
-          "type": "select",
-          "structure": []
-        },
-        {
-          "id": "automations_censor_data",
-          "value": false,
-          "type": "checkbox",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": false
-        }
-      ],
-      "x": -2922,
-      "y": 1034,
-      "loopBlockId": "76AA3D41-6FAE-4406-9AAD-67EA9C1B1E7D",
-      "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
-      "endpoint_guid": "61a20140-eb31-11ed-8f08-a515d1528437",
-      "endpoint_role": "list"
-    },
-    {
-      "id": "76AA3D41-6FAE-4406-9AAD-67EA9C1B1E7D",
-      "type": "VariableBlock",
-      "disabled": false,
-      "name": "userPermissions",
-      "displayName": "Variable - userPermissions",
-      "comment": "Add userDefault role to user permissions list.",
-      "childId": null,
-      "inputs": [],
-      "settings": [],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": false
-        }
-      ],
-      "x": -2802,
-      "y": 1134,
-      "variableGuid": "4283B5F6-E6C0-492F-AA5B-21195FFF74DF",
-      "operations": [
-        {
-          "id": "merge",
-          "key": "E08C7C2C-0351-4834-9C2B-8621AA9CCFB0",
-          "name": "Merge other list into { variable }",
-          "value": "{ $.listRoles.item.assignedScopes }"
-        }
-      ]
-    },
-    {
-      "id": "CA3E018B-042B-421C-9FFE-B53DFA5E392A",
-      "type": "EndpointBlock",
-      "disabled": false,
-      "name": "getApp",
-      "displayName": "Qlik Cloud Services - Get App",
-      "comment": "Retrieve the app definition since this format will match the published app format used in liveApps later. This is more reliable than calling items right after publishing.",
-      "childId": "F3CCCABB-3F06-47D2-B3A0-E018A8EAD140",
-      "inputs": [
-        {
-          "id": "dbeaab00-c7a5-11ea-9342-e9d6ce76e8f1",
-          "value": "{ $.loop3.item.resourceId }",
-          "type": "string",
-          "structure": []
-        }
-      ],
-      "settings": [
-        {
-          "id": "blendr_on_error",
-          "value": "stop",
-          "type": "select",
-          "structure": []
-        },
-        {
-          "id": "cache",
-          "value": "0",
-          "type": "select",
-          "structure": []
-        },
-        {
-          "id": "automations_censor_data",
-          "value": false,
-          "type": "checkbox",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": true
-        }
-      ],
-      "x": -2322,
-      "y": 17234,
-      "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
-      "endpoint_guid": "dbdc5470-c7a5-11ea-9135-b9442d1570d8",
-      "endpoint_role": "get"
-    },
-    {
-      "id": "D93CC85B-1E1E-4EE9-A2C4-D60FB7E19A92",
-      "type": "ForEachBlock",
-      "disabled": false,
-      "name": "loop9",
-      "displayName": "Loop 9",
-      "comment": "Loop - assignedGroups",
-      "childId": "CD1DE6F6-8F1B-43EE-9B1A-E1ED8E200416",
-      "inputs": [
-        {
-          "id": "input",
-          "value": "{ $.getUser.assignedGroups }",
-          "type": "string",
-          "structure": {}
-        }
-      ],
-      "settings": [
-        {
-          "id": "automations_censor_data",
-          "value": false,
-          "type": "checkbox",
-          "structure": {}
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": false
-        }
-      ],
-      "x": -2922,
-      "y": 134,
-      "loopBlockId": "EB88BBA6-62CF-4BE2-AE54-D656545BCDB8"
-    },
-    {
-      "id": "EB88BBA6-62CF-4BE2-AE54-D656545BCDB8",
-      "type": "ForEachBlock",
-      "disabled": false,
-      "name": "loop10",
-      "displayName": "Loop 10",
-      "comment": "Loop - group.assignedRoles",
-      "childId": null,
-      "inputs": [
-        {
-          "id": "input",
-          "value": "{ $.loop9.item.assignedRoles }",
-          "type": "string",
-          "structure": {}
-        }
-      ],
-      "settings": [
-        {
-          "id": "automations_censor_data",
-          "value": false,
-          "type": "checkbox",
-          "structure": {}
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": false
-        }
-      ],
-      "x": -2802,
-      "y": 234,
-      "loopBlockId": "19CC7B58-34C4-4762-A144-898EF788EA13"
-    },
-    {
-      "id": "19CC7B58-34C4-4762-A144-898EF788EA13",
-      "type": "VariableBlock",
-      "disabled": false,
-      "name": "userRoles#2",
-      "displayName": "Variable - userRoles 2",
-      "comment": "Collect all roles for API key access checks.",
-      "childId": null,
-      "inputs": [],
-      "settings": [],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": false
-        }
-      ],
-      "x": -2682,
-      "y": 334,
-      "variableGuid": "CD9F0C76-28B4-482E-A218-EDE5763F6807",
-      "operations": [
-        {
-          "key": "FF3F1190-B850-4D68-AFF6-CAE2EB644159",
-          "id": "add_item",
-          "name": "Add item to { variable }",
-          "value": "{object: '{\"id\":\"{ $.loop10.item.id }\",\"name\":\"{ $.loop10.item.name }\",\"type\":\"{ $.loop10.item.type }\",\"level\":\"{ $.loop10.item.level }\"}'}"
-        }
-      ]
-    },
-    {
-      "id": "3521F356-424C-44DE-8801-3042B0539E8D",
-      "type": "FormBlock",
-      "disabled": false,
-      "name": "inputs4",
-      "displayName": "Inputs 4",
-      "comment": "want to proceed with update?",
-      "childId": "ABF9478A-D559-4049-BA23-984416DB5D99",
-      "inputs": [],
-      "settings": [
-        {
-          "id": "persist_data",
-          "value": "no",
-          "type": "select",
-          "structure": []
-        },
-        {
-          "id": "automations_censor_data",
-          "value": false,
-          "type": "checkbox",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": false
-        }
-      ],
-      "x": -2802,
-      "y": -1466,
-      "form": [
-        {
-          "id": "inputs4-input-0",
-          "label": "Automatically update this automation?",
-          "helpText": "This will update the automation to the latest version of the Qlik Cloud Monitoring Apps deployer. Select Yes to proceed or No to cancel.",
-          "type": "select",
-          "values": "Yes,No",
-          "isRequired": true,
-          "options": {},
-          "order": 0
-        }
-      ],
-      "persistData": "no"
-    },
-    {
-      "id": "8F006B7D-F5B6-4BAA-8BFB-76D2B794E8AF",
-      "type": "ShowBlock",
-      "disabled": false,
-      "name": "output55",
-      "displayName": "Output 55",
-      "comment": "Ouptut - Upate needed",
-      "childId": "3521F356-424C-44DE-8801-3042B0539E8D",
-      "inputs": [
-        {
-          "id": "input",
-          "value": "## Upate needed!\n\nThis deployer template is version \"{$.currentTemplateVersionNum}\", which is less than the required version \"{$.callURL.installers[?(@.template=='qcmad')].version}\"",
-          "type": "string",
-          "structure": {}
-        }
-      ],
-      "settings": [
-        {
-          "id": "display_mode",
-          "value": "add",
-          "type": "select",
-          "structure": {}
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": false
-        }
-      ],
-      "x": -2802,
-      "y": -1586
-    },
-    {
-      "id": "ABF9478A-D559-4049-BA23-984416DB5D99",
-      "type": "IfElseBlock",
-      "disabled": false,
-      "name": "condition36",
-      "displayName": "Condition 36",
-      "comment": "Users answer",
-      "childId": null,
-      "inputs": [
-        {
-          "id": "conditions",
-          "value": {
-            "mode": "all",
-            "conditions": [
+                  "id": "blendr_on_error",
+                  "value": "stop",
+                  "type": "select",
+                  "structure": []
+              },
               {
-                "input1": "{ $.inputs4.'Automatically update this automation?' }",
-                "input2": "Yes",
-                "operator": "="
+                  "id": "cache",
+                  "value": "0",
+                  "type": "select",
+                  "structure": []
+              },
+              {
+                  "id": "automations_censor_data",
+                  "value": false,
+                  "type": "checkbox",
+                  "structure": []
               }
-            ]
-          },
-          "type": "custom",
-          "structure": []
-        }
-      ],
-      "settings": [],
-      "collapsed": [
-        {
-          "name": "both",
-          "isCollapsed": false
-        },
-        {
-          "name": "yes",
-          "isCollapsed": false
-        },
-        {
-          "name": "no",
-          "isCollapsed": false
-        }
-      ],
-      "x": -2802,
-      "y": -1346,
-      "childTrueId": "6DB0BCE2-239C-491D-89F1-6E9F63937F49",
-      "childFalseId": null
-    },
-    {
-      "id": "6DB0BCE2-239C-491D-89F1-6E9F63937F49",
-      "type": "CallUrlBlock",
-      "disabled": false,
-      "name": "callURL4",
-      "displayName": "Call URL 4",
-      "comment": "Get the current version ",
-      "childId": "1C53F6DA-FE4F-4BE3-8A95-82EF0EC3E288",
-      "inputs": [
-        {
-          "id": "url",
-          "value": "https://raw.githubusercontent.com/qlik-oss/qlik-cloud-monitoring-apps/main/automations/singleTenantDeployer.json",
-          "type": "string",
-          "structure": {}
-        },
-        {
-          "id": "method",
-          "value": "GET",
-          "type": "select",
-          "structure": {}
-        },
-        {
-          "id": "timeout",
-          "value": "",
-          "type": "string",
-          "structure": {}
-        },
-        {
-          "id": "params",
-          "value": null,
-          "type": "object",
-          "mode": "keyValue",
-          "structure": {}
-        },
-        {
-          "id": "headers",
-          "value": null,
-          "type": "object",
-          "mode": "keyValue",
-          "structure": {}
-        },
-        {
-          "id": "encoding",
-          "value": "",
-          "type": "string",
-          "structure": {}
-        }
-      ],
-      "settings": [
-        {
-          "id": "blendr_on_error",
-          "value": "stop",
-          "type": "select",
-          "structure": {}
-        },
-        {
-          "id": "full_response",
-          "value": null,
-          "type": "checkbox",
-          "structure": {}
-        },
-        {
-          "id": "capitalize_headers",
-          "value": true,
-          "type": "checkbox",
-          "structure": {}
-        },
-        {
-          "id": "automations_censor_data",
-          "value": false,
-          "type": "checkbox",
-          "structure": {}
-        }
-      ],
-      "collapsed": [
-        {
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": false
+              }
+          ],
+          "x": -2922,
+          "y": -2466,
+          "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
+          "endpoint_guid": "7e670290-c7a5-11ea-9a9c-6dd2b282df86",
+          "endpoint_role": "get"
+      },
+      {
+          "id": "E9A1664E-7B3A-4333-9DCA-65E34A43AD2D",
+          "type": "ShowBlock",
+          "disabled": false,
+          "name": "output2",
+          "displayName": "Output 2",
+          "comment": "Status output.",
+          "childId": "C199B1F5-97A8-493A-BA22-0632702923FD",
+          "inputs": [
+              {
+                  "id": "input",
+                  "value": "| Variable | Value |\n| -------- | ------- |\n| monitoringAppsToInstall | { implode: {$.configuredMonitoringApps}, ',' } |\n| refreshConnectorCredentials | {$.refreshConnectorCredentials} |\n| sharedSpaceName | {$.sharedSpaceName} |\n| managedSpaceName | {$.managedSpaceName} | \n| versionsToKeep | {$.versionsToKeep} |\n| Current User | {$.getUser.id} |\n| Tenant hostname | {$.tenantHostname} |\n| Template version | {$.currentTemplateVersionNum} |",
+                  "type": "string",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "display_mode",
+                  "value": "add",
+                  "type": "select",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": false
+              }
+          ],
+          "x": -2922,
+          "y": -1866
+      },
+      {
+          "id": "D0E7DF6C-C216-4DB6-8502-1F3C4ADF5AFE",
+          "type": "IfElseBlock",
+          "disabled": false,
+          "name": "condition3",
+          "displayName": "Condition 3",
+          "comment": "Ensures that the current user has the TenantAdmin role. This is required for license checks and the detail app.",
+          "childId": "948CF475-AF52-4C8B-AF9E-07DD7DE82F45",
+          "inputs": [
+              {
+                  "id": "conditions",
+                  "value": {
+                      "mode": "all",
+                      "conditions": [
+                          {
+                              "input1": "{$.getUser.assignedRoles[*].name}",
+                              "input2": "TenantAdmin",
+                              "operator": "notInList"
+                          },
+                          {
+                              "input1": "{$.getUser.assignedGroups[*].assignedRoles[*].name}",
+                              "input2": "TenantAdmin",
+                              "operator": "notInList"
+                          }
+                      ]
+                  },
+                  "type": "custom",
+                  "structure": []
+              }
+          ],
+          "settings": [],
+          "collapsed": [
+              {
+                  "name": "yes",
+                  "isCollapsed": false
+              },
+              {
+                  "name": "no",
+                  "isCollapsed": false
+              },
+              {
+                  "name": "both",
+                  "isCollapsed": false
+              }
+          ],
+          "x": -2922,
+          "y": -506,
+          "childTrueId": "BE7F53B8-B1FD-48DF-A8A5-D6638F74FA2C",
+          "childFalseId": null
+      },
+      {
+          "id": "9C6779A3-FFA8-49D8-B3AE-ADA3D57BA1D5",
+          "type": "EndpointBlock",
+          "disabled": false,
+          "name": "getLicenseOverview",
+          "displayName": "Qlik Cloud Services - Get License Overview",
+          "comment": "Get license to check for capacity-based flags.",
+          "childId": "6AB100F2-DB70-49EC-AA91-33C3F4639953",
+          "inputs": [],
+          "settings": [
+              {
+                  "id": "blendr_on_error",
+                  "value": "stop",
+                  "type": "select",
+                  "structure": []
+              },
+              {
+                  "id": "cache",
+                  "value": "0",
+                  "type": "select",
+                  "structure": []
+              },
+              {
+                  "id": "automations_censor_data",
+                  "value": false,
+                  "type": "checkbox",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": false
+              }
+          ],
+          "x": -2922,
+          "y": 1934,
+          "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
+          "endpoint_guid": "0e6d4530-3291-11ed-a2e9-3bc221fc190c",
+          "endpoint_role": "get"
+      },
+      {
+          "id": "6C0A56A0-B3A3-4740-858E-57ABB5BF2CAC",
+          "type": "ShowBlock",
+          "disabled": false,
+          "name": "output3",
+          "displayName": "Output 3",
+          "comment": "Status output.",
+          "childId": "7BB23A76-A47D-4859-AE1D-D5532E49031D",
+          "inputs": [
+              {
+                  "id": "input",
+                  "value": "## Deployment progress\n\nDeployment is in progress. Status will be updated below.\n\n| Step | Status |\n| -------- | ------- |",
+                  "type": "string",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "display_mode",
+                  "value": "add",
+                  "type": "select",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": false
+              }
+          ],
+          "x": -2922,
+          "y": 3654
+      },
+      {
+          "id": "F718EF32-99B6-49C3-A5A5-6996F86B0B87",
+          "type": "EndpointBlock",
+          "disabled": false,
+          "name": "searchSpaces",
+          "displayName": "Qlik Cloud Services - Search Spaces",
+          "comment": "Look for shared space.",
+          "childId": "FEA21EF3-D8E8-48DF-9013-8DC36FE5A54D",
+          "inputs": [
+              {
+                  "id": "592e21a0-6d2e-11eb-9985-3ff14fb3335f",
+                  "value": null,
+                  "type": "string",
+                  "structure": []
+              },
+              {
+                  "id": "5935dec0-6d2e-11eb-8365-ab8493d4c237",
+                  "value": null,
+                  "type": "string",
+                  "structure": []
+              },
+              {
+                  "id": "593c5340-6d2e-11eb-a82b-e17cfa6c8a6d",
+                  "value": null,
+                  "type": "string",
+                  "structure": []
+              },
+              {
+                  "id": "59429c60-6d2e-11eb-b7b1-e7ca1f22830c",
+                  "value": "{$.sharedSpaceName}",
+                  "type": "string",
+                  "structure": []
+              },
+              {
+                  "id": "5949c230-6d2e-11eb-b345-99be61e9908c",
+                  "value": null,
+                  "type": "string",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "maxitemcount",
+                  "value": "",
+                  "type": "string",
+                  "structure": []
+              },
+              {
+                  "id": "blendr_on_error",
+                  "value": "stop",
+                  "type": "select",
+                  "structure": []
+              },
+              {
+                  "id": "automations_censor_data",
+                  "value": false,
+                  "type": "checkbox",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": false
+              }
+          ],
+          "x": -2922,
+          "y": 7314,
+          "loopBlockId": null,
+          "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
+          "endpoint_guid": "590a1a20-6d2e-11eb-9714-df1bbaac055d",
+          "endpoint_role": "search"
+      },
+      {
+          "id": "FEA21EF3-D8E8-48DF-9013-8DC36FE5A54D",
+          "type": "VariableBlock",
+          "disabled": false,
+          "name": "sharedSpaceId",
+          "displayName": "Variable - sharedSpaceId",
+          "comment": "Initialise the variable.",
+          "childId": "34B88617-9583-4EA4-948E-D580D65F3C49",
+          "inputs": [],
+          "settings": [],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": false
+              }
+          ],
+          "x": -2922,
+          "y": 7474,
+          "variableGuid": "DE390532-B1F9-4098-BBE0-B7E6101BD502",
+          "operations": [
+              {
+                  "id": "empty",
+                  "key": "D491693B-F764-49C2-94C2-C893014C604B",
+                  "name": "Empty { variable }",
+                  "value": null
+              }
+          ]
+      },
+      {
+          "id": "EB27466E-BFCB-4FFC-8B1A-3AA517AB3F4F",
+          "type": "ShowBlock",
+          "disabled": false,
+          "name": "output6",
+          "displayName": "Output 6",
+          "comment": "Status output.",
+          "childId": "3C37421F-9C07-4344-AD2E-1022C48BADF9",
+          "inputs": [
+              {
+                  "id": "input",
+                  "value": "| Shared space lookup | Found {$.filterList4.item.type} space matching name [{$.sharedSpaceName}]({$.tenantHostname}analytics/catalog?space_filter={$.sharedSpaceId}). |",
+                  "type": "string",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "display_mode",
+                  "value": "add",
+                  "type": "select",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2802,
+          "y": 7814
+      },
+      {
+          "id": "34B88617-9583-4EA4-948E-D580D65F3C49",
+          "type": "FilterListBlock",
+          "disabled": false,
+          "name": "filterList4",
+          "displayName": "Filter over Qlik Cloud Services - Search Spaces - Filter List 4",
+          "comment": "Filter for exact name match for shared space.",
+          "childId": "E14426D0-F329-44A1-B59F-A27869D8920F",
+          "inputs": [
+              {
+                  "id": "list",
+                  "value": "{ $.searchSpaces }",
+                  "type": "string",
+                  "structure": []
+              },
+              {
+                  "id": "conditions",
+                  "value": {
+                      "mode": "all",
+                      "conditions": [
+                          {
+                              "input1": "name",
+                              "input2": "{$.sharedSpaceName}",
+                              "operator": "="
+                          }
+                      ]
+                  },
+                  "type": "custom",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "automations_censor_data",
+                  "value": false,
+                  "type": "checkbox",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": false
+              }
+          ],
+          "x": -2922,
+          "y": 7594,
+          "loopBlockId": "7E7CFBF2-F088-4F93-9BA8-DE932E22956E"
+      },
+      {
+          "id": "7E7CFBF2-F088-4F93-9BA8-DE932E22956E",
+          "type": "VariableBlock",
+          "disabled": false,
+          "name": "sharedSpaceId",
+          "displayName": "Variable - sharedSpaceId",
+          "comment": "Store shared space ID.",
+          "childId": "EB27466E-BFCB-4FFC-8B1A-3AA517AB3F4F",
+          "inputs": [],
+          "settings": [],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2802,
+          "y": 7694,
+          "variableGuid": "DE390532-B1F9-4098-BBE0-B7E6101BD502",
+          "operations": [
+              {
+                  "id": "set_value",
+                  "key": "112D67F1-764F-46E4-8CD8-79B8735F30E9",
+                  "name": "Set value of { variable }",
+                  "value": "{ $.filterList4.item.id }"
+              }
+          ]
+      },
+      {
+          "id": "3C37421F-9C07-4344-AD2E-1022C48BADF9",
+          "type": "IfElseBlock",
+          "disabled": false,
+          "name": "condition13",
+          "displayName": "Condition 13",
+          "comment": "If the space type is not shared, exit; otherwise, apply the Can Manage role.",
+          "childId": null,
+          "inputs": [
+              {
+                  "id": "conditions",
+                  "value": {
+                      "mode": "all",
+                      "conditions": [
+                          {
+                              "input1": "{$.filterList4[0].type}",
+                              "input2": "shared",
+                              "operator": "!="
+                          }
+                      ]
+                  },
+                  "type": "custom",
+                  "structure": []
+              }
+          ],
+          "settings": [],
+          "collapsed": [
+              {
+                  "name": "yes",
+                  "isCollapsed": true
+              },
+              {
+                  "name": "no",
+                  "isCollapsed": true
+              },
+              {
+                  "name": "both",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2802,
+          "y": 7934,
+          "childTrueId": "A29FDF70-7705-4848-B467-90DD6CD8F293",
+          "childFalseId": "EABD8111-E99F-4C5B-A67D-3D7F0ACE778E"
+      },
+      {
+          "id": "A29FDF70-7705-4848-B467-90DD6CD8F293",
+          "type": "VariableBlock",
+          "disabled": false,
+          "name": "errorTitle",
+          "displayName": "Variable - errorTitle",
+          "comment": "Set error title for standard error output.",
+          "childId": "6A1F7D55-1177-4CED-96ED-C5EAB1EF473C",
+          "inputs": [],
+          "settings": [],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2561,
+          "y": 7132,
+          "variableGuid": "407730A6-EC96-4337-BE80-CF4C0D552F08",
+          "operations": [
+              {
+                  "id": "set_value",
+                  "key": "1BC10F4C-68C2-42E9-9000-25865B076073",
+                  "name": "Set value of { variable }",
+                  "value": "A space of the wrong type was found with the configured shared space name."
+              }
+          ]
+      },
+      {
+          "id": "6A1F7D55-1177-4CED-96ED-C5EAB1EF473C",
+          "type": "VariableBlock",
+          "disabled": false,
+          "name": "errorDetail",
+          "displayName": "Variable - errorDetail",
+          "comment": "Variable to store detailed error message.",
+          "childId": "4B13B3CA-4EE2-4F26-A4E4-ECBE8AD13378",
+          "inputs": [],
+          "settings": [],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2561,
+          "y": 7252,
+          "variableGuid": "1BF2068B-106E-4D58-BC51-884F1810F03C",
+          "operations": [
+              {
+                  "id": "set_value",
+                  "key": "1BC10F4C-68C2-42E9-9000-25865B076073",
+                  "name": "Set value of { variable }",
+                  "value": "Exiting, an existing space with a type other than `shared` was found for the provided shared space name. Try another shared space name."
+              }
+          ]
+      },
+      {
+          "id": "4B13B3CA-4EE2-4F26-A4E4-ECBE8AD13378",
+          "type": "GotoBlock",
+          "disabled": false,
+          "name": "goToLabel8",
+          "displayName": "Go To Label 8",
+          "comment": "Go to the label named error.",
+          "childId": null,
+          "inputs": [
+              {
+                  "id": "label",
+                  "value": "EF82AD29-E2CF-44C9-A7DB-24C784618756",
+                  "type": "select",
+                  "displayValue": "error",
+                  "structure": []
+              }
+          ],
+          "settings": [],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2561,
+          "y": 7372
+      },
+      {
+          "id": "EF82AD29-E2CF-44C9-A7DB-24C784618756",
+          "type": "LabelBlock",
+          "disabled": false,
+          "name": "label",
+          "displayName": "Label - error",
+          "comment": "Standard error handler which provides standardized error output.",
+          "childId": "D46F6E49-3856-430B-A685-0A07984CDAEB",
+          "inputs": [
+              {
+                  "id": "name",
+                  "value": "error",
+                  "type": "string",
+                  "structure": []
+              }
+          ],
+          "settings": [],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -1219,
+          "y": -2915
+      },
+      {
+          "id": "EABD8111-E99F-4C5B-A67D-3D7F0ACE778E",
+          "type": "IfElseBlock",
+          "disabled": false,
+          "name": "condition14",
+          "displayName": "Condition 14",
+          "comment": "If not the owner, checks and updates the roles. ",
+          "childId": null,
+          "inputs": [
+              {
+                  "id": "conditions",
+                  "value": {
+                      "mode": "all",
+                      "conditions": [
+                          {
+                              "input1": "{ $.filterList4.item.ownerId }",
+                              "input2": "{ $.getCurrentUserId }",
+                              "operator": "!="
+                          }
+                      ]
+                  },
+                  "type": "custom",
+                  "structure": []
+              }
+          ],
+          "settings": [],
+          "collapsed": [
+              {
+                  "name": "yes",
+                  "isCollapsed": true
+              },
+              {
+                  "name": "no",
+                  "isCollapsed": true
+              },
+              {
+                  "name": "both",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2561,
+          "y": 7532,
+          "childTrueId": "478E6D39-A231-4808-A8C8-AEE1EDF3121E",
+          "childFalseId": "94B0A4B3-5C6A-4958-BF8D-622F72452977"
+      },
+      {
+          "id": "478E6D39-A231-4808-A8C8-AEE1EDF3121E",
+          "type": "EndpointBlock",
+          "disabled": false,
+          "name": "listMembersFromSpace",
+          "displayName": "Qlik Cloud Services - List Members From Space",
+          "comment": "Get a list of members in the shared space.",
+          "childId": "7CFB4DF1-CB8C-4302-AE53-73BCF1F8BFBC",
+          "inputs": [
+              {
+                  "id": "358ee8a0-6d34-11eb-b1f3-91a0d7274b22",
+                  "value": "{ $.sharedSpaceId }",
+                  "type": "string",
+                  "structure": []
+              },
+              {
+                  "id": "86f34440-dd7e-11ef-91d1-63f16d094078",
+                  "value": "{ $.getCurrentUserId }",
+                  "type": "string",
+                  "structure": []
+              },
+              {
+                  "id": "972a9800-dd7e-11ef-95ae-93a368f4ba58",
+                  "value": "9fecb2a0-dd7e-11ef-85d3-9f8aefa67848",
+                  "type": "select",
+                  "displayValue": "user",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "maxitemcount",
+                  "value": "",
+                  "type": "string",
+                  "structure": []
+              },
+              {
+                  "id": "blendr_on_error",
+                  "value": "stop",
+                  "type": "select",
+                  "structure": []
+              },
+              {
+                  "id": "cache",
+                  "value": "0",
+                  "type": "select",
+                  "structure": []
+              },
+              {
+                  "id": "automations_censor_data",
+                  "value": false,
+                  "type": "checkbox",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2441,
+          "y": 7612,
+          "loopBlockId": null,
+          "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
+          "endpoint_guid": "ffe6d930-6d33-11eb-ad8a-334e25c5e295",
+          "endpoint_role": "list"
+      },
+      {
+          "id": "7CFB4DF1-CB8C-4302-AE53-73BCF1F8BFBC",
+          "type": "IfElseBlock",
+          "disabled": false,
+          "name": "condition15",
+          "displayName": "Condition 15",
+          "comment": "If the user is found, update; otherwise, add the user to the shared space with the facilitator role.",
+          "childId": null,
+          "inputs": [
+              {
+                  "id": "conditions",
+                  "value": {
+                      "mode": "all",
+                      "conditions": [
+                          {
+                              "input1": "{count: {$.listMembersFromSpace}}",
+                              "input2": "1",
+                              "operator": "="
+                          }
+                      ]
+                  },
+                  "type": "custom",
+                  "structure": []
+              }
+          ],
+          "settings": [],
+          "collapsed": [
+              {
+                  "name": "yes",
+                  "isCollapsed": true
+              },
+              {
+                  "name": "no",
+                  "isCollapsed": true
+              },
+              {
+                  "name": "both",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2441,
+          "y": 7732,
+          "childTrueId": "35CB70BA-0EC6-4883-829C-D9EF6FB850F3",
+          "childFalseId": "463B5474-1CF6-490D-884A-0A2E6252F64F"
+      },
+      {
+          "id": "35CB70BA-0EC6-4883-829C-D9EF6FB850F3",
+          "type": "IfElseBlock",
+          "disabled": false,
+          "name": "condition16",
+          "displayName": "Condition 16",
+          "comment": "If the user does not have the facilitator role, add it.",
+          "childId": null,
+          "inputs": [
+              {
+                  "id": "conditions",
+                  "value": {
+                      "mode": "all",
+                      "conditions": [
+                          {
+                              "input1": "{$.listMembersFromSpace[0].roles}",
+                              "input2": "facilitator",
+                              "operator": "notInList"
+                          }
+                      ]
+                  },
+                  "type": "custom",
+                  "structure": []
+              }
+          ],
+          "settings": [],
+          "collapsed": [
+              {
+                  "name": "yes",
+                  "isCollapsed": true
+              },
+              {
+                  "name": "no",
+                  "isCollapsed": true
+              },
+              {
+                  "name": "both",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2321,
+          "y": 7812,
+          "childTrueId": "824F1EDD-71E4-4833-9634-D37637283AE0",
+          "childFalseId": "A99BD3FB-EB73-41C1-B684-FBFDB4CB6D28"
+      },
+      {
+          "id": "824F1EDD-71E4-4833-9634-D37637283AE0",
+          "type": "VariableBlock",
+          "disabled": false,
+          "name": "spaceRoles",
+          "displayName": "Variable - spaceRoles",
+          "comment": "List variable to add the facilitator role, along with the existing roles, to the user in the shared space.",
+          "childId": "B6226FFD-EC59-4DB5-91A6-A706091A4FD6",
+          "inputs": [],
+          "settings": [],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2201,
+          "y": 7892,
+          "variableGuid": "E413E2FB-E4E7-4AFF-8894-6D27792FA8D8",
+          "operations": [
+              {
+                  "id": "empty",
+                  "key": "9837B21E-F102-462E-A474-E0C7D78117CE",
+                  "name": "Empty { variable }",
+                  "value": null
+              },
+              {
+                  "id": "add_item",
+                  "key": "68A49E6D-72F7-47D1-BD36-892E32464CB5",
+                  "name": "Add item to { variable }",
+                  "value": "facilitator"
+              },
+              {
+                  "id": "merge",
+                  "key": "680DE388-428C-40C5-97E2-C4FB11F0930D",
+                  "name": "Merge other list into { variable }",
+                  "value": "{ $.listMembersFromSpace[0].roles }",
+                  "allow_duplicates": "no"
+              }
+          ]
+      },
+      {
+          "id": "B6226FFD-EC59-4DB5-91A6-A706091A4FD6",
+          "type": "EndpointBlock",
+          "disabled": false,
+          "name": "updateRolesOfMemberFromSpace",
+          "displayName": "Qlik Cloud Services - Update Roles Of Member From Space",
+          "comment": "Add the facilitator role to the user in the shared space.",
+          "childId": "E4CAC506-9BC8-4BDE-8F96-7A73212BB4B1",
+          "inputs": [
+              {
+                  "id": "8c6b43e0-6d42-11eb-85f6-917131a7d145",
+                  "value": "{$.sharedSpaceId}",
+                  "type": "string",
+                  "structure": []
+              },
+              {
+                  "id": "8c72c230-6d42-11eb-837d-b1e5663f20d2",
+                  "value": "{$.listMembersFromSpace[0].id}",
+                  "type": "string",
+                  "structure": []
+              },
+              {
+                  "id": "01ac8e60-6d43-11eb-9d02-4d69db8c0501",
+                  "value": "{json: {$.spaceRoles}}",
+                  "type": "string",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "blendr_on_error",
+                  "value": "stop",
+                  "type": "select",
+                  "structure": []
+              },
+              {
+                  "id": "automations_censor_data",
+                  "value": false,
+                  "type": "checkbox",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2201,
+          "y": 8012,
+          "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
+          "endpoint_guid": "8c54ade0-6d42-11eb-b3a8-75befcc89b0a",
+          "endpoint_role": "update"
+      },
+      {
+          "id": "E4CAC506-9BC8-4BDE-8F96-7A73212BB4B1",
+          "type": "ShowBlock",
+          "disabled": false,
+          "name": "output7",
+          "displayName": "Output 7",
+          "comment": "Status output.",
+          "childId": null,
+          "inputs": [
+              {
+                  "id": "input",
+                  "value": "| Shared space permissions | Added facilitator role to existing space assignment. |",
+                  "type": "string",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "display_mode",
+                  "value": "add",
+                  "type": "select",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2201,
+          "y": 8132
+      },
+      {
+          "id": "A99BD3FB-EB73-41C1-B684-FBFDB4CB6D28",
+          "type": "ShowBlock",
+          "disabled": false,
+          "name": "output8",
+          "displayName": "Output 8",
+          "comment": "Status output.",
+          "childId": null,
+          "inputs": [
+              {
+                  "id": "input",
+                  "value": "| Shared space permissions | No changes made. |",
+                  "type": "string",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "display_mode",
+                  "value": "add",
+                  "type": "select",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2201,
+          "y": 8292
+      },
+      {
+          "id": "463B5474-1CF6-490D-884A-0A2E6252F64F",
+          "type": "EndpointBlock",
+          "disabled": false,
+          "name": "addMemberToSpace",
+          "displayName": "Qlik Cloud Services - Add Member To Space",
+          "comment": "Add user with facilitator role.",
+          "childId": "D2438EC7-D532-4274-8D13-27C2EC31CAAE",
+          "inputs": [
+              {
+                  "id": "3162f740-6d33-11eb-a089-71f7ccab24b9",
+                  "value": "{$.sharedSpaceId}",
+                  "type": "string",
+                  "structure": []
+              },
+              {
+                  "id": "27499b00-6d31-11eb-bbe5-5b3db3c974dc",
+                  "value": "{$.getCurrentUserId}",
+                  "type": "string",
+                  "structure": []
+              },
+              {
+                  "id": "2751b870-6d31-11eb-9d77-41c5fae28bc5",
+                  "value": "[\"facilitator\"]",
+                  "type": "string",
+                  "structure": []
+              },
+              {
+                  "id": "275e2c50-6d31-11eb-8eeb-157347755492",
+                  "value": "aec7c5b0-6d32-11eb-a4b2-f5e181a2c241",
+                  "type": "select",
+                  "displayValue": "user",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "blendr_on_error",
+                  "value": "stop",
+                  "type": "select",
+                  "structure": []
+              },
+              {
+                  "id": "automations_censor_data",
+                  "value": false,
+                  "type": "checkbox",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2321,
+          "y": 8532,
+          "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
+          "endpoint_guid": "272d9c70-6d31-11eb-870f-67624392ed86",
+          "endpoint_role": "create"
+      },
+      {
+          "id": "D2438EC7-D532-4274-8D13-27C2EC31CAAE",
+          "type": "ShowBlock",
+          "disabled": false,
+          "name": "output9",
+          "displayName": "Output 9",
+          "comment": "Status output.",
+          "childId": null,
+          "inputs": [
+              {
+                  "id": "input",
+                  "value": "| Shared space permissions | Added user to shared space. |",
+                  "type": "string",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "display_mode",
+                  "value": "add",
+                  "type": "select",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2321,
+          "y": 8652
+      },
+      {
+          "id": "94B0A4B3-5C6A-4958-BF8D-622F72452977",
+          "type": "ShowBlock",
+          "disabled": false,
+          "name": "output10",
+          "displayName": "Output 10",
+          "comment": "Status output.",
+          "childId": null,
+          "inputs": [
+              {
+                  "id": "input",
+                  "value": "| Shared space permissions | Found user is owner of space, no permission updates required. |",
+                  "type": "string",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "display_mode",
+                  "value": "add",
+                  "type": "select",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2441,
+          "y": 8892
+      },
+      {
+          "id": "EF5E86CE-DE0B-4961-BD90-B7355163A6E9",
+          "type": "VariableBlock",
+          "disabled": false,
+          "name": "managedSpaceId",
+          "displayName": "Variable - managedSpaceId",
+          "comment": "Initialise the variable.",
+          "childId": "8B32EC24-AC36-47A1-B60B-2FC217B835E3",
+          "inputs": [],
+          "settings": [],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": false
+              }
+          ],
+          "x": -2922,
+          "y": 8294,
+          "variableGuid": "B6C34135-EF0E-42EF-AC0D-621D8A8A165D",
+          "operations": [
+              {
+                  "id": "empty",
+                  "key": "CFAB487E-9183-44D8-8990-4AD864BE24A2",
+                  "name": "Empty { variable }",
+                  "value": null
+              }
+          ]
+      },
+      {
+          "id": "EA734A3A-B6F0-47F4-BB88-4D3C1DCADBE2",
+          "type": "ErrorBlock",
+          "disabled": false,
+          "name": "error",
+          "displayName": "Error",
+          "comment": "Show the error message and stop the automation.",
+          "childId": null,
+          "inputs": [
+              {
+                  "id": "message",
+                  "value": "Error: { $.errorTitle }",
+                  "type": "string",
+                  "structure": []
+              },
+              {
+                  "id": "action",
+                  "value": "stop",
+                  "type": "select",
+                  "structure": []
+              }
+          ],
+          "settings": [],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -1219,
+          "y": -2555
+      },
+      {
+          "id": "E14426D0-F329-44A1-B59F-A27869D8920F",
+          "type": "EndpointBlock",
+          "disabled": false,
+          "name": "searchSpaces2",
+          "displayName": "Qlik Cloud Services - Search Spaces 2",
+          "comment": "Look for managed space.",
+          "childId": "EF5E86CE-DE0B-4961-BD90-B7355163A6E9",
+          "inputs": [
+              {
+                  "id": "592e21a0-6d2e-11eb-9985-3ff14fb3335f",
+                  "value": null,
+                  "type": "string",
+                  "structure": []
+              },
+              {
+                  "id": "5935dec0-6d2e-11eb-8365-ab8493d4c237",
+                  "value": null,
+                  "type": "string",
+                  "structure": []
+              },
+              {
+                  "id": "593c5340-6d2e-11eb-a82b-e17cfa6c8a6d",
+                  "value": null,
+                  "type": "string",
+                  "structure": []
+              },
+              {
+                  "id": "59429c60-6d2e-11eb-b7b1-e7ca1f22830c",
+                  "value": "{$.managedSpaceName}",
+                  "type": "string",
+                  "structure": []
+              },
+              {
+                  "id": "5949c230-6d2e-11eb-b345-99be61e9908c",
+                  "value": null,
+                  "type": "string",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "maxitemcount",
+                  "value": "",
+                  "type": "string",
+                  "structure": []
+              },
+              {
+                  "id": "blendr_on_error",
+                  "value": "stop",
+                  "type": "select",
+                  "structure": []
+              },
+              {
+                  "id": "automations_censor_data",
+                  "value": false,
+                  "type": "checkbox",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": false
+              }
+          ],
+          "x": -2922,
+          "y": 8134,
+          "loopBlockId": null,
+          "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
+          "endpoint_guid": "590a1a20-6d2e-11eb-9714-df1bbaac055d",
+          "endpoint_role": "search"
+      },
+      {
+          "id": "8B32EC24-AC36-47A1-B60B-2FC217B835E3",
+          "type": "FilterListBlock",
+          "disabled": false,
+          "name": "filterList5",
+          "displayName": "Filter over Qlik Cloud Services - Search Spaces 2 - Filter List 5",
+          "comment": "Filter for exact name match for managed space.",
+          "childId": "7C0C15A5-F334-4AD6-A9D4-C0AC674CC34B",
+          "inputs": [
+              {
+                  "id": "list",
+                  "value": "{ $.searchSpaces2 }",
+                  "type": "string",
+                  "structure": []
+              },
+              {
+                  "id": "conditions",
+                  "value": {
+                      "mode": "all",
+                      "conditions": [
+                          {
+                              "input1": "name",
+                              "input2": "{$.managedSpaceName}",
+                              "operator": "="
+                          }
+                      ]
+                  },
+                  "type": "custom",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "automations_censor_data",
+                  "value": false,
+                  "type": "checkbox",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": false
+              }
+          ],
+          "x": -2922,
+          "y": 8414,
+          "loopBlockId": "FCBE0570-D739-43D6-B0AD-B16A2DA6F28A"
+      },
+      {
+          "id": "FCBE0570-D739-43D6-B0AD-B16A2DA6F28A",
+          "type": "VariableBlock",
+          "disabled": false,
+          "name": "managedSpaceId",
+          "displayName": "Variable - managedSpaceId",
+          "comment": "Store managed space ID.",
+          "childId": "820347D1-83F1-4F4E-A9A3-AACE4DF3685E",
+          "inputs": [],
+          "settings": [],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2802,
+          "y": 8514,
+          "variableGuid": "B6C34135-EF0E-42EF-AC0D-621D8A8A165D",
+          "operations": [
+              {
+                  "id": "set_value",
+                  "key": "FF599B67-45E6-44E2-9966-4EEEE9F474D4",
+                  "name": "Set value of { variable }",
+                  "value": "{$.filterList5.item.id}"
+              }
+          ]
+      },
+      {
+          "id": "820347D1-83F1-4F4E-A9A3-AACE4DF3685E",
+          "type": "ShowBlock",
+          "disabled": false,
+          "name": "output11",
+          "displayName": "Output 11",
+          "comment": "Status output.",
+          "childId": "B35B33BE-B45B-4749-813C-64BA4AA4FA1D",
+          "inputs": [
+              {
+                  "id": "input",
+                  "value": "| Managed space lookup | Found {$.filterList5.item.type} space matching name [{$.managedSpaceName}]({$.tenantHostname}analytics/catalog?space_filter={$.managedSpaceId}). |",
+                  "type": "string",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "display_mode",
+                  "value": "add",
+                  "type": "select",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2802,
+          "y": 8634
+      },
+      {
+          "id": "B35B33BE-B45B-4749-813C-64BA4AA4FA1D",
+          "type": "IfElseBlock",
+          "disabled": false,
+          "name": "condition17",
+          "displayName": "Condition 17",
+          "comment": "If the space type is not managed, exit; otherwise, ensure that the publisher role is present.",
+          "childId": null,
+          "inputs": [
+              {
+                  "id": "conditions",
+                  "value": {
+                      "mode": "all",
+                      "conditions": [
+                          {
+                              "input1": "{$.filterList5[0].type}",
+                              "input2": "managed",
+                              "operator": "!="
+                          }
+                      ]
+                  },
+                  "type": "custom",
+                  "structure": []
+              }
+          ],
+          "settings": [],
+          "collapsed": [
+              {
+                  "name": "yes",
+                  "isCollapsed": false
+              },
+              {
+                  "name": "no",
+                  "isCollapsed": false
+              },
+              {
+                  "name": "both",
+                  "isCollapsed": false
+              }
+          ],
+          "x": -2802,
+          "y": 8754,
+          "childTrueId": "F0DEE5BC-C9A2-4F91-964A-EA7C64F90457",
+          "childFalseId": "2FDCB00D-3E41-4B95-A904-51DBFF7345AA"
+      },
+      {
+          "id": "F0DEE5BC-C9A2-4F91-964A-EA7C64F90457",
+          "type": "VariableBlock",
+          "disabled": false,
+          "name": "errorTitle",
+          "displayName": "Variable - errorTitle",
+          "comment": "Set error title for standard error output.",
+          "childId": "CDB7C2AB-E721-492F-9238-2A91F9B67CF2",
+          "inputs": [],
+          "settings": [],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2682,
+          "y": 8834,
+          "variableGuid": "407730A6-EC96-4337-BE80-CF4C0D552F08",
+          "operations": [
+              {
+                  "id": "set_value",
+                  "key": "1BC10F4C-68C2-42E9-9000-25865B076073",
+                  "name": "Set value of { variable }",
+                  "value": "A space of the wrong type was found with the configured managed space name."
+              }
+          ]
+      },
+      {
+          "id": "CDB7C2AB-E721-492F-9238-2A91F9B67CF2",
+          "type": "VariableBlock",
+          "disabled": false,
+          "name": "errorDetail",
+          "displayName": "Variable - errorDetail",
+          "comment": "Variable to store detailed error message.",
+          "childId": "1324CB60-D99D-4A46-AB5A-734A7B31D12B",
+          "inputs": [],
+          "settings": [],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2682,
+          "y": 8954,
+          "variableGuid": "1BF2068B-106E-4D58-BC51-884F1810F03C",
+          "operations": [
+              {
+                  "id": "set_value",
+                  "key": "1BC10F4C-68C2-42E9-9000-25865B076073",
+                  "name": "Set value of { variable }",
+                  "value": "Exiting, an existing space with a type other than `managed` was found for the provided managed space name. Try another managed space name."
+              }
+          ]
+      },
+      {
+          "id": "1324CB60-D99D-4A46-AB5A-734A7B31D12B",
+          "type": "GotoBlock",
+          "disabled": false,
+          "name": "goToLabel9",
+          "displayName": "Go To Label 9",
+          "comment": "Go to the label named error.",
+          "childId": null,
+          "inputs": [
+              {
+                  "id": "label",
+                  "value": "EF82AD29-E2CF-44C9-A7DB-24C784618756",
+                  "type": "select",
+                  "displayValue": "error",
+                  "structure": []
+              }
+          ],
+          "settings": [],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2682,
+          "y": 9074
+      },
+      {
+          "id": "2FDCB00D-3E41-4B95-A904-51DBFF7345AA",
+          "type": "IfElseBlock",
+          "disabled": false,
+          "name": "condition18",
+          "displayName": "Condition 18",
+          "comment": "If not the owner, check and update roles.",
+          "childId": null,
+          "inputs": [
+              {
+                  "id": "conditions",
+                  "value": {
+                      "mode": "all",
+                      "conditions": [
+                          {
+                              "input1": "{ $.filterList5.item.ownerId }",
+                              "input2": "{ $.getCurrentUserId }",
+                              "operator": "!="
+                          }
+                      ]
+                  },
+                  "type": "custom",
+                  "structure": []
+              }
+          ],
+          "settings": [],
+          "collapsed": [
+              {
+                  "name": "yes",
+                  "isCollapsed": false
+              },
+              {
+                  "name": "no",
+                  "isCollapsed": false
+              },
+              {
+                  "name": "both",
+                  "isCollapsed": false
+              }
+          ],
+          "x": -2682,
+          "y": 9234,
+          "childTrueId": "064FC5B0-AF19-4C57-B22A-E171D71F3643",
+          "childFalseId": "F37D6ACE-DF7C-4EB9-A990-E7DBCD31ABDF"
+      },
+      {
+          "id": "064FC5B0-AF19-4C57-B22A-E171D71F3643",
+          "type": "EndpointBlock",
+          "disabled": false,
+          "name": "listMembersFromSpace2",
+          "displayName": "Qlik Cloud Services - List Members From Space 2",
+          "comment": "Get a list of members in the managed space.",
+          "childId": "4C669FE6-61A1-402B-9A79-357A350E8030",
+          "inputs": [
+              {
+                  "id": "358ee8a0-6d34-11eb-b1f3-91a0d7274b22",
+                  "value": "{ $.managedSpaceId }",
+                  "type": "string",
+                  "structure": []
+              },
+              {
+                  "id": "86f34440-dd7e-11ef-91d1-63f16d094078",
+                  "value": "{ $.getCurrentUserId }",
+                  "type": "string",
+                  "structure": []
+              },
+              {
+                  "id": "972a9800-dd7e-11ef-95ae-93a368f4ba58",
+                  "value": "9fecb2a0-dd7e-11ef-85d3-9f8aefa67848",
+                  "type": "select",
+                  "displayValue": "user",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "maxitemcount",
+                  "value": "",
+                  "type": "string",
+                  "structure": []
+              },
+              {
+                  "id": "blendr_on_error",
+                  "value": "stop",
+                  "type": "select",
+                  "structure": []
+              },
+              {
+                  "id": "cache",
+                  "value": "0",
+                  "type": "select",
+                  "structure": []
+              },
+              {
+                  "id": "automations_censor_data",
+                  "value": false,
+                  "type": "checkbox",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": false
+              }
+          ],
+          "x": -2562,
+          "y": 9314,
+          "loopBlockId": null,
+          "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
+          "endpoint_guid": "ffe6d930-6d33-11eb-ad8a-334e25c5e295",
+          "endpoint_role": "list"
+      },
+      {
+          "id": "4C669FE6-61A1-402B-9A79-357A350E8030",
+          "type": "IfElseBlock",
+          "disabled": false,
+          "name": "condition19",
+          "displayName": "Condition 19",
+          "comment": "If the user is found, update; otherwise, create an assignment.",
+          "childId": null,
+          "inputs": [
+              {
+                  "id": "conditions",
+                  "value": {
+                      "mode": "all",
+                      "conditions": [
+                          {
+                              "input1": "{count: {$.listMembersFromSpace2}}",
+                              "input2": "1",
+                              "operator": "="
+                          }
+                      ]
+                  },
+                  "type": "custom",
+                  "structure": []
+              }
+          ],
+          "settings": [],
+          "collapsed": [
+              {
+                  "name": "yes",
+                  "isCollapsed": false
+              },
+              {
+                  "name": "no",
+                  "isCollapsed": false
+              },
+              {
+                  "name": "both",
+                  "isCollapsed": false
+              }
+          ],
+          "x": -2562,
+          "y": 9474,
+          "childTrueId": "D0EEE98C-7DA0-47F5-B8C6-31B0507505FD",
+          "childFalseId": "9CC93349-E133-4BCC-860C-7AAE4991A788"
+      },
+      {
+          "id": "D0EEE98C-7DA0-47F5-B8C6-31B0507505FD",
+          "type": "IfElseBlock",
+          "disabled": false,
+          "name": "condition20",
+          "displayName": "Condition 20",
+          "comment": "If the user does not have the facilitator and publisher roles, add them.",
+          "childId": null,
+          "inputs": [
+              {
+                  "id": "conditions",
+                  "value": {
+                      "mode": "some",
+                      "conditions": [
+                          {
+                              "input1": "{$.listMembersFromSpace2[0].roles}",
+                              "input2": "facilitator",
+                              "operator": "notInList"
+                          },
+                          {
+                              "input1": "{ $.listMembersFromSpace2[0].roles }",
+                              "input2": "publisher",
+                              "operator": "notInList"
+                          }
+                      ]
+                  },
+                  "type": "custom",
+                  "structure": []
+              }
+          ],
+          "settings": [],
+          "collapsed": [
+              {
+                  "name": "yes",
+                  "isCollapsed": false
+              },
+              {
+                  "name": "no",
+                  "isCollapsed": false
+              },
+              {
+                  "name": "both",
+                  "isCollapsed": false
+              }
+          ],
+          "x": -2442,
+          "y": 9554,
+          "childTrueId": "BE0D6DE8-CA32-466A-917B-40EA75EB91C9",
+          "childFalseId": "253E7602-5CB9-473C-A66A-ABB7711934A6"
+      },
+      {
+          "id": "BE0D6DE8-CA32-466A-917B-40EA75EB91C9",
+          "type": "VariableBlock",
+          "disabled": false,
+          "name": "spaceRoles",
+          "displayName": "Variable - spaceRoles",
+          "comment": "List variable to add facilitator and publisher roles along with the existing roles, to the user in the managed space.",
+          "childId": "759EE2C8-9EAF-4D15-9A14-D059BC43154C",
+          "inputs": [],
+          "settings": [],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2322,
+          "y": 9634,
+          "variableGuid": "E413E2FB-E4E7-4AFF-8894-6D27792FA8D8",
+          "operations": [
+              {
+                  "id": "empty",
+                  "key": "9837B21E-F102-462E-A474-E0C7D78117CE",
+                  "name": "Empty { variable }",
+                  "value": null
+              },
+              {
+                  "id": "add_item",
+                  "key": "68A49E6D-72F7-47D1-BD36-892E32464CB5",
+                  "name": "Add item to { variable }",
+                  "value": "facilitator"
+              },
+              {
+                  "id": "add_item",
+                  "key": "17E5F253-7880-4709-BD29-6CDBC72BC2C2",
+                  "name": "Add item to { variable }",
+                  "value": "publisher"
+              },
+              {
+                  "id": "merge",
+                  "key": "680DE388-428C-40C5-97E2-C4FB11F0930D",
+                  "name": "Merge other list into { variable }",
+                  "value": "{ $.listMembersFromSpace2[0].roles }",
+                  "allow_duplicates": "no"
+              }
+          ]
+      },
+      {
+          "id": "759EE2C8-9EAF-4D15-9A14-D059BC43154C",
+          "type": "EndpointBlock",
+          "disabled": false,
+          "name": "updateRolesOfMemberFromSpace2",
+          "displayName": "Qlik Cloud Services - Update Roles Of Member From Space 2",
+          "comment": "Add the facilitator and publisher roles to the user in the managed space.",
+          "childId": "3C75AC47-4371-4B5E-B512-BF7319CADCF4",
+          "inputs": [
+              {
+                  "id": "8c6b43e0-6d42-11eb-85f6-917131a7d145",
+                  "value": "{$.managedSpaceId}",
+                  "type": "string",
+                  "structure": []
+              },
+              {
+                  "id": "8c72c230-6d42-11eb-837d-b1e5663f20d2",
+                  "value": "{$.listMembersFromSpace2[0].id}",
+                  "type": "string",
+                  "structure": []
+              },
+              {
+                  "id": "01ac8e60-6d43-11eb-9d02-4d69db8c0501",
+                  "value": "{json: {$.spaceRoles}}",
+                  "type": "string",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "blendr_on_error",
+                  "value": "stop",
+                  "type": "select",
+                  "structure": []
+              },
+              {
+                  "id": "automations_censor_data",
+                  "value": false,
+                  "type": "checkbox",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2322,
+          "y": 9754,
+          "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
+          "endpoint_guid": "8c54ade0-6d42-11eb-b3a8-75befcc89b0a",
+          "endpoint_role": "update"
+      },
+      {
+          "id": "3C75AC47-4371-4B5E-B512-BF7319CADCF4",
+          "type": "ShowBlock",
+          "disabled": false,
+          "name": "output12",
+          "displayName": "Output 12",
+          "comment": "Status output.",
+          "childId": null,
+          "inputs": [
+              {
+                  "id": "input",
+                  "value": "| Managed space permissions | Added facilitator and publisher role to existing space assignment. |",
+                  "type": "string",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "display_mode",
+                  "value": "add",
+                  "type": "select",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2322,
+          "y": 9874
+      },
+      {
+          "id": "253E7602-5CB9-473C-A66A-ABB7711934A6",
+          "type": "ShowBlock",
+          "disabled": false,
+          "name": "output13",
+          "displayName": "Output 13",
+          "comment": "Status output.",
+          "childId": null,
+          "inputs": [
+              {
+                  "id": "input",
+                  "value": "| Managed space permissions | No changes made. |",
+                  "type": "string",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "display_mode",
+                  "value": "add",
+                  "type": "select",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2322,
+          "y": 10034
+      },
+      {
+          "id": "9CC93349-E133-4BCC-860C-7AAE4991A788",
+          "type": "EndpointBlock",
+          "disabled": false,
+          "name": "addMemberToSpace2",
+          "displayName": "Qlik Cloud Services - Add Member To Space 2",
+          "comment": "Add user with facilitator and publisher roles.",
+          "childId": "DD87C70B-9C4F-4DDF-9DFA-4515A73AD2DF",
+          "inputs": [
+              {
+                  "id": "3162f740-6d33-11eb-a089-71f7ccab24b9",
+                  "value": "{$.managedSpaceId}",
+                  "type": "string",
+                  "structure": []
+              },
+              {
+                  "id": "27499b00-6d31-11eb-bbe5-5b3db3c974dc",
+                  "value": "{$.getCurrentUserId}",
+                  "type": "string",
+                  "structure": []
+              },
+              {
+                  "id": "2751b870-6d31-11eb-9d77-41c5fae28bc5",
+                  "value": "[\"facilitator\",\"publisher\"]",
+                  "type": "string",
+                  "structure": []
+              },
+              {
+                  "id": "275e2c50-6d31-11eb-8eeb-157347755492",
+                  "value": "aec7c5b0-6d32-11eb-a4b2-f5e181a2c241",
+                  "type": "select",
+                  "displayValue": "user",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "blendr_on_error",
+                  "value": "stop",
+                  "type": "select",
+                  "structure": []
+              },
+              {
+                  "id": "automations_censor_data",
+                  "value": false,
+                  "type": "checkbox",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2442,
+          "y": 10274,
+          "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
+          "endpoint_guid": "272d9c70-6d31-11eb-870f-67624392ed86",
+          "endpoint_role": "create"
+      },
+      {
+          "id": "DD87C70B-9C4F-4DDF-9DFA-4515A73AD2DF",
+          "type": "ShowBlock",
+          "disabled": false,
+          "name": "output14",
+          "displayName": "Output 14",
+          "comment": "Status output.",
+          "childId": null,
+          "inputs": [
+              {
+                  "id": "input",
+                  "value": "| Managed space permissions | Added user to managed space. |",
+                  "type": "string",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "display_mode",
+                  "value": "add",
+                  "type": "select",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2442,
+          "y": 10394
+      },
+      {
+          "id": "F37D6ACE-DF7C-4EB9-A990-E7DBCD31ABDF",
+          "type": "ShowBlock",
+          "disabled": false,
+          "name": "output15",
+          "displayName": "Output 15",
+          "comment": "Status output.",
+          "childId": null,
+          "inputs": [
+              {
+                  "id": "input",
+                  "value": "| Managed space permissions | Found user is owner of space, no permission updates required. |",
+                  "type": "string",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "display_mode",
+                  "value": "add",
+                  "type": "select",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2562,
+          "y": 10634
+      },
+      {
+          "id": "7C0C15A5-F334-4AD6-A9D4-C0AC674CC34B",
+          "type": "IfElseBlock",
+          "disabled": false,
+          "name": "condition21",
+          "displayName": "Condition 21",
+          "comment": "If no shared space is found, create it.",
+          "childId": "230E3338-D040-459F-A88C-47CD38B6BD39",
+          "inputs": [
+              {
+                  "id": "conditions",
+                  "value": {
+                      "mode": "all",
+                      "conditions": [
+                          {
+                              "input1": "{$.sharedSpaceId}",
+                              "input2": null,
+                              "operator": "empty"
+                          }
+                      ]
+                  },
+                  "type": "custom",
+                  "structure": []
+              }
+          ],
+          "settings": [],
+          "collapsed": [
+              {
+                  "name": "yes",
+                  "isCollapsed": false
+              },
+              {
+                  "name": "no",
+                  "isCollapsed": false
+              },
+              {
+                  "name": "both",
+                  "isCollapsed": false
+              }
+          ],
+          "x": -2922,
+          "y": 10954,
+          "childTrueId": "A835D799-19FC-450D-BF01-88DB67C89291",
+          "childFalseId": null
+      },
+      {
+          "id": "A835D799-19FC-450D-BF01-88DB67C89291",
+          "type": "EndpointBlock",
+          "disabled": false,
+          "name": "createSpace",
+          "displayName": "Qlik Cloud Services - Create Space",
+          "comment": "Create shared space.",
+          "childId": "19A7E512-81F6-407C-B4F5-A537C5DA9597",
+          "inputs": [
+              {
+                  "id": "f0de69a0-6d24-11eb-8c07-ebadb5af2511",
+                  "value": "{$.sharedSpaceName}",
+                  "type": "string",
+                  "structure": []
+              },
+              {
+                  "id": "79771850-6d25-11eb-8021-177e65e81ac9",
+                  "value": "shared",
+                  "type": "select",
+                  "structure": []
+              },
+              {
+                  "id": "f0ecac30-6d24-11eb-a7b6-d15be2d36858",
+                  "value": "This space is managed by the Qlik Cloud monitoring app deployer automation. It contains staged monitoring applications which have been imported for publishing to a managed space. This space will contain n copies of each application, where n is the value set for versionsToKeep in the automation.",
+                  "type": "string",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "blendr_on_error",
+                  "value": "stop",
+                  "type": "select",
+                  "structure": []
+              },
+              {
+                  "id": "automations_censor_data",
+                  "value": false,
+                  "type": "checkbox",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2802,
+          "y": 11034,
+          "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
+          "endpoint_guid": "f0c14620-6d24-11eb-aa67-c519e2671d3d",
+          "endpoint_role": "create"
+      },
+      {
+          "id": "19A7E512-81F6-407C-B4F5-A537C5DA9597",
+          "type": "VariableBlock",
+          "disabled": false,
+          "name": "sharedSpaceId",
+          "displayName": "Variable - sharedSpaceId",
+          "comment": "Store the newly created shared space ID in this variable.",
+          "childId": "E43BB4EB-9F53-4ACA-9649-051763575EE8",
+          "inputs": [],
+          "settings": [],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2802,
+          "y": 11154,
+          "variableGuid": "DE390532-B1F9-4098-BBE0-B7E6101BD502",
+          "operations": [
+              {
+                  "id": "set_value",
+                  "key": "FF599B67-45E6-44E2-9966-4EEEE9F474D4",
+                  "name": "Set value of { variable }",
+                  "value": "{$.createSpace.id}"
+              }
+          ]
+      },
+      {
+          "id": "E43BB4EB-9F53-4ACA-9649-051763575EE8",
+          "type": "ShowBlock",
+          "disabled": false,
+          "name": "output16",
+          "displayName": "Output 16",
+          "comment": "Status output.",
+          "childId": null,
+          "inputs": [
+              {
+                  "id": "input",
+                  "value": "| Shared space created | Created space [{$.sharedSpaceName}]({$.tenantHostname}analytics/catalog?space_filter={$.sharedSpaceId}). |",
+                  "type": "string",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "display_mode",
+                  "value": "add",
+                  "type": "select",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2802,
+          "y": 11274
+      },
+      {
+          "id": "230E3338-D040-459F-A88C-47CD38B6BD39",
+          "type": "IfElseBlock",
+          "disabled": false,
+          "name": "condition22",
+          "displayName": "Condition 22",
+          "comment": "If a managed space is not found, create it.",
+          "childId": "F4D0DE07-AD02-4C58-9CEA-A3409E738389",
+          "inputs": [
+              {
+                  "id": "conditions",
+                  "value": {
+                      "mode": "all",
+                      "conditions": [
+                          {
+                              "input1": "{$.managedSpaceId}",
+                              "input2": null,
+                              "operator": "empty"
+                          }
+                      ]
+                  },
+                  "type": "custom",
+                  "structure": []
+              }
+          ],
+          "settings": [],
+          "collapsed": [
+              {
+                  "name": "yes",
+                  "isCollapsed": false
+              },
+              {
+                  "name": "no",
+                  "isCollapsed": false
+              },
+              {
+                  "name": "both",
+                  "isCollapsed": false
+              }
+          ],
+          "x": -2922,
+          "y": 11474,
+          "childTrueId": "ED0FFFF7-7BA3-4BC5-B2CC-37F2AE4C0408",
+          "childFalseId": null
+      },
+      {
+          "id": "ED0FFFF7-7BA3-4BC5-B2CC-37F2AE4C0408",
+          "type": "EndpointBlock",
+          "disabled": false,
+          "name": "createSpace2",
+          "displayName": "Qlik Cloud Services - Create Space 2",
+          "comment": "Create managed space.",
+          "childId": "74016C4D-50A2-4FE0-AB21-3021ED1C263F",
+          "inputs": [
+              {
+                  "id": "f0de69a0-6d24-11eb-8c07-ebadb5af2511",
+                  "value": "{$.managedSpaceName}",
+                  "type": "string",
+                  "structure": []
+              },
+              {
+                  "id": "79771850-6d25-11eb-8021-177e65e81ac9",
+                  "value": "managed",
+                  "type": "select",
+                  "structure": []
+              },
+              {
+                  "id": "f0ecac30-6d24-11eb-a7b6-d15be2d36858",
+                  "value": "This space is managed by the Qlik Cloud monitoring app deployer automation. It contains published monitoring applications for analysis. It is not recommended to manually modify the contents of this space.",
+                  "type": "string",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "blendr_on_error",
+                  "value": "stop",
+                  "type": "select",
+                  "structure": []
+              },
+              {
+                  "id": "automations_censor_data",
+                  "value": false,
+                  "type": "checkbox",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2802,
+          "y": 11554,
+          "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
+          "endpoint_guid": "f0c14620-6d24-11eb-aa67-c519e2671d3d",
+          "endpoint_role": "create"
+      },
+      {
+          "id": "74016C4D-50A2-4FE0-AB21-3021ED1C263F",
+          "type": "VariableBlock",
+          "disabled": false,
+          "name": "managedSpaceId",
+          "displayName": "Variable - managedSpaceId",
+          "comment": "Store the newly created managed space ID in this variable.",
+          "childId": "8EA716DA-A818-45D1-8D97-92171239EAE3",
+          "inputs": [],
+          "settings": [],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2802,
+          "y": 11674,
+          "variableGuid": "B6C34135-EF0E-42EF-AC0D-621D8A8A165D",
+          "operations": [
+              {
+                  "id": "set_value",
+                  "key": "FF599B67-45E6-44E2-9966-4EEEE9F474D4",
+                  "name": "Set value of { variable }",
+                  "value": "{$.createSpace2.id}"
+              }
+          ]
+      },
+      {
+          "id": "8EA716DA-A818-45D1-8D97-92171239EAE3",
+          "type": "ShowBlock",
+          "disabled": false,
+          "name": "output17",
+          "displayName": "Output 17",
+          "comment": "Status output.",
+          "childId": null,
+          "inputs": [
+              {
+                  "id": "input",
+                  "value": "| Managed space created | Created space [{$.managedSpaceName}]({$.tenantHostname}analytics/catalog?space_filter={$.managedSpaceId}). |",
+                  "type": "string",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "display_mode",
+                  "value": "add",
+                  "type": "select",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2802,
+          "y": 11794
+      },
+      {
+          "id": "4BE16981-95D8-4418-B598-B26CA6843820",
+          "type": "VariableBlock",
+          "disabled": false,
+          "name": "cleanupCounter",
+          "displayName": "Variable - cleanupCounter",
+          "comment": "Variable to get the number of deployed apps in the shared space. Initially set the value of this variable to 0.",
+          "childId": "5006AC77-27D1-4EA3-AF11-DA559F907DB8",
+          "inputs": [],
+          "settings": [],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2682,
+          "y": 23554,
+          "variableGuid": "F6ED0768-9852-46AF-B822-2172586824B7",
+          "operations": [
+              {
+                  "id": "set_value",
+                  "key": "0AA127FF-539F-4311-BF88-189CFE16CC39",
+                  "name": "Set value of { variable }",
+                  "value": "0"
+              }
+          ]
+      },
+      {
+          "id": "5006AC77-27D1-4EA3-AF11-DA559F907DB8",
+          "type": "EndpointBlock",
+          "disabled": false,
+          "name": "searchItems",
+          "displayName": "Qlik Cloud Services - Search Items",
+          "comment": "Find apps in the shared space with the app tag.",
+          "childId": null,
+          "inputs": [
+              {
+                  "id": "84bbcd50-6f72-11eb-8452-c12329f7d1be",
+                  "value": "-createdAt",
+                  "type": "select",
+                  "structure": []
+              },
+              {
+                  "id": "b9c76ec0-6f72-11eb-ba14-4f34b1e4e6b4",
+                  "value": "app",
+                  "type": "string",
+                  "structure": []
+              },
+              {
+                  "id": "49786610-6f73-11eb-8f0a-2348e669c251",
+                  "value": null,
+                  "type": "string",
+                  "structure": []
+              },
+              {
+                  "id": "58fafe70-6f73-11eb-a310-696500e924d6",
+                  "value": null,
+                  "type": "string",
+                  "structure": []
+              },
+              {
+                  "id": "6eb0af00-6f73-11eb-9663-9f0b522e183f",
+                  "value": "{$.sharedSpaceId}",
+                  "type": "string",
+                  "structure": []
+              },
+              {
+                  "id": "a80dbc80-6f76-11eb-9648-4d8865fc84c1",
+                  "value": null,
+                  "type": "select",
+                  "structure": []
+              },
+              {
+                  "id": "964119b0-6f77-11eb-a576-3bf4b006d432",
+                  "value": "{ $.taggerIds.appTag }",
+                  "type": "string",
+                  "structure": []
+              },
+              {
+                  "id": "a7cd85c0-6f77-11eb-8511-2ba53a2a2998",
+                  "value": null,
+                  "type": "string",
+                  "structure": []
+              },
+              {
+                  "id": "d9032100-6f77-11eb-bffb-9bf794dfe9c7",
+                  "value": null,
+                  "type": "string",
+                  "structure": []
+              },
+              {
+                  "id": "fe391860-6f77-11eb-9529-afce50ac48a4",
+                  "value": null,
+                  "type": "string",
+                  "structure": []
+              },
+              {
+                  "id": "212f52c0-6f78-11eb-b09f-1f3e59290268",
+                  "value": null,
+                  "type": "string",
+                  "structure": []
+              },
+              {
+                  "id": "338287a0-6f78-11eb-a90c-152f5cce262e",
+                  "value": null,
+                  "type": "string",
+                  "structure": []
+              },
+              {
+                  "id": "41938660-6f78-11eb-94e2-8b5fb7dad158",
+                  "value": null,
+                  "type": "string",
+                  "structure": []
+              },
+              {
+                  "id": "4dc17010-6f78-11eb-9894-abf8a46a596a",
+                  "value": null,
+                  "type": "string",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "maxitemcount",
+                  "value": "",
+                  "type": "string",
+                  "structure": []
+              },
+              {
+                  "id": "blendr_on_error",
+                  "value": "stop",
+                  "type": "select",
+                  "structure": []
+              },
+              {
+                  "id": "automations_censor_data",
+                  "value": false,
+                  "type": "checkbox",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": false
+              }
+          ],
+          "x": -2682,
+          "y": 23674,
+          "loopBlockId": "1B323E62-40BB-40D7-AD9A-D04DA4A5FFB6",
+          "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
+          "endpoint_guid": "84ad9050-6f72-11eb-aa08-a1dda4364ef5",
+          "endpoint_role": "search"
+      },
+      {
+          "id": "1B323E62-40BB-40D7-AD9A-D04DA4A5FFB6",
+          "type": "IfElseBlock",
+          "disabled": false,
+          "name": "condition33",
+          "displayName": "Condition 33",
+          "comment": "Delete if cleanupCounter value is greater than versionsToKeep value.",
+          "childId": "D5570044-9796-4DC7-81B6-C6D2F937FB1F",
+          "inputs": [
+              {
+                  "id": "conditions",
+                  "value": {
+                      "mode": "all",
+                      "conditions": [
+                          {
+                              "input1": "{$.cleanupCounter}",
+                              "input2": "{$.versionsToKeep}",
+                              "operator": ">="
+                          }
+                      ]
+                  },
+                  "type": "custom",
+                  "structure": []
+              }
+          ],
+          "settings": [],
+          "collapsed": [
+              {
+                  "name": "yes",
+                  "isCollapsed": false
+              },
+              {
+                  "name": "no",
+                  "isCollapsed": false
+              },
+              {
+                  "name": "both",
+                  "isCollapsed": false
+              }
+          ],
+          "x": -2562,
+          "y": 23774,
+          "childTrueId": "1C69733A-CADE-4901-9BC2-4CDA59A50DA2",
+          "childFalseId": null
+      },
+      {
+          "id": "1C69733A-CADE-4901-9BC2-4CDA59A50DA2",
+          "type": "EndpointBlock",
+          "disabled": false,
+          "name": "deleteApp",
+          "displayName": "Qlik Cloud Services - Delete App",
+          "comment": "Delete older version of app from the shared space.",
+          "childId": "27388F0E-6FFB-4D16-B4E5-08174412BC75",
+          "inputs": [
+              {
+                  "id": "fcd14a20-67b2-11eb-9f5e-9113990ec3b6",
+                  "value": "{$.searchItems.item.resourceAttributes.id}",
+                  "type": "string",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "blendr_on_error",
+                  "value": "stop",
+                  "type": "select",
+                  "structure": []
+              },
+              {
+                  "id": "automations_censor_data",
+                  "value": false,
+                  "type": "checkbox",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2442,
+          "y": 23854,
+          "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
+          "endpoint_guid": "fcc108b0-67b2-11eb-806a-3957ec36f31b",
+          "endpoint_role": "delete"
+      },
+      {
+          "id": "27388F0E-6FFB-4D16-B4E5-08174412BC75",
+          "type": "ShowBlock",
+          "disabled": false,
+          "name": "output44",
+          "displayName": "Output 44",
+          "comment": "Status output.",
+          "childId": null,
+          "inputs": [
+              {
+                  "id": "input",
+                  "value": "| {$.loop2.item.name} - Cleanup | > Configured to keep {$.versionsToKeep} apps, deleted app {add: {$.cleanupCounter}, 1} from shared space: [{$.searchItems.item.resourceAttributes.name}]. |",
+                  "type": "string",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "display_mode",
+                  "value": "add",
+                  "type": "select",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2442,
+          "y": 23974
+      },
+      {
+          "id": "D5570044-9796-4DC7-81B6-C6D2F937FB1F",
+          "type": "VariableBlock",
+          "disabled": false,
+          "name": "cleanupCounter",
+          "displayName": "Variable - cleanupCounter",
+          "comment": "Increment the variable by 1 to get the total count of apps that have been backed up in the shared space.",
+          "childId": null,
+          "inputs": [],
+          "settings": [],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2562,
+          "y": 24174,
+          "variableGuid": "F6ED0768-9852-46AF-B822-2172586824B7",
+          "operations": [
+              {
+                  "id": "add",
+                  "key": "5B03057A-3746-4B90-83B6-69A9F037542C",
+                  "name": "Add to { variable }",
+                  "value": "1"
+              }
+          ]
+      },
+      {
+          "id": "BE7F53B8-B1FD-48DF-A8A5-D6638F74FA2C",
+          "type": "VariableBlock",
+          "disabled": false,
+          "name": "errorTitle",
+          "displayName": "Variable - errorTitle",
+          "comment": "Set error title for standard error output.",
+          "childId": "A8F7B895-B7BB-4F7A-9189-B757D5A85B52",
+          "inputs": [],
+          "settings": [],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2802,
+          "y": -426,
+          "variableGuid": "407730A6-EC96-4337-BE80-CF4C0D552F08",
+          "operations": [
+              {
+                  "id": "set_value",
+                  "key": "1BC10F4C-68C2-42E9-9000-25865B076073",
+                  "name": "Set value of { variable }",
+                  "value": "Missing TenantAdmin role on executing user. Assign this role to your user and try again."
+              }
+          ]
+      },
+      {
+          "id": "A8F7B895-B7BB-4F7A-9189-B757D5A85B52",
+          "type": "VariableBlock",
+          "disabled": false,
+          "name": "errorDetail",
+          "displayName": "Variable - errorDetail",
+          "comment": "Variable to store detailed error message.",
+          "childId": "1D1FB21E-ADAA-4284-8526-5C849D304B59",
+          "inputs": [],
+          "settings": [],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2802,
+          "y": -306,
+          "variableGuid": "1BF2068B-106E-4D58-BC51-884F1810F03C",
+          "operations": [
+              {
+                  "id": "set_value",
+                  "key": "1BC10F4C-68C2-42E9-9000-25865B076073",
+                  "name": "Set value of { variable }",
+                  "value": "Exiting, could not find TenantAdmin role assigned to current user either via direct or group assignment."
+              }
+          ]
+      },
+      {
+          "id": "1D1FB21E-ADAA-4284-8526-5C849D304B59",
+          "type": "GotoBlock",
+          "disabled": false,
+          "name": "goToLabel2",
+          "displayName": "Go To Label 2",
+          "comment": "Go to the label named error.",
+          "childId": null,
+          "inputs": [
+              {
+                  "id": "label",
+                  "value": "EF82AD29-E2CF-44C9-A7DB-24C784618756",
+                  "type": "select",
+                  "displayValue": "error",
+                  "structure": []
+              }
+          ],
+          "settings": [],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2802,
+          "y": -186
+      },
+      {
+          "id": "D46F6E49-3856-430B-A685-0A07984CDAEB",
+          "type": "ShowBlock",
+          "disabled": false,
+          "name": "output54",
+          "displayName": "Output 54",
+          "comment": "Exit output.",
+          "childId": "D7265A2B-A82F-47D4-B7CA-83E0EA902FCF",
+          "inputs": [
+              {
+                  "id": "input",
+                  "value": "Error: { $.errorDetail }",
+                  "type": "string",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "display_mode",
+                  "value": "add",
+                  "type": "select",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -1219,
+          "y": -2795
+      },
+      {
+          "id": "D7265A2B-A82F-47D4-B7CA-83E0EA902FCF",
+          "type": "UpdateJobBlock",
+          "disabled": false,
+          "name": "updateRunTitle2",
+          "displayName": "Update Run Title 2",
+          "comment": "Update run title with the error message.",
+          "childId": "EA734A3A-B6F0-47F4-BB88-4D3C1DCADBE2",
+          "inputs": [
+              {
+                  "id": "title",
+                  "value": "Error: { $.errorTitle }",
+                  "type": "string",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "automations_censor_data",
+                  "value": false,
+                  "type": "checkbox",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -1219,
+          "y": -2675
+      },
+      {
+          "id": "43D8ED19-F455-48F9-9CC4-7FE2A93B1884",
+          "type": "EndpointBlock",
+          "disabled": false,
+          "name": "getCurrentTenantInfo",
+          "displayName": "Qlik Cloud Services - Get Current Tenant Info",
+          "comment": "Get record for the current tenant.",
+          "childId": "DD6471AE-35D5-4348-819C-90FB501F35CD",
+          "inputs": [],
+          "settings": [
+              {
+                  "id": "blendr_on_error",
+                  "value": "stop",
+                  "type": "select",
+                  "structure": []
+              },
+              {
+                  "id": "cache",
+                  "value": "0",
+                  "type": "select",
+                  "structure": []
+              },
+              {
+                  "id": "automations_censor_data",
+                  "value": false,
+                  "type": "checkbox",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": false
+              }
+          ],
+          "x": -2922,
+          "y": -2346,
+          "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
+          "endpoint_guid": "55051480-cb86-11ec-b746-892c1d04114e",
+          "endpoint_role": "get"
+      },
+      {
+          "id": "DD6471AE-35D5-4348-819C-90FB501F35CD",
+          "type": "VariableBlock",
+          "disabled": false,
+          "name": "tenantHostname",
+          "displayName": "Variable - tenantHostname",
+          "comment": "Determine tenant hostname. Use alias if available.",
+          "childId": "82CEC2F2-0C2A-438F-8D85-41BF9C90E37B",
+          "inputs": [],
+          "settings": [],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": false
+              }
+          ],
+          "x": -2922,
+          "y": -2226,
+          "variableGuid": "3723D829-3B14-4B68-AAFE-63966A7025E6",
+          "operations": [
+              {
+                  "id": "set_value",
+                  "key": "552A5562-F8C8-4C4C-AB89-C90BD892542E",
+                  "name": "Set value of { variable }",
+                  "value": "https://{if: { $.getCurrentTenantInfo.hostnames[1] } empty , $.getCurrentTenantInfo.hostnames[0], $.getCurrentTenantInfo.hostnames[1]}/"
+              }
+          ]
+      },
+      {
+          "id": "AABAC2BF-30E8-49FC-982B-52BD9707DAE0",
+          "type": "VariableBlock",
+          "disabled": false,
+          "name": "refreshConnectorCredentials",
+          "displayName": "Variable - refreshConnectorCredentials",
+          "comment": "Configure whether to refresh the REST credentials on every run. By default, it is set to 1, which will recreate the credentials each time. Set to 0 to leave the API keys unchanged.",
+          "childId": "2E61A575-F621-4713-B446-C1BAC52D8834",
+          "inputs": [],
+          "settings": [],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2802,
+          "y": -3386,
+          "variableGuid": "64E41053-153C-41E1-8E96-441CE6CCC379",
+          "operations": [
+              {
+                  "id": "set_value",
+                  "key": "2A53EE0E-A13C-45CD-9E07-D012532B33CA",
+                  "name": "Set value of { variable }",
+                  "value": "1"
+              }
+          ]
+      },
+      {
+          "id": "82CEC2F2-0C2A-438F-8D85-41BF9C90E37B",
+          "type": "VariableBlock",
+          "disabled": false,
+          "name": "currentTemplateVersionNum",
+          "displayName": "Variable - currentTemplateVersionNum",
+          "comment": "The current version number of this template",
+          "childId": "D7D4A126-BDC4-41D8-AB46-9D581AAE2FED",
+          "inputs": [],
+          "settings": [],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": false
+              }
+          ],
+          "x": -2922,
+          "y": -2106,
+          "variableGuid": "69E3DE89-62A4-4A45-A797-81D480D8BBC9",
+          "operations": [
+              {
+                  "id": "set_value",
+                  "key": "F54109D0-B3B3-4AB8-AB22-1E1379CCFA98",
+                  "name": "Set value of { variable }",
+                  "value": "3"
+              }
+          ]
+      },
+      {
+          "id": "D7D4A126-BDC4-41D8-AB46-9D581AAE2FED",
+          "type": "CallUrlBlock",
+          "disabled": false,
+          "name": "callURL",
+          "displayName": "Call URL",
+          "comment": "Retrieve installer manifest from Qlik to determine latest version of this automation.",
+          "childId": "E9A1664E-7B3A-4333-9DCA-65E34A43AD2D",
+          "inputs": [
+              {
+                  "id": "url",
+                  "value": "https://raw.githubusercontent.com/qlik-oss/qlik-cloud-monitoring-apps/main/manifests/installers.json",
+                  "type": "string",
+                  "structure": []
+              },
+              {
+                  "id": "method",
+                  "value": "GET",
+                  "type": "select",
+                  "structure": []
+              },
+              {
+                  "id": "timeout",
+                  "value": "",
+                  "type": "string",
+                  "structure": []
+              },
+              {
+                  "id": "params",
+                  "value": null,
+                  "type": "object",
+                  "mode": "keyValue",
+                  "structure": []
+              },
+              {
+                  "id": "headers",
+                  "value": null,
+                  "type": "object",
+                  "mode": "keyValue",
+                  "structure": []
+              },
+              {
+                  "id": "encoding",
+                  "value": "",
+                  "type": "string",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "blendr_on_error",
+                  "value": "stop",
+                  "type": "select",
+                  "structure": []
+              },
+              {
+                  "id": "full_response",
+                  "value": null,
+                  "type": "checkbox",
+                  "structure": []
+              },
+              {
+                  "id": "capitalize_headers",
+                  "value": true,
+                  "type": "checkbox",
+                  "structure": []
+              },
+              {
+                  "id": "automations_censor_data",
+                  "value": false,
+                  "type": "checkbox",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": false
+              }
+          ],
+          "x": -2922,
+          "y": -1986
+      },
+      {
+          "id": "C199B1F5-97A8-493A-BA22-0632702923FD",
+          "type": "IfElseBlock",
+          "disabled": false,
+          "name": "condition2",
+          "displayName": "Condition 2",
+          "comment": "If the automation version is greater than or equal to the manifest version.",
+          "childId": "D0E7DF6C-C216-4DB6-8502-1F3C4ADF5AFE",
+          "inputs": [
+              {
+                  "id": "conditions",
+                  "value": {
+                      "mode": "all",
+                      "conditions": [
+                          {
+                              "input1": "{ $.currentTemplateVersionNum }",
+                              "input2": "{ $.callURL.installers[?(@.template=='qcmad')].version }",
+                              "operator": ">="
+                          },
+                          {
+                              "input1": "{ $.callURL.installers[?(@.template=='qcmad')].version }",
+                              "input2": null,
+                              "operator": "notEmpty"
+                          }
+                      ]
+                  },
+                  "type": "custom",
+                  "structure": []
+              }
+          ],
+          "settings": [],
+          "collapsed": [
+              {
+                  "name": "both",
+                  "isCollapsed": false
+              },
+              {
+                  "name": "yes",
+                  "isCollapsed": false
+              },
+              {
+                  "name": "no",
+                  "isCollapsed": false
+              }
+          ],
+          "x": -2922,
+          "y": -1746,
+          "childTrueId": null,
+          "childFalseId": "8F006B7D-F5B6-4BAA-8BFB-76D2B794E8AF"
+      },
+      {
+          "id": "8C8FFCA6-849B-49E7-9852-7B0C074D6F65",
+          "type": "EndpointBlock",
+          "disabled": false,
+          "name": "rawAPIRequest",
+          "displayName": "Qlik Cloud Services - Raw API Request",
+          "comment": "Look up user by subject.",
+          "childId": "9C6779A3-FFA8-49D8-B3AE-ADA3D57BA1D5",
+          "inputs": [
+              {
+                  "id": "734cbcc0-bbb0-11f0-b998-f73920377683",
+                  "value": "v1/licenses/assignments",
+                  "type": "string",
+                  "structure": []
+              },
+              {
+                  "id": "7322a550-bbb0-11f0-9c8c-43f143a32456",
+                  "value": "7341e840-bbb0-11f0-9bb8-11c201f87b6d",
+                  "type": "select",
+                  "displayValue": "GET",
+                  "structure": []
+              },
+              {
+                  "id": "73000fe0-bbb0-11f0-8a80-59ece3571bd9",
+                  "value": null,
+                  "type": "object",
+                  "mode": "keyValue",
+                  "structure": []
+              },
+              {
+                  "id": "736fae60-bbb0-11f0-ad62-c98a0046f418",
+                  "value": [
+                      {
+                          "key": "filter",
+                          "value": "subject eq \"{regexreplace: { $.getUser.subject }, '(\\\\)', '\\\\\\\\'}\""
+                      }
+                  ],
+                  "type": "object",
+                  "mode": "keyValue",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "blendr_on_error",
+                  "value": "stop",
+                  "type": "select",
+                  "structure": []
+              },
+              {
+                  "id": "automations_censor_data",
+                  "value": false,
+                  "type": "checkbox",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": false
+              }
+          ],
+          "x": -2922,
+          "y": 1814,
+          "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
+          "endpoint_guid": "72d48530-bbb0-11f0-875a-b322bf237aeb",
+          "endpoint_role": "create"
+      },
+      {
+          "id": "F893CB46-17A5-4082-BB7B-5564538B5F8B",
+          "type": "IfElseBlock",
+          "disabled": false,
+          "name": "condition5",
+          "displayName": "Condition 5",
+          "comment": "If not a capacity product, fail if user doesn't have a professional license as we cannot guarantee these can be auto assigned.",
+          "childId": "6DA24FBE-A1C7-4EF8-85CA-9C796A00B84D",
+          "inputs": [
+              {
+                  "id": "conditions",
+                  "value": {
+                      "mode": "all",
+                      "conditions": [
+                          {
+                              "input1": "{ $.rawAPIRequest.data[*].type }",
+                              "input2": "professional",
+                              "operator": "notInList"
+                          },
+                          {
+                              "input1": "{ $.isCapacityTenant }",
+                              "input2": "0",
+                              "operator": "="
+                          }
+                      ]
+                  },
+                  "type": "custom",
+                  "structure": []
+              }
+          ],
+          "settings": [],
+          "collapsed": [
+              {
+                  "name": "both",
+                  "isCollapsed": false
+              },
+              {
+                  "name": "yes",
+                  "isCollapsed": false
+              },
+              {
+                  "name": "no",
+                  "isCollapsed": false
+              }
+          ],
+          "x": -2922,
+          "y": 2174,
+          "childTrueId": "D115A0F9-A1B3-4483-8169-145D1F47A9B1",
+          "childFalseId": null
+      },
+      {
+          "id": "D115A0F9-A1B3-4483-8169-145D1F47A9B1",
+          "type": "VariableBlock",
+          "disabled": false,
+          "name": "errorTitle",
+          "displayName": "Variable - errorTitle",
+          "comment": "Set error title for standard error output.",
+          "childId": "6064DA9A-04D6-49DD-B223-C3752D3769F4",
+          "inputs": [],
+          "settings": [],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2802,
+          "y": 2254,
+          "variableGuid": "407730A6-EC96-4337-BE80-CF4C0D552F08",
+          "operations": [
+              {
+                  "id": "set_value",
+                  "key": "1BC10F4C-68C2-42E9-9000-25865B076073",
+                  "name": "Set value of { variable }",
+                  "value": "Missing professional entitlement on executing user. Ensure a professional entitlement is assigned to your user and try again."
+              }
+          ]
+      },
+      {
+          "id": "6064DA9A-04D6-49DD-B223-C3752D3769F4",
+          "type": "VariableBlock",
+          "disabled": false,
+          "name": "errorDetail",
+          "displayName": "Variable - errorDetail",
+          "comment": "Variable to store detailed error message.",
+          "childId": "F81EA66B-BC74-4856-AE46-4B9C1D64A6AE",
+          "inputs": [],
+          "settings": [],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2802,
+          "y": 2374,
+          "variableGuid": "1BF2068B-106E-4D58-BC51-884F1810F03C",
+          "operations": [
+              {
+                  "id": "set_value",
+                  "key": "1BC10F4C-68C2-42E9-9000-25865B076073",
+                  "name": "Set value of { variable }",
+                  "value": "Exiting, could not find a professional entitlement assigned to current user. Please assign a professional entitlement to your user. A log out may be required to clear caches."
+              }
+          ]
+      },
+      {
+          "id": "F81EA66B-BC74-4856-AE46-4B9C1D64A6AE",
+          "type": "GotoBlock",
+          "disabled": false,
+          "name": "goToLabel4",
+          "displayName": "Go To Label 4",
+          "comment": "Go to the label named error.",
+          "childId": null,
+          "inputs": [
+              {
+                  "id": "label",
+                  "value": "EF82AD29-E2CF-44C9-A7DB-24C784618756",
+                  "type": "select",
+                  "displayValue": "error",
+                  "structure": []
+              }
+          ],
+          "settings": [],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2802,
+          "y": 2494
+      },
+      {
+          "id": "948CF475-AF52-4C8B-AF9E-07DD7DE82F45",
+          "type": "VariableBlock",
+          "disabled": false,
+          "name": "userRoles",
+          "displayName": "Variable - userRoles",
+          "comment": "Collect all roles for API key access checks.",
+          "childId": "D93CC85B-1E1E-4EE9-A2C4-D60FB7E19A92",
+          "inputs": [],
+          "settings": [],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": false
+              }
+          ],
+          "x": -2922,
+          "y": 14,
+          "variableGuid": "CD9F0C76-28B4-482E-A218-EDE5763F6807",
+          "operations": [
+              {
+                  "id": "merge",
+                  "key": "1835DD18-E922-44C8-B5B7-CE7182E56679",
+                  "name": "Merge other list into { variable }",
+                  "value": "{ $.getUser.assignedRoles }"
+              }
+          ]
+      },
+      {
+          "id": "3F9D73BE-55D6-406B-B9DE-D518B12BAA4E",
+          "type": "FilterListBlock",
+          "disabled": false,
+          "name": "filterList",
+          "displayName": "Filter List",
+          "comment": "Loop over custom roles to build list of permissions.",
+          "childId": "4D28FE57-54CB-4FA9-A5EE-A7C65992D3FD",
+          "inputs": [
+              {
+                  "id": "list",
+                  "value": "{ $.userRoles }",
+                  "type": "string",
+                  "structure": []
+              },
+              {
+                  "id": "conditions",
+                  "value": {
+                      "mode": "all",
+                      "conditions": [
+                          {
+                              "input1": "type",
+                              "input2": "custom",
+                              "operator": "="
+                          }
+                      ]
+                  },
+                  "type": "custom",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "automations_censor_data",
+                  "value": false,
+                  "type": "checkbox",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": false
+              }
+          ],
+          "x": -2922,
+          "y": 654,
+          "loopBlockId": "73CC9998-44BE-4947-9526-54DE0D4A39C4"
+      },
+      {
+          "id": "73CC9998-44BE-4947-9526-54DE0D4A39C4",
+          "type": "EndpointBlock",
+          "disabled": false,
+          "name": "getRole",
+          "displayName": "Qlik Cloud Services - Get Role",
+          "comment": "Get details of a specific role.",
+          "childId": "652F5F89-37E7-4AB8-96DA-F3A3A9242C95",
+          "inputs": [
+              {
+                  "id": "b537b230-3702-11f0-a5a5-6dd4cd401495",
+                  "value": "{ $.filterList.item.id }",
+                  "type": "string",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "blendr_on_error",
+                  "value": "stop",
+                  "type": "select",
+                  "structure": []
+              },
+              {
+                  "id": "cache",
+                  "value": "0",
+                  "type": "select",
+                  "structure": []
+              },
+              {
+                  "id": "automations_censor_data",
+                  "value": false,
+                  "type": "checkbox",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2802,
+          "y": 754,
+          "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
+          "endpoint_guid": "76c4e5d0-3702-11f0-bd5c-8b8be373d450",
+          "endpoint_role": "get"
+      },
+      {
+          "id": "CD1DE6F6-8F1B-43EE-9B1A-E1ED8E200416",
+          "type": "VariableBlock",
+          "disabled": false,
+          "name": "userPermissions",
+          "displayName": "Variable - userPermissions",
+          "comment": "Empty user permissions list.",
+          "childId": "3F9D73BE-55D6-406B-B9DE-D518B12BAA4E",
+          "inputs": [],
+          "settings": [],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": false
+              }
+          ],
+          "x": -2922,
+          "y": 534,
+          "variableGuid": "4283B5F6-E6C0-492F-AA5B-21195FFF74DF",
+          "operations": [
+              {
+                  "id": "empty",
+                  "key": "5CA3D3DF-A8A6-4787-BE09-8DC63ADBF31C",
+                  "name": "Empty { variable }",
+                  "value": null
+              }
+          ]
+      },
+      {
+          "id": "652F5F89-37E7-4AB8-96DA-F3A3A9242C95",
+          "type": "VariableBlock",
+          "disabled": false,
+          "name": "userPermissions",
+          "displayName": "Variable - userPermissions",
+          "comment": "Add to user permissions list.",
+          "childId": null,
+          "inputs": [],
+          "settings": [],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2802,
+          "y": 874,
+          "variableGuid": "4283B5F6-E6C0-492F-AA5B-21195FFF74DF",
+          "operations": [
+              {
+                  "id": "merge",
+                  "key": "E08C7C2C-0351-4834-9C2B-8621AA9CCFB0",
+                  "name": "Merge other list into { variable }",
+                  "value": "{ $.getRole.assignedScopes }"
+              }
+          ]
+      },
+      {
+          "id": "192CAC57-0476-4EA6-9E3B-44900026EB88",
+          "type": "IfElseBlock",
+          "disabled": false,
+          "name": "condition4",
+          "displayName": "Condition 4",
+          "comment": "If api-keys permission not present, exit.",
+          "childId": "8C8FFCA6-849B-49E7-9852-7B0C074D6F65",
+          "inputs": [
+              {
+                  "id": "conditions",
+                  "value": {
+                      "mode": "all",
+                      "conditions": [
+                          {
+                              "input1": "{ $.userPermissions }",
+                              "input2": "api-keys",
+                              "operator": "doesntContain"
+                          }
+                      ]
+                  },
+                  "type": "custom",
+                  "structure": []
+              }
+          ],
+          "settings": [],
+          "collapsed": [
+              {
+                  "name": "both",
+                  "isCollapsed": false
+              },
+              {
+                  "name": "yes",
+                  "isCollapsed": false
+              },
+              {
+                  "name": "no",
+                  "isCollapsed": false
+              }
+          ],
+          "x": -2922,
+          "y": 1294,
+          "childTrueId": "85BD0C04-9778-4A9E-A153-DE2A74C1CE3B",
+          "childFalseId": null
+      },
+      {
+          "id": "85BD0C04-9778-4A9E-A153-DE2A74C1CE3B",
+          "type": "VariableBlock",
+          "disabled": false,
+          "name": "errorTitle",
+          "displayName": "Variable - errorTitle",
+          "comment": "Set error title for standard error output.",
+          "childId": "0C31D3FC-EAF9-4A51-B843-F7E4F7817619",
+          "inputs": [],
+          "settings": [],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2802,
+          "y": 1374,
+          "variableGuid": "407730A6-EC96-4337-BE80-CF4C0D552F08",
+          "operations": [
+              {
+                  "id": "set_value",
+                  "key": "1BC10F4C-68C2-42E9-9000-25865B076073",
+                  "name": "Set value of { variable }",
+                  "value": "Missing api-keys permission on executing user. Assign this permission and try again."
+              }
+          ]
+      },
+      {
+          "id": "0C31D3FC-EAF9-4A51-B843-F7E4F7817619",
+          "type": "VariableBlock",
+          "disabled": false,
+          "name": "errorDetail",
+          "displayName": "Variable - errorDetail",
+          "comment": "Variable to store detailed error message.",
+          "childId": "EBC4167E-EF3B-4828-B452-457EB4B11613",
+          "inputs": [],
+          "settings": [],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2802,
+          "y": 1494,
+          "variableGuid": "1BF2068B-106E-4D58-BC51-884F1810F03C",
+          "operations": [
+              {
+                  "id": "set_value",
+                  "key": "1BC10F4C-68C2-42E9-9000-25865B076073",
+                  "name": "Set value of { variable }",
+                  "value": "Exiting, could not find the `api-keys` permission assigned to current user. Please either add this permission to a custom role and assign that to your user, or allow this permission for all users. Formerly, access to API keys was controlled by the `Developer` role, which is deprecated. A log out may be required to clear caches."
+              }
+          ]
+      },
+      {
+          "id": "EBC4167E-EF3B-4828-B452-457EB4B11613",
+          "type": "GotoBlock",
+          "disabled": false,
+          "name": "goToLabel3",
+          "displayName": "Go To Label 3",
+          "comment": "Go to the label named error.",
+          "childId": null,
+          "inputs": [
+              {
+                  "id": "label",
+                  "value": "EF82AD29-E2CF-44C9-A7DB-24C784618756",
+                  "type": "select",
+                  "displayValue": "error",
+                  "structure": []
+              }
+          ],
+          "settings": [],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2802,
+          "y": 1614
+      },
+      {
+          "id": "6DA24FBE-A1C7-4EF8-85CA-9C796A00B84D",
+          "type": "EndpointBlock",
+          "disabled": false,
+          "name": "rawAPIRequest2",
+          "displayName": "Qlik Cloud Services - Raw API Request 2",
+          "comment": "Get API key settings for max expiry.",
+          "childId": "60DC4193-EAC7-4353-86C5-C9233AF169EA",
+          "inputs": [
+              {
+                  "id": "734cbcc0-bbb0-11f0-b998-f73920377683",
+                  "value": "v1/api-keys/configs/{$.getCurrentTenantInfo.id}",
+                  "type": "string",
+                  "structure": []
+              },
+              {
+                  "id": "7322a550-bbb0-11f0-9c8c-43f143a32456",
+                  "value": "7341e840-bbb0-11f0-9bb8-11c201f87b6d",
+                  "type": "select",
+                  "displayValue": "GET",
+                  "structure": []
+              },
+              {
+                  "id": "73000fe0-bbb0-11f0-8a80-59ece3571bd9",
+                  "value": null,
+                  "type": "object",
+                  "mode": "keyValue",
+                  "structure": []
+              },
+              {
+                  "id": "736fae60-bbb0-11f0-ad62-c98a0046f418",
+                  "value": null,
+                  "type": "object",
+                  "mode": "keyValue",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "blendr_on_error",
+                  "value": "stop",
+                  "type": "select",
+                  "structure": []
+              },
+              {
+                  "id": "automations_censor_data",
+                  "value": false,
+                  "type": "checkbox",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": false
+              }
+          ],
+          "x": -2922,
+          "y": 2694,
+          "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
+          "endpoint_guid": "72d48530-bbb0-11f0-875a-b322bf237aeb",
+          "endpoint_role": "create"
+      },
+      {
+          "id": "E98AA699-4CAD-416D-81EF-A97EB737FD6C",
+          "type": "IfElseBlock",
+          "disabled": false,
+          "name": "condition6",
+          "displayName": "Condition 6",
+          "comment": "For tenants using the deprecated API key toggle, are API keys enabled on the tenant? (Qlik internal reference: TLV-750)",
+          "childId": "F959E5AA-4EC0-4284-AA66-F59C788B6B08",
+          "inputs": [
+              {
+                  "id": "conditions",
+                  "value": {
+                      "mode": "some",
+                      "conditions": [
+                          {
+                              "input1": "{$.rawAPIRequest2.api_keys_enabled}",
+                              "input2": "true",
+                              "operator": "isTrue"
+                          },
+                          {
+                              "input1": "{ textlength: {$.rawAPIRequest2.api_keys_enabled} }",
+                              "input2": "0",
+                              "operator": "="
+                          }
+                      ]
+                  },
+                  "type": "custom",
+                  "structure": []
+              }
+          ],
+          "settings": [],
+          "collapsed": [
+              {
+                  "name": "both",
+                  "isCollapsed": false
+              },
+              {
+                  "name": "yes",
+                  "isCollapsed": false
+              },
+              {
+                  "name": "no",
+                  "isCollapsed": false
+              }
+          ],
+          "x": -2922,
+          "y": 2934,
+          "childTrueId": null,
+          "childFalseId": "D31546CE-90C1-43CA-9A5E-10B35DDE0BFE"
+      },
+      {
+          "id": "D31546CE-90C1-43CA-9A5E-10B35DDE0BFE",
+          "type": "VariableBlock",
+          "disabled": false,
+          "name": "errorTitle",
+          "displayName": "Variable - errorTitle",
+          "comment": "Set error title for standard error output.",
+          "childId": "D25BBAB7-8646-46AC-BC9B-D512B163DE2A",
+          "inputs": [],
+          "settings": [],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2802,
+          "y": 3094,
+          "variableGuid": "407730A6-EC96-4337-BE80-CF4C0D552F08",
+          "operations": [
+              {
+                  "id": "set_value",
+                  "key": "1BC10F4C-68C2-42E9-9000-25865B076073",
+                  "name": "Set value of { variable }",
+                  "value": "API keys are not enabled on the tenant. Please enable API keys and try again."
+              }
+          ]
+      },
+      {
+          "id": "D25BBAB7-8646-46AC-BC9B-D512B163DE2A",
+          "type": "VariableBlock",
+          "disabled": false,
+          "name": "errorDetail",
+          "displayName": "Variable - errorDetail",
+          "comment": "Variable to store detailed error message.",
+          "childId": "2C6FA9CF-3DE8-45CE-B24E-0979C9A78584",
+          "inputs": [],
+          "settings": [],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2802,
+          "y": 3214,
+          "variableGuid": "1BF2068B-106E-4D58-BC51-884F1810F03C",
+          "operations": [
+              {
+                  "id": "set_value",
+                  "key": "1BC10F4C-68C2-42E9-9000-25865B076073",
+                  "name": "Set value of { variable }",
+                  "value": "Exiting, API keys must be enabled on the tenant to use the monitoring apps since they rely on an API key for the REST data connections used for loading data from Qlik Cloud. Please enable API keys and try again."
+              }
+          ]
+      },
+      {
+          "id": "2C6FA9CF-3DE8-45CE-B24E-0979C9A78584",
+          "type": "GotoBlock",
+          "disabled": false,
+          "name": "goToLabel5",
+          "displayName": "Go To Label 5",
+          "comment": "Go to the label named error.",
+          "childId": null,
+          "inputs": [
+              {
+                  "id": "label",
+                  "value": "EF82AD29-E2CF-44C9-A7DB-24C784618756",
+                  "type": "select",
+                  "displayValue": "error",
+                  "structure": []
+              }
+          ],
+          "settings": [],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2802,
+          "y": 3334
+      },
+      {
+          "id": "60DC4193-EAC7-4353-86C5-C9233AF169EA",
+          "type": "VariableBlock",
+          "disabled": false,
+          "name": "apiKeyDuration",
+          "displayName": "Variable - apiKeyDuration",
+          "comment": "Variable to store API key expiry.",
+          "childId": "E98AA699-4CAD-416D-81EF-A97EB737FD6C",
+          "inputs": [],
+          "settings": [],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": false
+              }
+          ],
+          "x": -2922,
+          "y": 2814,
+          "variableGuid": "51DCB139-A5E7-427D-8E9C-9382DB8A530C",
+          "operations": [
+              {
+                  "id": "set_value",
+                  "key": "F7907433-1824-49AD-AECA-0367D48E77E5",
+                  "name": "Set value of { variable }",
+                  "value": "{ $.rawAPIRequest2.max_api_key_expiry }"
+              }
+          ]
+      },
+      {
+          "id": "7BB23A76-A47D-4859-AE1D-D5532E49031D",
+          "type": "CallUrlBlock",
+          "disabled": false,
+          "name": "callURL2",
+          "displayName": "Call URL 2",
+          "comment": "Fetch monitoring applications manifest.",
+          "childId": "D68D0C47-8D62-4ADC-AC47-553E8E9A05ED",
+          "inputs": [
+              {
+                  "id": "url",
+                  "value": "https://raw.githubusercontent.com/qlik-oss/qlik-cloud-monitoring-apps/main/manifests/resources.json",
+                  "type": "string",
+                  "structure": []
+              },
+              {
+                  "id": "method",
+                  "value": "GET",
+                  "type": "select",
+                  "structure": []
+              },
+              {
+                  "id": "timeout",
+                  "value": "",
+                  "type": "string",
+                  "structure": []
+              },
+              {
+                  "id": "params",
+                  "value": null,
+                  "type": "object",
+                  "mode": "keyValue",
+                  "structure": []
+              },
+              {
+                  "id": "headers",
+                  "value": null,
+                  "type": "object",
+                  "mode": "keyValue",
+                  "structure": []
+              },
+              {
+                  "id": "encoding",
+                  "value": "",
+                  "type": "string",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "blendr_on_error",
+                  "value": "stop",
+                  "type": "select",
+                  "structure": []
+              },
+              {
+                  "id": "full_response",
+                  "value": null,
+                  "type": "checkbox",
+                  "structure": []
+              },
+              {
+                  "id": "capitalize_headers",
+                  "value": true,
+                  "type": "checkbox",
+                  "structure": []
+              },
+              {
+                  "id": "automations_censor_data",
+                  "value": false,
+                  "type": "checkbox",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": false
+              }
+          ],
+          "x": -2922,
+          "y": 3774
+      },
+      {
+          "id": "D68D0C47-8D62-4ADC-AC47-553E8E9A05ED",
+          "type": "VariableBlock",
+          "disabled": false,
+          "name": "manifest",
+          "displayName": "Variable - manifest",
+          "comment": "Store the manifest.",
+          "childId": "66C7B574-5D06-4B85-BCEB-A11CBD175283",
+          "inputs": [],
+          "settings": [],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": false
+              }
+          ],
+          "x": -2922,
+          "y": 3894,
+          "variableGuid": "4FCFD564-CA0B-4516-AD61-A1A2EE9CF38C",
+          "operations": [
+              {
+                  "id": "set",
+                  "key": "FB81147D-D0D3-4B9B-B21C-AEB7DAE251AD",
+                  "name": "Set { variable } equal to object ",
+                  "value": "{$.callURL2}"
+              }
+          ]
+      },
+      {
+          "id": "9BC2CF3D-A602-4940-A86B-73BA20439C0F",
+          "type": "IfElseBlock",
+          "disabled": false,
+          "name": "condition7",
+          "displayName": "Condition 7",
+          "comment": "Is this a user-based tenant?",
+          "childId": "0BC5D2A0-7566-4F59-BA2B-078480075F4E",
+          "inputs": [
+              {
+                  "id": "conditions",
+                  "value": {
+                      "mode": "all",
+                      "conditions": [
+                          {
+                              "input1": "{ $.isCapacityTenant }",
+                              "input2": "0",
+                              "operator": "="
+                          }
+                      ]
+                  },
+                  "type": "custom",
+                  "structure": []
+              }
+          ],
+          "settings": [],
+          "collapsed": [
+              {
+                  "name": "both",
+                  "isCollapsed": false
+              },
+              {
+                  "name": "yes",
+                  "isCollapsed": false
+              },
+              {
+                  "name": "no",
+                  "isCollapsed": false
+              }
+          ],
+          "x": -2922,
+          "y": 4134,
+          "childTrueId": "FBD838AA-F63C-4948-B755-00F8F6F2CDCF",
+          "childFalseId": "8968628A-54FC-4578-98FD-32FAE0B1454F"
+      },
+      {
+          "id": "FBD838AA-F63C-4948-B755-00F8F6F2CDCF",
+          "type": "FilterListBlock",
+          "disabled": false,
+          "name": "filterList2",
+          "displayName": "Filter List 2",
+          "comment": "Filter to just user-supported applications.",
+          "childId": null,
+          "inputs": [
+              {
+                  "id": "list",
+                  "value": "{$.manifest}",
+                  "type": "string",
+                  "structure": []
+              },
+              {
+                  "id": "conditions",
+                  "value": {
+                      "mode": "all",
+                      "conditions": [
+                          {
+                              "input1": "subscriptionTypes",
+                              "input2": "user",
+                              "operator": "inList"
+                          },
+                          {
+                              "input1": "qcmaInstaller",
+                              "input2": null,
+                              "operator": "isTrue"
+                          }
+                      ]
+                  },
+                  "type": "custom",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "automations_censor_data",
+                  "value": false,
+                  "type": "checkbox",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": false
+              }
+          ],
+          "x": -2802,
+          "y": 4214,
+          "loopBlockId": "D3F1FBD1-BEBC-4148-92AF-528D93FE1B8A"
+      },
+      {
+          "id": "8C37F961-8477-4705-A167-CACE4E579177",
+          "type": "VariableBlock",
+          "disabled": false,
+          "name": "monitoringAppsToInstall",
+          "displayName": "Variable - monitoringAppsToInstall",
+          "comment": "Add monitoring apps to list.",
+          "childId": null,
+          "inputs": [],
+          "settings": [],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2562,
+          "y": 4394,
+          "variableGuid": "1ECFDB29-BC7A-4B7A-AE5F-2A2DBE77B1E0",
+          "operations": [
+              {
+                  "id": "add_item",
+                  "key": "5167867F-4931-4E4C-BDBA-28A2270E3E98",
+                  "name": "Add item to { variable }",
+                  "value": "{ $.filterList2.item }"
+              }
+          ]
+      },
+      {
+          "id": "8968628A-54FC-4578-98FD-32FAE0B1454F",
+          "type": "FilterListBlock",
+          "disabled": false,
+          "name": "filterList3",
+          "displayName": "Filter List 3",
+          "comment": "Filter to just capacity-supported applications.",
+          "childId": null,
+          "inputs": [
+              {
+                  "id": "list",
+                  "value": "{$.manifest}",
+                  "type": "string",
+                  "structure": []
+              },
+              {
+                  "id": "conditions",
+                  "value": {
+                      "mode": "all",
+                      "conditions": [
+                          {
+                              "input1": "subscriptionTypes",
+                              "input2": "capacity",
+                              "operator": "inList"
+                          },
+                          {
+                              "input1": "qcmaInstaller",
+                              "input2": null,
+                              "operator": "isTrue"
+                          }
+                      ]
+                  },
+                  "type": "custom",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "automations_censor_data",
+                  "value": false,
+                  "type": "checkbox",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": false
+              }
+          ],
+          "x": -2802,
+          "y": 4714,
+          "loopBlockId": "619BAD5D-8B64-4866-9E4B-A6E8108FF386"
+      },
+      {
+          "id": "D5F81616-F18E-481D-8254-DC54513F20A3",
+          "type": "VariableBlock",
+          "disabled": false,
+          "name": "monitoringAppsToInstall",
+          "displayName": "Variable - monitoringAppsToInstall",
+          "comment": "Add monitoring apps to list.",
+          "childId": null,
+          "inputs": [],
+          "settings": [],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2562,
+          "y": 4894,
+          "variableGuid": "1ECFDB29-BC7A-4B7A-AE5F-2A2DBE77B1E0",
+          "operations": [
+              {
+                  "id": "add_item",
+                  "key": "EA1F052D-3E48-4CB3-A200-3FE04BFB5F56",
+                  "name": "Add item to { variable }",
+                  "value": "{ $.filterList3.item }"
+              }
+          ]
+      },
+      {
+          "id": "6AB100F2-DB70-49EC-AA91-33C3F4639953",
+          "type": "VariableBlock",
+          "disabled": false,
+          "name": "isCapacityTenant",
+          "displayName": "Variable - isCapacityTenant",
+          "comment": "Check for presence of \"QLIK SMT\" for capacity tenants.",
+          "childId": "F893CB46-17A5-4082-BB7B-5564538B5F8B",
+          "inputs": [],
+          "settings": [],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": false
+              }
+          ],
+          "x": -2922,
+          "y": 2054,
+          "variableGuid": "AD716F55-666C-4730-B830-F2D97A502F6B",
+          "operations": [
+              {
+                  "id": "set_value",
+                  "key": "D3F822AC-2E03-45D7-9C6E-7C5CB897D3A1",
+                  "name": "Set value of { variable }",
+                  "value": "{ if: { $.getLicenseOverview.product } contain 'QLIK SMT', 1, 0 }"
+              }
+          ]
+      },
+      {
+          "id": "66C7B574-5D06-4B85-BCEB-A11CBD175283",
+          "type": "VariableBlock",
+          "disabled": false,
+          "name": "monitoringAppsToInstall",
+          "displayName": "Variable - monitoringAppsToInstall",
+          "comment": "Clear monitoring app list.",
+          "childId": "9BC2CF3D-A602-4940-A86B-73BA20439C0F",
+          "inputs": [],
+          "settings": [],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": false
+              }
+          ],
+          "x": -2922,
+          "y": 4014,
+          "variableGuid": "1ECFDB29-BC7A-4B7A-AE5F-2A2DBE77B1E0",
+          "operations": [
+              {
+                  "id": "empty",
+                  "key": "422812C6-BD65-40D2-B175-AD2E1BBA5969",
+                  "name": "Empty { variable }",
+                  "value": null
+              }
+          ]
+      },
+      {
+          "id": "2E327220-1609-47A0-8385-6B40E70A7CFB",
+          "type": "VariableBlock",
+          "disabled": false,
+          "name": "configuredMonitoringApps",
+          "displayName": "Variable - configuredMonitoringApps",
+          "comment": "Configure which monitoring apps to install & maintain. Delete the record to skip installing/updating it. Must be a case sensitive match with the app names in the manifest.",
+          "childId": "AABAC2BF-30E8-49FC-982B-52BD9707DAE0",
+          "inputs": [],
+          "settings": [],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2802,
+          "y": -3506,
+          "variableGuid": "8E1D15E6-7269-4E6B-A87E-AF56400A2F7A",
+          "operations": [
+              {
+                  "id": "add_item",
+                  "key": "7FB0497F-6787-4032-A558-9F703F088CF4",
+                  "name": "Add item to { variable }",
+                  "value": "Access Evaluator"
+              },
+              {
+                  "id": "add_item",
+                  "key": "6716C27F-4A80-44FE-8CEC-DF73FD5FF17A",
+                  "name": "Add item to { variable }",
+                  "value": "Answers Analyzer"
+              },
+              {
+                  "id": "add_item",
+                  "key": "E4B393A2-E344-4A32-B6F4-B78C39896B9B",
+                  "name": "Add item to { variable }",
+                  "value": "App Analyzer"
+              },
+              {
+                  "id": "add_item",
+                  "key": "350EAF4C-9327-4C1E-BA2F-58C0C043E8E4",
+                  "name": "Add item to { variable }",
+                  "value": "Automation Analyzer"
+              },
+              {
+                  "id": "add_item",
+                  "key": "9FC73D37-6D3C-4BCB-B683-D527BB11E438",
+                  "name": "Add item to { variable }",
+                  "value": "Entitlement Analyzer"
+              },
+              {
+                  "id": "add_item",
+                  "key": "068D740C-BF98-42FE-AC99-397782586B6D",
+                  "name": "Add item to { variable }",
+                  "value": "Reload Analyzer"
+              },
+              {
+                  "id": "add_item",
+                  "key": "DE2D215A-30D2-4D17-956D-27940C0F46DF",
+                  "name": "Add item to { variable }",
+                  "value": "Report Analyzer"
+              }
+          ]
+      },
+      {
+          "id": "D3F1FBD1-BEBC-4148-92AF-528D93FE1B8A",
+          "type": "IfElseBlock",
+          "disabled": false,
+          "name": "condition8",
+          "displayName": "Condition 8",
+          "comment": "If in configured list.",
+          "childId": null,
+          "inputs": [
+              {
+                  "id": "conditions",
+                  "value": {
+                      "mode": "all",
+                      "conditions": [
+                          {
+                              "input1": "{ $.configuredMonitoringApps }",
+                              "input2": "{ $.filterList2.item.name }",
+                              "operator": "inList"
+                          }
+                      ]
+                  },
+                  "type": "custom",
+                  "structure": []
+              }
+          ],
+          "settings": [],
+          "collapsed": [
+              {
+                  "name": "both",
+                  "isCollapsed": false
+              },
+              {
+                  "name": "yes",
+                  "isCollapsed": false
+              },
+              {
+                  "name": "no",
+                  "isCollapsed": false
+              }
+          ],
+          "x": -2682,
+          "y": 4314,
+          "childTrueId": "8C37F961-8477-4705-A167-CACE4E579177",
+          "childFalseId": null
+      },
+      {
+          "id": "619BAD5D-8B64-4866-9E4B-A6E8108FF386",
+          "type": "IfElseBlock",
+          "disabled": false,
+          "name": "condition9",
+          "displayName": "Condition 9",
+          "comment": "If in configured list.",
+          "childId": null,
+          "inputs": [
+              {
+                  "id": "conditions",
+                  "value": {
+                      "mode": "all",
+                      "conditions": [
+                          {
+                              "input1": "{ $.configuredMonitoringApps }",
+                              "input2": "{ $.filterList3.item.name }",
+                              "operator": "inList"
+                          }
+                      ]
+                  },
+                  "type": "custom",
+                  "structure": []
+              }
+          ],
+          "settings": [],
+          "collapsed": [
+              {
+                  "name": "both",
+                  "isCollapsed": false
+              },
+              {
+                  "name": "yes",
+                  "isCollapsed": false
+              },
+              {
+                  "name": "no",
+                  "isCollapsed": false
+              }
+          ],
+          "x": -2682,
+          "y": 4814,
+          "childTrueId": "D5F81616-F18E-481D-8254-DC54513F20A3",
+          "childFalseId": null
+      },
+      {
+          "id": "0BC5D2A0-7566-4F59-BA2B-078480075F4E",
+          "type": "ShowBlock",
+          "disabled": false,
+          "name": "output4",
+          "displayName": "Output 4",
+          "comment": "Status output.",
+          "childId": "B67C3598-6171-40D5-87CE-E7CBA1D58E16",
+          "inputs": [
+              {
+                  "id": "input",
+                  "value": "| Confirmed apps in scope | Will load the following monitoring apps based on license & application availability: **{implode: { $.monitoringAppsToInstall[*].name }, ','}** |",
+                  "type": "string",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "display_mode",
+                  "value": "add",
+                  "type": "select",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": false
+              }
+          ],
+          "x": -2922,
+          "y": 5214
+      },
+      {
+          "id": "F211A56A-FBCB-4413-BA12-91144F38B722",
+          "type": "ShowBlock",
+          "disabled": false,
+          "name": "output5",
+          "displayName": "Output 5",
+          "comment": "Status output.",
+          "childId": "00B11FD2-3490-4643-B8E8-F03547EB32B3",
+          "inputs": [
+              {
+                  "id": "input",
+                  "value": "| Missing role | User is missing required role `{ $.loop.item }`. Please assign to your user and re-run. |",
+                  "type": "string",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "display_mode",
+                  "value": "add",
+                  "type": "select",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2682,
+          "y": 5754
+      },
+      {
+          "id": "B67C3598-6171-40D5-87CE-E7CBA1D58E16",
+          "type": "VariableBlock",
+          "disabled": false,
+          "name": "requiredRoles",
+          "displayName": "Variable - requiredRoles",
+          "comment": "Collate required roles from monitoringAppsToInstall.",
+          "childId": "432F3D61-2AEC-471B-8837-04AB4F56B9DB",
+          "inputs": [],
+          "settings": [],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": false
+              }
+          ],
+          "x": -2922,
+          "y": 5334,
+          "variableGuid": "09C608F2-CF67-4C9A-983E-F39019D443B9",
+          "operations": [
+              {
+                  "id": "merge",
+                  "key": "D773C6E0-4087-4487-945D-FCEC9A0C00F9",
+                  "name": "Merge other list into { variable }",
+                  "value": "{$.monitoringAppsToInstall[*].requiredRoles[*]}"
+              }
+          ]
+      },
+      {
+          "id": "F364D449-B628-4325-9617-1B04B7DBFB6A",
+          "type": "ForEachBlock",
+          "disabled": false,
           "name": "loop",
-          "isCollapsed": false
-        }
-      ],
-      "x": -2682,
-      "y": -1266
-    },
-    {
-      "id": "1C53F6DA-FE4F-4BE3-8A95-82EF0EC3E288",
-      "type": "EndpointBlock",
-      "disabled": false,
-      "name": "updateAutomation",
-      "displayName": "Qlik Cloud Services - Update Automation",
-      "comment": "Update this automation",
-      "childId": "99C259DE-CADE-4561-8634-3C93EA662301",
-      "inputs": [
-        {
-          "id": "428c8660-d041-11ec-864d-5bed7a9667ee",
-          "value": "{ automationid }",
-          "type": "string",
-          "structure": []
-        },
-        {
-          "id": "1f1d64b0-d041-11ec-bc03-e5fdbc243961",
-          "value": null,
-          "type": "string",
-          "structure": []
-        },
-        {
-          "id": "1f272e60-d041-11ec-9044-dda9cc402447",
-          "value": null,
-          "type": "string",
-          "structure": []
-        },
-        {
-          "id": "7fcdf4c0-2833-11ed-a6a9-797f49b90041",
-          "value": "{ $.callURL4 }",
-          "type": "string",
-          "structure": []
-        },
-        {
-          "id": "99e1a8c0-2833-11ed-b085-83fc18a9cd7d",
-          "value": null,
-          "type": "string",
-          "structure": []
-        }
-      ],
-      "settings": [
-        {
-          "id": "blendr_on_error",
-          "value": "stop",
-          "type": "select",
-          "structure": []
-        },
-        {
-          "id": "automations_censor_data",
-          "value": false,
-          "type": "checkbox",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": false
-        }
-      ],
-      "x": -2682,
-      "y": -1146,
-      "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
-      "endpoint_guid": "1f022b50-d041-11ec-a842-e9973f7c493f",
-      "endpoint_role": "update"
-    },
-    {
-      "id": "99C259DE-CADE-4561-8634-3C93EA662301",
-      "type": "ShowBlock",
-      "disabled": false,
-      "name": "output56",
-      "displayName": "Output 56",
-      "comment": "Output - Automation has been updated",
-      "childId": "08CBB6D5-ACC3-40AD-A7DA-AA28CD5AD4DB",
-      "inputs": [
-        {
-          "id": "input",
-          "value": "## Automation has been updated. Please refresh the page or open: \n[This link to refresh]({$.tenantHostname}analytics/automations/editor/{automationid})",
-          "type": "string",
-          "structure": []
-        }
-      ],
-      "settings": [
-        {
-          "id": "display_mode",
-          "value": "add",
-          "type": "select",
-          "structure": []
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": false
-        }
-      ],
-      "x": -2682,
-      "y": -1026
-    },
-    {
-      "id": "F8CCF961-2D55-43AE-A8B3-CED17A4A0B9A",
-      "type": "StopBlock",
-      "disabled": false,
-      "name": "stop",
-      "displayName": "Stop",
-      "comment": "Don't continue.",
-      "childId": null,
-      "inputs": [],
-      "settings": [],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": false
-        }
-      ],
-      "x": -2682,
-      "y": -786
-    },
-    {
-      "id": "08CBB6D5-ACC3-40AD-A7DA-AA28CD5AD4DB",
-      "type": "UpdateJobBlock",
-      "disabled": false,
-      "name": "updateRunTitle3",
-      "displayName": "Update Run Title 3",
-      "comment": "Update title - New version and run again.",
-      "childId": "F8CCF961-2D55-43AE-A8B3-CED17A4A0B9A",
-      "inputs": [
-        {
-          "id": "title",
-          "value": "Updated to version: { $.callURL.installers[?(@.template=='qcma')].version }. Please run again.",
-          "type": "string",
-          "structure": {}
-        }
-      ],
-      "settings": [
-        {
-          "id": "automations_censor_data",
-          "value": false,
-          "type": "checkbox",
-          "structure": {}
-        }
-      ],
-      "collapsed": [
-        {
-          "name": "loop",
-          "isCollapsed": false
-        }
-      ],
-      "x": -2682,
-      "y": -906
-    }
+          "displayName": "Loop",
+          "comment": "Loop over required roles.",
+          "childId": "E6D1BA8E-24D6-4602-9400-9A74031E1EAB",
+          "inputs": [
+              {
+                  "id": "input",
+                  "value": "{ $.requiredRoles }",
+                  "type": "string",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "automations_censor_data",
+                  "value": false,
+                  "type": "checkbox",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": false
+              }
+          ],
+          "x": -2922,
+          "y": 5574,
+          "loopBlockId": "7CE340D0-20D9-4B6B-80C0-9295582D1CF9"
+      },
+      {
+          "id": "7CE340D0-20D9-4B6B-80C0-9295582D1CF9",
+          "type": "IfElseBlock",
+          "disabled": false,
+          "name": "condition10",
+          "displayName": "Condition 10",
+          "comment": "If role isn't assigned.",
+          "childId": null,
+          "inputs": [
+              {
+                  "id": "conditions",
+                  "value": {
+                      "mode": "all",
+                      "conditions": [
+                          {
+                              "input1": "{ $.userRoles[*].name }",
+                              "input2": "{ $.loop.item }",
+                              "operator": "notInList"
+                          }
+                      ]
+                  },
+                  "type": "custom",
+                  "structure": []
+              }
+          ],
+          "settings": [],
+          "collapsed": [
+              {
+                  "name": "both",
+                  "isCollapsed": false
+              },
+              {
+                  "name": "yes",
+                  "isCollapsed": false
+              },
+              {
+                  "name": "no",
+                  "isCollapsed": false
+              }
+          ],
+          "x": -2802,
+          "y": 5674,
+          "childTrueId": "F211A56A-FBCB-4413-BA12-91144F38B722",
+          "childFalseId": null
+      },
+      {
+          "id": "E6D1BA8E-24D6-4602-9400-9A74031E1EAB",
+          "type": "IfElseBlock",
+          "disabled": false,
+          "name": "condition11",
+          "displayName": "Condition 11",
+          "comment": "If missing roles, exit.",
+          "childId": "ECCD6D36-805D-44EF-A411-A73316586DD1",
+          "inputs": [
+              {
+                  "id": "conditions",
+                  "value": {
+                      "mode": "all",
+                      "conditions": [
+                          {
+                              "input1": "{count: { $.missingRoles }}",
+                              "input2": "0",
+                              "operator": ">"
+                          }
+                      ]
+                  },
+                  "type": "custom",
+                  "structure": []
+              }
+          ],
+          "settings": [],
+          "collapsed": [
+              {
+                  "name": "both",
+                  "isCollapsed": false
+              },
+              {
+                  "name": "yes",
+                  "isCollapsed": false
+              },
+              {
+                  "name": "no",
+                  "isCollapsed": false
+              }
+          ],
+          "x": -2922,
+          "y": 6154,
+          "childTrueId": "EBDE966E-F544-46BF-89EA-FB5A671494B7",
+          "childFalseId": null
+      },
+      {
+          "id": "EBDE966E-F544-46BF-89EA-FB5A671494B7",
+          "type": "VariableBlock",
+          "disabled": false,
+          "name": "errorTitle",
+          "displayName": "Variable - errorTitle",
+          "comment": "Set error title for standard error output.",
+          "childId": "D13F1BD0-95CE-4118-B875-7DC61E17AA1E",
+          "inputs": [],
+          "settings": [],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2802,
+          "y": 6234,
+          "variableGuid": "407730A6-EC96-4337-BE80-CF4C0D552F08",
+          "operations": [
+              {
+                  "id": "set_value",
+                  "key": "1BC10F4C-68C2-42E9-9000-25865B076073",
+                  "name": "Set value of { variable }",
+                  "value": "User is missing required roles: { implode: { $.missingRoles }, ',' }."
+              }
+          ]
+      },
+      {
+          "id": "D13F1BD0-95CE-4118-B875-7DC61E17AA1E",
+          "type": "VariableBlock",
+          "disabled": false,
+          "name": "errorDetail",
+          "displayName": "Variable - errorDetail",
+          "comment": "Variable to store detailed error message.",
+          "childId": "69F43DAF-28FE-44A5-8D0F-5BF0E066A618",
+          "inputs": [],
+          "settings": [],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2802,
+          "y": 6354,
+          "variableGuid": "1BF2068B-106E-4D58-BC51-884F1810F03C",
+          "operations": [
+              {
+                  "id": "set_value",
+                  "key": "1BC10F4C-68C2-42E9-9000-25865B076073",
+                  "name": "Set value of { variable }",
+                  "value": "Exiting, user is missing one or more roles required by one of the monitoring apps: `{ implode: { $.missingRoles }, ',' }`. Review the output for the missing role, assign to your user, and try again."
+              }
+          ]
+      },
+      {
+          "id": "69F43DAF-28FE-44A5-8D0F-5BF0E066A618",
+          "type": "GotoBlock",
+          "disabled": false,
+          "name": "goToLabel6",
+          "displayName": "Go To Label 6",
+          "comment": "Go to the label named error.",
+          "childId": null,
+          "inputs": [
+              {
+                  "id": "label",
+                  "value": "EF82AD29-E2CF-44C9-A7DB-24C784618756",
+                  "type": "select",
+                  "displayValue": "error",
+                  "structure": []
+              }
+          ],
+          "settings": [],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2802,
+          "y": 6474
+      },
+      {
+          "id": "ECCD6D36-805D-44EF-A411-A73316586DD1",
+          "type": "EndpointBlock",
+          "disabled": false,
+          "name": "rawAPIRequest3",
+          "displayName": "Qlik Cloud Services - Raw API Request 3",
+          "comment": "Get REST connector settings.",
+          "childId": "2CE857A5-5770-4230-B4A7-E64B4B777B22",
+          "inputs": [
+              {
+                  "id": "734cbcc0-bbb0-11f0-b998-f73920377683",
+                  "value": "v1/data-sources/rest/settings",
+                  "type": "string",
+                  "structure": []
+              },
+              {
+                  "id": "7322a550-bbb0-11f0-9c8c-43f143a32456",
+                  "value": "7341e840-bbb0-11f0-9bb8-11c201f87b6d",
+                  "type": "select",
+                  "displayValue": "GET",
+                  "structure": []
+              },
+              {
+                  "id": "73000fe0-bbb0-11f0-8a80-59ece3571bd9",
+                  "value": null,
+                  "type": "object",
+                  "mode": "keyValue",
+                  "structure": []
+              },
+              {
+                  "id": "736fae60-bbb0-11f0-ad62-c98a0046f418",
+                  "value": null,
+                  "type": "object",
+                  "mode": "keyValue",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "blendr_on_error",
+                  "value": "stop",
+                  "type": "select",
+                  "structure": []
+              },
+              {
+                  "id": "automations_censor_data",
+                  "value": false,
+                  "type": "checkbox",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": false
+              }
+          ],
+          "x": -2922,
+          "y": 6674,
+          "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
+          "endpoint_guid": "72d48530-bbb0-11f0-875a-b322bf237aeb",
+          "endpoint_role": "create"
+      },
+      {
+          "id": "00B11FD2-3490-4643-B8E8-F03547EB32B3",
+          "type": "VariableBlock",
+          "disabled": false,
+          "name": "missingRoles",
+          "displayName": "Variable - missingRoles",
+          "comment": "Add missing role to list.",
+          "childId": null,
+          "inputs": [],
+          "settings": [],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2682,
+          "y": 5874,
+          "variableGuid": "CB55538C-0F1A-4871-98DD-C68EC5B00D84",
+          "operations": [
+              {
+                  "id": "add_item",
+                  "key": "9172C800-C9AE-419C-B411-DC1D4D65C8A0",
+                  "name": "Add item to { variable }",
+                  "value": "{ $.loop.item }"
+              }
+          ]
+      },
+      {
+          "id": "432F3D61-2AEC-471B-8837-04AB4F56B9DB",
+          "type": "VariableBlock",
+          "disabled": false,
+          "name": "missingRoles",
+          "displayName": "Variable - missingRoles",
+          "comment": "Empty missing role list.",
+          "childId": "F364D449-B628-4325-9617-1B04B7DBFB6A",
+          "inputs": [],
+          "settings": [],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": false
+              }
+          ],
+          "x": -2922,
+          "y": 5454,
+          "variableGuid": "CB55538C-0F1A-4871-98DD-C68EC5B00D84",
+          "operations": [
+              {
+                  "id": "empty",
+                  "key": "0D2CE328-09DF-41C6-9021-02ED68132F13",
+                  "name": "Empty { variable }",
+                  "value": null
+              }
+          ]
+      },
+      {
+          "id": "7151B1C7-58CC-49D0-AE62-51CBB945D6D4",
+          "type": "EndpointBlock",
+          "disabled": false,
+          "name": "listApps",
+          "displayName": "Qlik Cloud Services - List Apps",
+          "comment": "List apps in managed space.",
+          "childId": "E68DA53C-EC7E-4FB7-9D95-FBD9050E0659",
+          "inputs": [
+              {
+                  "id": "8cd8db50-107b-11ec-8082-edc45dd151ef",
+                  "value": null,
+                  "type": "select",
+                  "structure": []
+              },
+              {
+                  "id": "8ce4fad0-107b-11ec-a6ac-2bd407ad134b",
+                  "value": "{ $.managedSpaceId }",
+                  "type": "string",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "maxitemcount",
+                  "value": "",
+                  "type": "string",
+                  "structure": []
+              },
+              {
+                  "id": "blendr_on_error",
+                  "value": "stop",
+                  "type": "select",
+                  "structure": []
+              },
+              {
+                  "id": "cache",
+                  "value": "0",
+                  "type": "select",
+                  "structure": []
+              },
+              {
+                  "id": "automations_censor_data",
+                  "value": false,
+                  "type": "checkbox",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": false
+              }
+          ],
+          "x": -2922,
+          "y": 15014,
+          "loopBlockId": "DAD45F04-D485-42E3-B7DD-D8C3106EA5FC",
+          "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
+          "endpoint_guid": "8cc63340-107b-11ec-ab5d-f9b221ed2dc5",
+          "endpoint_role": "list"
+      },
+      {
+          "id": "DAD45F04-D485-42E3-B7DD-D8C3106EA5FC",
+          "type": "EndpointBlock",
+          "disabled": false,
+          "name": "rawAPIRequest9",
+          "displayName": "Qlik Cloud Services - Raw API Request 9",
+          "comment": "Retrieve item so we can get the tags.",
+          "childId": "4F40CB60-2782-41D7-BFA4-FF2A709B137F",
+          "inputs": [
+              {
+                  "id": "734cbcc0-bbb0-11f0-b998-f73920377683",
+                  "value": "v1/items/{$.listApps.item.itemId}",
+                  "type": "string",
+                  "structure": []
+              },
+              {
+                  "id": "7322a550-bbb0-11f0-9c8c-43f143a32456",
+                  "value": "7341e840-bbb0-11f0-9bb8-11c201f87b6d",
+                  "type": "select",
+                  "displayValue": "GET",
+                  "structure": []
+              },
+              {
+                  "id": "73000fe0-bbb0-11f0-8a80-59ece3571bd9",
+                  "value": null,
+                  "type": "object",
+                  "mode": "keyValue",
+                  "structure": []
+              },
+              {
+                  "id": "736fae60-bbb0-11f0-ad62-c98a0046f418",
+                  "value": null,
+                  "type": "object",
+                  "mode": "keyValue",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "blendr_on_error",
+                  "value": "stop",
+                  "type": "select",
+                  "structure": []
+              },
+              {
+                  "id": "automations_censor_data",
+                  "value": false,
+                  "type": "checkbox",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2802,
+          "y": 15114,
+          "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
+          "endpoint_guid": "72d48530-bbb0-11f0-875a-b322bf237aeb",
+          "endpoint_role": "create"
+      },
+      {
+          "id": "D2C679AD-2434-474C-9ACC-B95C8232BA8A",
+          "type": "VariableBlock",
+          "disabled": false,
+          "name": "existingAppList",
+          "displayName": "Variable - existingAppList",
+          "comment": "Empty app list.",
+          "childId": "7151B1C7-58CC-49D0-AE62-51CBB945D6D4",
+          "inputs": [],
+          "settings": [],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": false
+              }
+          ],
+          "x": -2922,
+          "y": 14894,
+          "variableGuid": "2E37F6E5-BE30-44ED-B0B6-B544ECEAAB9E",
+          "operations": [
+              {
+                  "id": "empty",
+                  "key": "6B0A6464-4A87-49C7-B4C8-667C17C9CEB9",
+                  "name": "Empty { variable }",
+                  "value": null
+              }
+          ]
+      },
+      {
+          "id": "E68DA53C-EC7E-4FB7-9D95-FBD9050E0659",
+          "type": "ForEachBlock",
+          "disabled": false,
+          "name": "loop2",
+          "displayName": "Loop 2",
+          "comment": "Loop over list of monitoring apps we want to install.",
+          "childId": "9745F8DD-9BEC-4E02-B0B9-B275B8BCFCB1",
+          "inputs": [
+              {
+                  "id": "input",
+                  "value": "{ $.monitoringAppsToInstall }",
+                  "type": "string",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "automations_censor_data",
+                  "value": false,
+                  "type": "checkbox",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": false
+              }
+          ],
+          "x": -2922,
+          "y": 15394,
+          "loopBlockId": "0DBF0B78-A809-4DDE-B02F-EF043A628D39"
+      },
+      {
+          "id": "FB709E97-66EC-46E2-BFD4-25C11DAA5112",
+          "type": "IfElseBlock",
+          "disabled": false,
+          "name": "condition29",
+          "displayName": "Condition 29",
+          "comment": "If no app was found, or existing apps need update.",
+          "childId": null,
+          "inputs": [
+              {
+                  "id": "conditions",
+                  "value": {
+                      "mode": "some",
+                      "conditions": [
+                          {
+                              "input1": "{ $.workingAppExists }",
+                              "input2": "0",
+                              "operator": "="
+                          },
+                          {
+                              "input1": "{ count: { $.workingAppList } }",
+                              "input2": "0",
+                              "operator": ">"
+                          }
+                      ]
+                  },
+                  "type": "custom",
+                  "structure": []
+              }
+          ],
+          "settings": [],
+          "collapsed": [
+              {
+                  "name": "both",
+                  "isCollapsed": false
+              },
+              {
+                  "name": "yes",
+                  "isCollapsed": false
+              },
+              {
+                  "name": "no",
+                  "isCollapsed": false
+              }
+          ],
+          "x": -2802,
+          "y": 18114,
+          "childTrueId": "40EC15FE-C25F-442B-8CD9-5C87150436B3",
+          "childFalseId": null
+      },
+      {
+          "id": "4F40CB60-2782-41D7-BFA4-FF2A709B137F",
+          "type": "VariableBlock",
+          "disabled": false,
+          "name": "existingAppList",
+          "displayName": "Variable - existingAppList",
+          "comment": "Add app to applist.",
+          "childId": null,
+          "inputs": [],
+          "settings": [],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2802,
+          "y": 15234,
+          "variableGuid": "2E37F6E5-BE30-44ED-B0B6-B544ECEAAB9E",
+          "operations": [
+              {
+                  "id": "add_item",
+                  "key": "80C831BF-1F3C-4F48-87A0-60205A2325C0",
+                  "name": "Add item to { variable }",
+                  "value": "{ $.rawAPIRequest9 }"
+              }
+          ]
+      },
+      {
+          "id": "6D0F022E-164E-4CE3-B955-5961AA02A540",
+          "type": "ForEachBlock",
+          "disabled": false,
+          "name": "loop3",
+          "displayName": "Loop 3",
+          "comment": "Loop over existing apps.",
+          "childId": "FB709E97-66EC-46E2-BFD4-25C11DAA5112",
+          "inputs": [
+              {
+                  "id": "input",
+                  "value": "{ $.existingAppList }",
+                  "type": "string",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "automations_censor_data",
+                  "value": false,
+                  "type": "checkbox",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": false
+              }
+          ],
+          "x": -2802,
+          "y": 15974,
+          "loopBlockId": "5BD148B9-BDD1-4C37-8EB3-73641F532BB3"
+      },
+      {
+          "id": "5BD148B9-BDD1-4C37-8EB3-73641F532BB3",
+          "type": "IfElseBlock",
+          "disabled": false,
+          "name": "condition25",
+          "displayName": "Condition 25",
+          "comment": "If the apps match, it means we need to check to upgrade it.",
+          "childId": null,
+          "inputs": [
+              {
+                  "id": "conditions",
+                  "value": {
+                      "mode": "all",
+                      "conditions": [
+                          {
+                              "input1": "{ $.loop3.item.meta.tags[*].name }",
+                              "input2": "{ $.workingAppTagName }",
+                              "operator": "inList"
+                          }
+                      ]
+                  },
+                  "type": "custom",
+                  "structure": []
+              }
+          ],
+          "settings": [],
+          "collapsed": [
+              {
+                  "name": "both",
+                  "isCollapsed": false
+              },
+              {
+                  "name": "yes",
+                  "isCollapsed": false
+              },
+              {
+                  "name": "no",
+                  "isCollapsed": false
+              }
+          ],
+          "x": -2682,
+          "y": 16074,
+          "childTrueId": "0C03554A-88E9-4987-8DA7-2707C33613B5",
+          "childFalseId": null
+      },
+      {
+          "id": "0DBF0B78-A809-4DDE-B02F-EF043A628D39",
+          "type": "VariableBlock",
+          "disabled": false,
+          "name": "workingAppList",
+          "displayName": "Variable - workingAppList",
+          "comment": "Empty working list. This will be used to build a list of apps which need upgrading for this specific monitoring app template.",
+          "childId": "981978BE-431B-4AF5-BD0D-451A3885B024",
+          "inputs": [],
+          "settings": [],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2802,
+          "y": 15494,
+          "variableGuid": "B762B4A7-25F9-4764-BECA-D4461377CE04",
+          "operations": [
+              {
+                  "id": "empty",
+                  "key": "7CA93272-5204-449B-845A-AD9E8281F303",
+                  "name": "Empty { variable }",
+                  "value": null
+              }
+          ]
+      },
+      {
+          "id": "5181CCB7-03EB-4C0C-83CC-FD647E7EF358",
+          "type": "VariableBlock",
+          "disabled": false,
+          "name": "workingAppList",
+          "displayName": "Variable - workingAppList",
+          "comment": "Add app to working list.",
+          "childId": "0C14812A-A344-4903-9697-1426DB5C5DFA",
+          "inputs": [],
+          "settings": [],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2202,
+          "y": 16674,
+          "variableGuid": "B762B4A7-25F9-4764-BECA-D4461377CE04",
+          "operations": [
+              {
+                  "id": "add_item",
+                  "key": "D99F10CF-AAA9-4B94-A8DF-ABA631F2BA46",
+                  "name": "Add item to { variable }",
+                  "value": "{ $.loop3.item }"
+              }
+          ]
+      },
+      {
+          "id": "1D37B0B5-533A-4C98-8C0C-5D27CA83E613",
+          "type": "ShowBlock",
+          "disabled": false,
+          "name": "output29",
+          "displayName": "Output 29",
+          "comment": "Status output.",
+          "childId": null,
+          "inputs": [
+              {
+                  "id": "input",
+                  "value": "| {$.loop2.item.name} - Verify | Excluding existing app [{$.loop3.item.name}]({$.tenantHostname}sense/app/{$.loop3.item.resourceId}) in [{$.managedSpaceName}]({$.tenantHostname}analytics/catalog?space_filter={$.managedSpaceId}). **Cannot upgrade since it is missing a version tag. This may result in another copy of the app being deployed.** |",
+                  "type": "string",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "display_mode",
+                  "value": "add",
+                  "type": "select",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2442,
+          "y": 17754
+      },
+      {
+          "id": "0C03554A-88E9-4987-8DA7-2707C33613B5",
+          "type": "FilterListBlock",
+          "disabled": false,
+          "name": "filterList8",
+          "displayName": "Filter List 8",
+          "comment": "Attempt to extract the version from tags.",
+          "childId": "2D10B51D-A303-4112-95D3-722117C7AAC3",
+          "inputs": [
+              {
+                  "id": "list",
+                  "value": "{ $.loop3.item.meta.tags }",
+                  "type": "string",
+                  "structure": []
+              },
+              {
+                  "id": "conditions",
+                  "value": {
+                      "mode": "all",
+                      "conditions": [
+                          {
+                              "input1": "name",
+                              "input2": "QCMA - v",
+                              "operator": "contain"
+                          }
+                      ]
+                  },
+                  "type": "custom",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "automations_censor_data",
+                  "value": false,
+                  "type": "checkbox",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": false
+              }
+          ],
+          "x": -2562,
+          "y": 16154,
+          "loopBlockId": null
+      },
+      {
+          "id": "2D10B51D-A303-4112-95D3-722117C7AAC3",
+          "type": "IfElseBlock",
+          "disabled": false,
+          "name": "condition26",
+          "displayName": "Condition 26",
+          "comment": "If versions were found, continue.",
+          "childId": null,
+          "inputs": [
+              {
+                  "id": "conditions",
+                  "value": {
+                      "mode": "all",
+                      "conditions": [
+                          {
+                              "input1": "{ count: { $.filterList8 } }",
+                              "input2": "0",
+                              "operator": ">"
+                          }
+                      ]
+                  },
+                  "type": "custom",
+                  "structure": []
+              }
+          ],
+          "settings": [],
+          "collapsed": [
+              {
+                  "name": "both",
+                  "isCollapsed": false
+              },
+              {
+                  "name": "yes",
+                  "isCollapsed": false
+              },
+              {
+                  "name": "no",
+                  "isCollapsed": false
+              }
+          ],
+          "x": -2562,
+          "y": 16314,
+          "childTrueId": "7FC2859A-CB6D-4A81-B1B7-8DA4C1DF9E27",
+          "childFalseId": "1D37B0B5-533A-4C98-8C0C-5D27CA83E613"
+      },
+      {
+          "id": "7FC2859A-CB6D-4A81-B1B7-8DA4C1DF9E27",
+          "type": "IfElseBlock",
+          "disabled": false,
+          "name": "condition27",
+          "displayName": "Condition 27",
+          "comment": "If a single version was found.",
+          "childId": null,
+          "inputs": [
+              {
+                  "id": "conditions",
+                  "value": {
+                      "mode": "all",
+                      "conditions": [
+                          {
+                              "input1": "{ count: { $.filterList8 } }",
+                              "input2": "1",
+                              "operator": "="
+                          }
+                      ]
+                  },
+                  "type": "custom",
+                  "structure": []
+              }
+          ],
+          "settings": [],
+          "collapsed": [
+              {
+                  "name": "both",
+                  "isCollapsed": false
+              },
+              {
+                  "name": "yes",
+                  "isCollapsed": false
+              },
+              {
+                  "name": "no",
+                  "isCollapsed": false
+              }
+          ],
+          "x": -2442,
+          "y": 16394,
+          "childTrueId": "C1A9C7CC-6DAC-4E03-B987-F44C2C040BF9",
+          "childFalseId": "A6B5E4EE-819B-4767-AE9A-2E127BD6DC6C"
+      },
+      {
+          "id": "8A8AB1EE-BE5B-46F6-981A-5ABB5FA348D9",
+          "type": "VariableBlock",
+          "disabled": false,
+          "name": "workingAppTagVersion",
+          "displayName": "Variable - workingAppTagVersion",
+          "comment": "Set the QMCA tag for version.",
+          "childId": "6D0F022E-164E-4CE3-B955-5961AA02A540",
+          "inputs": [],
+          "settings": [],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2802,
+          "y": 15854,
+          "variableGuid": "4CFD6FDB-6937-45CE-8677-203A280087D1",
+          "operations": [
+              {
+                  "id": "set_value",
+                  "key": "B91BCBEA-54E0-41DF-81C7-D893EA467F77",
+                  "name": "Set value of { variable }",
+                  "value": "QCMA - { $.loop2.item.version }"
+              }
+          ]
+      },
+      {
+          "id": "6035B77C-4061-44DD-B0B4-BA016EF2F537",
+          "type": "VariableBlock",
+          "disabled": false,
+          "name": "workingAppTagName",
+          "displayName": "Variable - workingAppTagName",
+          "comment": "Set the QMCA tag for name.",
+          "childId": "8A8AB1EE-BE5B-46F6-981A-5ABB5FA348D9",
+          "inputs": [],
+          "settings": [],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2802,
+          "y": 15734,
+          "variableGuid": "12A37AC8-CD9C-41FC-9626-508B24997C86",
+          "operations": [
+              {
+                  "id": "set_value",
+                  "key": "B91BCBEA-54E0-41DF-81C7-D893EA467F77",
+                  "name": "Set value of { variable }",
+                  "value": "QCMA - { $.loop2.item.name }"
+              }
+          ]
+      },
+      {
+          "id": "A6B5E4EE-819B-4767-AE9A-2E127BD6DC6C",
+          "type": "ShowBlock",
+          "disabled": false,
+          "name": "output28",
+          "displayName": "Output 28",
+          "comment": "Status output.",
+          "childId": null,
+          "inputs": [
+              {
+                  "id": "input",
+                  "value": "| {$.loop2.item.name} - Verify | Excluding existing app [{$.loop3.item.name}]({$.tenantHostname}sense/app/{$.loop3.item.resourceId}) in [{$.managedSpaceName}]({$.tenantHostname}analytics/catalog?space_filter={$.managedSpaceId}). **Cannot upgrade since it has multiple version tags. This may result in another copy of the app being deployed.** |",
+                  "type": "string",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "display_mode",
+                  "value": "add",
+                  "type": "select",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2322,
+          "y": 17514
+      },
+      {
+          "id": "EE2B05F0-E29D-4EF4-8016-AD92050B6D2D",
+          "type": "ShowBlock",
+          "disabled": false,
+          "name": "output26",
+          "displayName": "Output 26",
+          "comment": "Status output.",
+          "childId": "5181CCB7-03EB-4C0C-83CC-FD647E7EF358",
+          "inputs": [
+              {
+                  "id": "input",
+                  "value": "| {$.loop2.item.name} - Verify | Found existing app [{$.loop3.item.name}]({$.tenantHostname}sense/app/{$.loop3.item.resourceId}) in [{$.managedSpaceName}]({$.tenantHostname}analytics/catalog?space_filter={$.managedSpaceId}). **Will be updated from {replace: { $.filterList8[0].name }, 'QCMA - '} to {$.loop2.item.version}.** |",
+                  "type": "string",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "display_mode",
+                  "value": "add",
+                  "type": "select",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2202,
+          "y": 16554
+      },
+      {
+          "id": "C1A9C7CC-6DAC-4E03-B987-F44C2C040BF9",
+          "type": "IfElseBlock",
+          "disabled": false,
+          "name": "condition28",
+          "displayName": "Condition 28",
+          "comment": "Check if redeploy needed. This is done on a plain string comparison.",
+          "childId": "CA3E018B-042B-421C-9FFE-B53DFA5E392A",
+          "inputs": [
+              {
+                  "id": "conditions",
+                  "value": {
+                      "mode": "all",
+                      "conditions": [
+                          {
+                              "input1": "{ $.workingAppTagVersion }",
+                              "input2": "{ $.filterList8[0].name }",
+                              "operator": "!="
+                          }
+                      ]
+                  },
+                  "type": "custom",
+                  "structure": []
+              }
+          ],
+          "settings": [],
+          "collapsed": [
+              {
+                  "name": "both",
+                  "isCollapsed": false
+              },
+              {
+                  "name": "yes",
+                  "isCollapsed": false
+              },
+              {
+                  "name": "no",
+                  "isCollapsed": false
+              }
+          ],
+          "x": -2322,
+          "y": 16474,
+          "childTrueId": "EE2B05F0-E29D-4EF4-8016-AD92050B6D2D",
+          "childFalseId": "6E0F226F-5497-4493-9201-8FB2CFE66C25"
+      },
+      {
+          "id": "981978BE-431B-4AF5-BD0D-451A3885B024",
+          "type": "VariableBlock",
+          "disabled": false,
+          "name": "workingAppExists",
+          "displayName": "Variable - workingAppExists",
+          "comment": "Reset the workingAppExists var, used for determining if there's already an up to date app.",
+          "childId": "6035B77C-4061-44DD-B0B4-BA016EF2F537",
+          "inputs": [],
+          "settings": [],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2802,
+          "y": 15614,
+          "variableGuid": "D8F8BD27-8FF5-42FF-82ED-0EE947E55327",
+          "operations": [
+              {
+                  "id": "set_value",
+                  "key": "8475B0B8-FEAB-437B-A7D1-3889CBBD80AC",
+                  "name": "Set value of { variable }",
+                  "value": "0"
+              }
+          ]
+      },
+      {
+          "id": "7BE1652F-2F1F-462E-9EAF-12AD879C8340",
+          "type": "VariableBlock",
+          "disabled": false,
+          "name": "workingAppExists",
+          "displayName": "Variable - workingAppExists",
+          "comment": "Set to 1 to skip new app import.",
+          "childId": null,
+          "inputs": [],
+          "settings": [],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2202,
+          "y": 17074,
+          "variableGuid": "D8F8BD27-8FF5-42FF-82ED-0EE947E55327",
+          "operations": [
+              {
+                  "id": "set_value",
+                  "key": "8475B0B8-FEAB-437B-A7D1-3889CBBD80AC",
+                  "name": "Set value of { variable }",
+                  "value": "1"
+              }
+          ]
+      },
+      {
+          "id": "6E0F226F-5497-4493-9201-8FB2CFE66C25",
+          "type": "ShowBlock",
+          "disabled": false,
+          "name": "output27",
+          "displayName": "Output 27",
+          "comment": "Status output.",
+          "childId": "7BE1652F-2F1F-462E-9EAF-12AD879C8340",
+          "inputs": [
+              {
+                  "id": "input",
+                  "value": "| {$.loop2.item.name} - Verify | Skipping existing app [{$.loop3.item.name}]({$.tenantHostname}sense/app/{$.loop3.item.resourceId}) in [{$.managedSpaceName}]({$.tenantHostname}analytics/catalog?space_filter={$.managedSpaceId}) as it is already at version {$.loop2.item.version}.  |",
+                  "type": "string",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "display_mode",
+                  "value": "add",
+                  "type": "select",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2202,
+          "y": 16954
+      },
+      {
+          "id": "0C14812A-A344-4903-9697-1426DB5C5DFA",
+          "type": "VariableBlock",
+          "disabled": false,
+          "name": "workingAppExists",
+          "displayName": "Variable - workingAppExists",
+          "comment": "Set to 1 to skip new app import.",
+          "childId": null,
+          "inputs": [],
+          "settings": [],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2202,
+          "y": 16794,
+          "variableGuid": "D8F8BD27-8FF5-42FF-82ED-0EE947E55327",
+          "operations": [
+              {
+                  "id": "set_value",
+                  "key": "8475B0B8-FEAB-437B-A7D1-3889CBBD80AC",
+                  "name": "Set value of { variable }",
+                  "value": "1"
+              }
+          ]
+      },
+      {
+          "id": "7FF48E4E-FF7E-4BE2-B5E2-5178171BC9CF",
+          "type": "ShowBlock",
+          "disabled": false,
+          "name": "output31",
+          "displayName": "Output 31",
+          "comment": "Status output.",
+          "childId": "4F36612D-0B32-4DA5-9803-85D5EEB3EDCB",
+          "inputs": [
+              {
+                  "id": "input",
+                  "value": "| {$.loop2.item.name} - Prepare | > Pulling and importing version {$.loop2.item.version} of {$.loop2.item.name} from manifest to shared space. |",
+                  "type": "string",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "display_mode",
+                  "value": "add",
+                  "type": "select",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2682,
+          "y": 18474
+      },
+      {
+          "id": "4F36612D-0B32-4DA5-9803-85D5EEB3EDCB",
+          "type": "CallUrlBlock",
+          "disabled": false,
+          "name": "callURL3",
+          "displayName": "Call URL 3",
+          "comment": "Get the qvf.",
+          "childId": "9E937365-2524-466B-95E9-309B3293FF8D",
+          "inputs": [
+              {
+                  "id": "url",
+                  "value": "{ $.loop2.item.source }",
+                  "type": "string",
+                  "structure": []
+              },
+              {
+                  "id": "method",
+                  "value": "GET",
+                  "type": "select",
+                  "structure": []
+              },
+              {
+                  "id": "timeout",
+                  "value": "",
+                  "type": "string",
+                  "structure": []
+              },
+              {
+                  "id": "params",
+                  "value": null,
+                  "type": "object",
+                  "mode": "keyValue",
+                  "structure": []
+              },
+              {
+                  "id": "headers",
+                  "value": null,
+                  "type": "object",
+                  "mode": "keyValue",
+                  "structure": []
+              },
+              {
+                  "id": "encoding",
+                  "value": "",
+                  "type": "string",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "blendr_on_error",
+                  "value": "stop",
+                  "type": "select",
+                  "structure": []
+              },
+              {
+                  "id": "full_response",
+                  "value": null,
+                  "type": "checkbox",
+                  "structure": []
+              },
+              {
+                  "id": "capitalize_headers",
+                  "value": true,
+                  "type": "checkbox",
+                  "structure": []
+              },
+              {
+                  "id": "automations_censor_data",
+                  "value": false,
+                  "type": "checkbox",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2682,
+          "y": 18594
+      },
+      {
+          "id": "9E937365-2524-466B-95E9-309B3293FF8D",
+          "type": "VariableBlock",
+          "disabled": false,
+          "name": "workingAppBinary",
+          "displayName": "Variable - workingAppBinary",
+          "comment": "Variable to store base64 encoded value of the qvf.",
+          "childId": "8E819B1F-C085-4394-B9FA-537D1A20F440",
+          "inputs": [],
+          "settings": [],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2682,
+          "y": 18714,
+          "variableGuid": "996190EC-165A-4CF1-A3B6-363B8F0DDF31",
+          "operations": [
+              {
+                  "id": "set_value",
+                  "key": "DDDC649C-D1BB-490B-B4E1-926F95F3B0C2",
+                  "name": "Set value of { variable }",
+                  "value": "{ base64encode: { $.callURL3 } }"
+              }
+          ]
+      },
+      {
+          "id": "8E819B1F-C085-4394-B9FA-537D1A20F440",
+          "type": "EndpointBlock",
+          "disabled": false,
+          "name": "importAppFromBase64EncodedFile",
+          "displayName": "Qlik Cloud Services - Import App From Base 64 Encoded File",
+          "comment": "Import monitoring app to the shared space.",
+          "childId": "B6ED8700-7AB0-4251-9DFF-93B9ACBF7CD3",
+          "inputs": [
+              {
+                  "id": "09b520a0-7aa4-11eb-8143-cde65e595ead",
+                  "value": "{ $.workingAppBinary }",
+                  "type": "string",
+                  "structure": []
+              },
+              {
+                  "id": "19661000-67b1-11eb-b4c6-fb30d89c586f",
+                  "value": "{ $.loop2.item.name } - { $.loop2.item.version }",
+                  "type": "string",
+                  "structure": []
+              },
+              {
+                  "id": "197675a0-67b1-11eb-b6f6-9ff3bc51ddbf",
+                  "value": "{ $.sharedSpaceId }",
+                  "type": "string",
+                  "structure": []
+              },
+              {
+                  "id": "4d3a3300-67b1-11eb-99af-3d55175faa9a",
+                  "value": null,
+                  "type": "select",
+                  "structure": []
+              },
+              {
+                  "id": "ac4b58f0-67b1-11eb-8126-89d0cf328adb",
+                  "value": null,
+                  "type": "string",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "blendr_on_error",
+                  "value": "stop",
+                  "type": "select",
+                  "structure": []
+              },
+              {
+                  "id": "automations_censor_data",
+                  "value": false,
+                  "type": "checkbox",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2682,
+          "y": 18834,
+          "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
+          "endpoint_guid": "194b9430-67b1-11eb-9e04-6dbde84bea83",
+          "endpoint_role": "create"
+      },
+      {
+          "id": "13CAF0D2-CA0F-41DE-BC1C-1E48738ED4C3",
+          "type": "ShowBlock",
+          "disabled": false,
+          "name": "output32",
+          "displayName": "Output 32",
+          "comment": "Status output.",
+          "childId": "142A4710-D6DC-4919-BE1C-54A699EED20A",
+          "inputs": [
+              {
+                  "id": "input",
+                  "value": "| {$.loop2.item.name} - Import | > Imported version {$.loop2.item.version} of [{ $.importAppFromBase64EncodedFile.attributes.name }]({$.tenantHostname}sense/app/{ $.importAppFromBase64EncodedFile.attributes.id }) to [{$.sharedSpaceName}]({$.tenantHostname}analytics/catalog?space_filter={$.sharedSpaceId}). |",
+                  "type": "string",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "display_mode",
+                  "value": "add",
+                  "type": "select",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2682,
+          "y": 19194
+      },
+      {
+          "id": "40EC15FE-C25F-442B-8CD9-5C87150436B3",
+          "type": "IfElseBlock",
+          "disabled": false,
+          "name": "condition30",
+          "displayName": "Condition 30",
+          "comment": "If new app needed, show notification in the timeline.",
+          "childId": "7FF48E4E-FF7E-4BE2-B5E2-5178171BC9CF",
+          "inputs": [
+              {
+                  "id": "conditions",
+                  "value": {
+                      "mode": "all",
+                      "conditions": [
+                          {
+                              "input1": "{ $.workingAppExists }",
+                              "input2": "0",
+                              "operator": "="
+                          }
+                      ]
+                  },
+                  "type": "custom",
+                  "structure": []
+              }
+          ],
+          "settings": [],
+          "collapsed": [
+              {
+                  "name": "both",
+                  "isCollapsed": false
+              },
+              {
+                  "name": "yes",
+                  "isCollapsed": false
+              },
+              {
+                  "name": "no",
+                  "isCollapsed": false
+              }
+          ],
+          "x": -2682,
+          "y": 18194,
+          "childTrueId": "BC596D9A-38F8-4F9A-8DC9-1D0DC81A57C4",
+          "childFalseId": null
+      },
+      {
+          "id": "BC596D9A-38F8-4F9A-8DC9-1D0DC81A57C4",
+          "type": "ShowBlock",
+          "disabled": false,
+          "name": "output30",
+          "displayName": "Output 30",
+          "comment": "Status output.",
+          "childId": null,
+          "inputs": [
+              {
+                  "id": "input",
+                  "value": "| {$.loop2.item.name} - Verify | The {$.loop2.item.name} was not found in [{$.managedSpaceName}]({$.tenantHostname}analytics/catalog?space_filter={$.managedSpaceId}). **Will be imported.** |",
+                  "type": "string",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "display_mode",
+                  "value": "add",
+                  "type": "select",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2562,
+          "y": 18274
+      },
+      {
+          "id": "15A91B88-3C31-400B-A2C8-D697AB8F175E",
+          "type": "ShowBlock",
+          "disabled": false,
+          "name": "output38",
+          "displayName": "Output 38",
+          "comment": "Status output.",
+          "childId": "00332E92-9B25-4849-B799-0A68E5F4931B",
+          "inputs": [
+              {
+                  "id": "input",
+                  "value": "| {$.loop2.item.name} - Publish | > Deployed [{$.loop3.item.name}]({$.tenantHostname}sense/app/{$.publishAppToManagedSpace.attributes.id}) to [{$.managedSpaceName}]({$.tenantHostname}analytics/catalog?space_filter={$.managedSpaceId}). |",
+                  "type": "string",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "display_mode",
+                  "value": "add",
+                  "type": "select",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2562,
+          "y": 21494
+      },
+      {
+          "id": "ECB7B639-F151-4B44-A89E-491B20BE66F3",
+          "type": "IfElseBlock",
+          "disabled": false,
+          "name": "condition32",
+          "displayName": "Condition 32",
+          "comment": "If new app needed, publish it.",
+          "childId": "4BE16981-95D8-4418-B598-B26CA6843820",
+          "inputs": [
+              {
+                  "id": "conditions",
+                  "value": {
+                      "mode": "all",
+                      "conditions": [
+                          {
+                              "input1": "{ $.workingAppExists }",
+                              "input2": "0",
+                              "operator": "="
+                          }
+                      ]
+                  },
+                  "type": "custom",
+                  "structure": []
+              }
+          ],
+          "settings": [],
+          "collapsed": [
+              {
+                  "name": "both",
+                  "isCollapsed": false
+              },
+              {
+                  "name": "yes",
+                  "isCollapsed": false
+              },
+              {
+                  "name": "no",
+                  "isCollapsed": false
+              }
+          ],
+          "x": -2682,
+          "y": 21174,
+          "childTrueId": "35EFB375-D90C-4F76-A966-47EDB1EAFAD2",
+          "childFalseId": "9EE0A5EF-EE84-4F46-811E-312073C232C6"
+      },
+      {
+          "id": "35EFB375-D90C-4F76-A966-47EDB1EAFAD2",
+          "type": "SnippetBlock",
+          "disabled": false,
+          "name": "publishAppToManagedSpace",
+          "displayName": "Qlik Cloud Services - Publish App To Managed Space",
+          "comment": "Publish monitoring app to managed space.",
+          "childId": "F8D411D5-6606-4BC1-BA09-2A24611D4B6A",
+          "inputs": [
+              {
+                  "id": "a0ab6dc0-00e2-11ec-92c0-fb834a93ff56",
+                  "value": "{ $.importAppFromBase64EncodedFile.attributes.id }",
+                  "type": "string",
+                  "structure": []
+              },
+              {
+                  "id": "a0ad09d0-00e2-11ec-b2c8-8587b72a110a",
+                  "value": "{ $.managedSpaceId }",
+                  "type": "string",
+                  "structure": []
+              },
+              {
+                  "id": "a0ad4d20-00e2-11ec-8cad-07ca8dd4b022",
+                  "value": "source",
+                  "type": "select",
+                  "displayValue": "source",
+                  "structure": []
+              },
+              {
+                  "id": "03f6be80-22bf-11ec-bd94-cfe02119d15e",
+                  "value": "Always publish",
+                  "type": "select",
+                  "displayValue": "Always publish",
+                  "structure": []
+              },
+              {
+                  "id": "e5b375a0-83ec-11ec-83cd-6d152b88c9ae",
+                  "value": "{ $.loop2.item.name }",
+                  "type": "string",
+                  "structure": []
+              },
+              {
+                  "id": "e5b45230-83ec-11ec-8c07-d9449d54e6ff",
+                  "value": null,
+                  "type": "string",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "blendr_on_error",
+                  "value": "stop",
+                  "type": "select",
+                  "structure": []
+              },
+              {
+                  "id": "automations_censor_data",
+                  "value": false,
+                  "type": "checkbox",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2562,
+          "y": 21254,
+          "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
+          "snippet_guid": "76a45090-00e1-11ec-ad85-b3b86b5b9a24"
+      },
+      {
+          "id": "FF63005B-73C8-4593-8609-AC99855C7167",
+          "type": "EndpointBlock",
+          "disabled": false,
+          "name": "rawAPIRequest10",
+          "displayName": "Qlik Cloud Services - Raw API Request 10",
+          "comment": "Get item ID of app",
+          "childId": "13CAF0D2-CA0F-41DE-BC1C-1E48738ED4C3",
+          "inputs": [
+              {
+                  "id": "734cbcc0-bbb0-11f0-b998-f73920377683",
+                  "value": "v1/items",
+                  "type": "string",
+                  "structure": []
+              },
+              {
+                  "id": "7322a550-bbb0-11f0-9c8c-43f143a32456",
+                  "value": "7341e840-bbb0-11f0-9bb8-11c201f87b6d",
+                  "type": "select",
+                  "displayValue": "GET",
+                  "structure": []
+              },
+              {
+                  "id": "73000fe0-bbb0-11f0-8a80-59ece3571bd9",
+                  "value": null,
+                  "type": "object",
+                  "mode": "keyValue",
+                  "structure": []
+              },
+              {
+                  "id": "736fae60-bbb0-11f0-ad62-c98a0046f418",
+                  "value": [
+                      {
+                          "key": "resourceId",
+                          "value": "{$.importAppFromBase64EncodedFile.attributes.id}"
+                      },
+                      {
+                          "key": "resourceType",
+                          "value": "app"
+                      }
+                  ],
+                  "type": "object",
+                  "mode": "keyValue",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "blendr_on_error",
+                  "value": "stop",
+                  "type": "select",
+                  "structure": []
+              },
+              {
+                  "id": "automations_censor_data",
+                  "value": false,
+                  "type": "checkbox",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2682,
+          "y": 19074,
+          "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
+          "endpoint_guid": "72d48530-bbb0-11f0-875a-b322bf237aeb",
+          "endpoint_role": "create"
+      },
+      {
+          "id": "B6ED8700-7AB0-4251-9DFF-93B9ACBF7CD3",
+          "type": "SleepBlock",
+          "disabled": false,
+          "name": "sleep",
+          "displayName": "Sleep",
+          "comment": "Wait for items to be aware of app.",
+          "childId": "FF63005B-73C8-4593-8609-AC99855C7167",
+          "inputs": [
+              {
+                  "id": "time",
+                  "value": "5",
+                  "type": "string",
+                  "structure": []
+              }
+          ],
+          "settings": [],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2682,
+          "y": 18954
+      },
+      {
+          "id": "9F37EC62-2694-40D2-8DB1-7F5265D9EB9F",
+          "type": "VariableBlock",
+          "disabled": false,
+          "name": "workingAppTags",
+          "displayName": "Variable - workingAppTags",
+          "comment": "Create object for assigning tags.",
+          "childId": "22D8A6B4-A055-40DE-BA67-0638D6005250",
+          "inputs": [],
+          "settings": [],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2682,
+          "y": 19794,
+          "variableGuid": "AE6C347F-BAAD-4FD0-A820-80AFEE588B29",
+          "operations": [
+              {
+                  "id": "empty",
+                  "key": "D2338734-D49E-498C-A550-01B971BAC5C1",
+                  "name": "Empty { variable }",
+                  "value": null
+              },
+              {
+                  "id": "set_key_value",
+                  "key": "4FFB7E92-7F6F-4A27-ADA6-FBC6DF13C3B3",
+                  "name": "Set key/values of { variable }",
+                  "value": [
+                      {
+                          "key": "appTag",
+                          "value": "{ $.workingAppTagName }"
+                      },
+                      {
+                          "key": "versionTag",
+                          "value": "{ $.workingAppTagVersion }"
+                      }
+                  ]
+              }
+          ]
+      },
+      {
+          "id": "22D8A6B4-A055-40DE-BA67-0638D6005250",
+          "type": "ForEachBlock",
+          "disabled": false,
+          "name": "loop4",
+          "displayName": "Loop 4",
+          "comment": "Loop over tags.",
+          "childId": "ECB7B639-F151-4B44-A89E-491B20BE66F3",
+          "inputs": [
+              {
+                  "id": "input",
+                  "value": "{ $.workingAppTags }",
+                  "type": "string",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "automations_censor_data",
+                  "value": false,
+                  "type": "checkbox",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": false
+              }
+          ],
+          "x": -2682,
+          "y": 19914,
+          "loopBlockId": "AFD7305E-B419-4128-95D3-1A9EAF98F9C8"
+      },
+      {
+          "id": "AFD7305E-B419-4128-95D3-1A9EAF98F9C8",
+          "type": "EndpointBlock",
+          "disabled": false,
+          "name": "rawAPIRequest11",
+          "displayName": "Qlik Cloud Services - Raw API Request 11",
+          "comment": "Filter the collection by name.",
+          "childId": "487F3340-7989-4675-9B60-AE93E556E5CD",
+          "inputs": [
+              {
+                  "id": "734cbcc0-bbb0-11f0-b998-f73920377683",
+                  "value": "v1/collections",
+                  "type": "string",
+                  "structure": []
+              },
+              {
+                  "id": "7322a550-bbb0-11f0-9c8c-43f143a32456",
+                  "value": "7341e840-bbb0-11f0-9bb8-11c201f87b6d",
+                  "type": "select",
+                  "displayValue": "GET",
+                  "structure": []
+              },
+              {
+                  "id": "73000fe0-bbb0-11f0-8a80-59ece3571bd9",
+                  "value": null,
+                  "type": "object",
+                  "mode": "keyValue",
+                  "structure": []
+              },
+              {
+                  "id": "736fae60-bbb0-11f0-ad62-c98a0046f418",
+                  "value": [
+                      {
+                          "key": "name",
+                          "value": "{ $.loop4.item }"
+                      },
+                      {
+                          "key": "type",
+                          "value": "public"
+                      }
+                  ],
+                  "type": "object",
+                  "mode": "keyValue",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "blendr_on_error",
+                  "value": "stop",
+                  "type": "select",
+                  "structure": []
+              },
+              {
+                  "id": "automations_censor_data",
+                  "value": false,
+                  "type": "checkbox",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2562,
+          "y": 20014,
+          "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
+          "endpoint_guid": "72d48530-bbb0-11f0-875a-b322bf237aeb",
+          "endpoint_role": "create"
+      },
+      {
+          "id": "487F3340-7989-4675-9B60-AE93E556E5CD",
+          "type": "IfElseBlock",
+          "disabled": false,
+          "name": "condition31",
+          "displayName": "Condition 31",
+          "comment": "Check if tag exists",
+          "childId": "B8418877-08D1-44AE-BCD4-B5FBA442AFDC",
+          "inputs": [
+              {
+                  "id": "conditions",
+                  "value": {
+                      "mode": "all",
+                      "conditions": [
+                          {
+                              "input1": "{count: {$.rawAPIRequest11.data}}",
+                              "input2": "0",
+                              "operator": ">"
+                          }
+                      ]
+                  },
+                  "type": "custom",
+                  "structure": []
+              }
+          ],
+          "settings": [],
+          "collapsed": [
+              {
+                  "name": "both",
+                  "isCollapsed": false
+              },
+              {
+                  "name": "yes",
+                  "isCollapsed": false
+              },
+              {
+                  "name": "no",
+                  "isCollapsed": false
+              }
+          ],
+          "x": -2562,
+          "y": 20134,
+          "childTrueId": "814E1A6D-6BCB-47DD-BD1D-39EC0CA9C101",
+          "childFalseId": "4DA2DA61-2BB9-41DB-B354-3A2B8C5F2F2E"
+      },
+      {
+          "id": "B8418877-08D1-44AE-BCD4-B5FBA442AFDC",
+          "type": "EndpointBlock",
+          "disabled": false,
+          "name": "rawAPIRequest13",
+          "displayName": "Qlik Cloud Services - Raw API Request 13",
+          "comment": "Add the tag to the item.",
+          "childId": "E3272B0B-EA20-485E-BAF3-E24EDF5D1931",
+          "inputs": [
+              {
+                  "id": "734cbcc0-bbb0-11f0-b998-f73920377683",
+                  "value": "v1/collections/{$.taggerIds.{ $.loop4.index }}/items",
+                  "type": "string",
+                  "structure": []
+              },
+              {
+                  "id": "7322a550-bbb0-11f0-9c8c-43f143a32456",
+                  "value": "7347ee10-bbb0-11f0-8cdc-59311dd108b3",
+                  "type": "select",
+                  "displayValue": "POST",
+                  "structure": []
+              },
+              {
+                  "id": "73000fe0-bbb0-11f0-8a80-59ece3571bd9",
+                  "value": "{\n  \"id\": \"{ $.rawAPIRequest10.data[0].id }\"\n}",
+                  "type": "object",
+                  "mode": "raw",
+                  "structure": []
+              },
+              {
+                  "id": "736fae60-bbb0-11f0-ad62-c98a0046f418",
+                  "value": null,
+                  "type": "object",
+                  "mode": "keyValue",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "blendr_on_error",
+                  "value": "stop",
+                  "type": "select",
+                  "structure": []
+              },
+              {
+                  "id": "automations_censor_data",
+                  "value": false,
+                  "type": "checkbox",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2562,
+          "y": 20894,
+          "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
+          "endpoint_guid": "72d48530-bbb0-11f0-875a-b322bf237aeb",
+          "endpoint_role": "create"
+      },
+      {
+          "id": "E3272B0B-EA20-485E-BAF3-E24EDF5D1931",
+          "type": "ShowBlock",
+          "disabled": false,
+          "name": "output37",
+          "displayName": "Output 37",
+          "comment": "Tag added.",
+          "childId": null,
+          "inputs": [
+              {
+                  "id": "input",
+                  "value": "| {$.loop2.item.name} - Tags (shared) | > Tag `{$.loop4.item}` added to shared space app. |",
+                  "type": "string",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "display_mode",
+                  "value": "add",
+                  "type": "select",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2562,
+          "y": 21014
+      },
+      {
+          "id": "814E1A6D-6BCB-47DD-BD1D-39EC0CA9C101",
+          "type": "ShowBlock",
+          "disabled": false,
+          "name": "output35",
+          "displayName": "Output 35",
+          "comment": "Tag exists.",
+          "childId": "E287D197-83E3-4C50-8598-34DDB03BD857",
+          "inputs": [
+              {
+                  "id": "input",
+                  "value": "| {$.loop2.item.name} - Tags | > Tag `{$.loop4.item}` exists. |",
+                  "type": "string",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "display_mode",
+                  "value": "add",
+                  "type": "select",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2442,
+          "y": 20214
+      },
+      {
+          "id": "E287D197-83E3-4C50-8598-34DDB03BD857",
+          "type": "VariableBlock",
+          "disabled": false,
+          "name": "taggerIds",
+          "displayName": "Variable - taggerIds",
+          "comment": "Store the tag ID.",
+          "childId": null,
+          "inputs": [],
+          "settings": [],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2442,
+          "y": 20334,
+          "variableGuid": "FA7C823B-3AA8-41EA-990F-21837758447A",
+          "operations": [
+              {
+                  "id": "set_key_value",
+                  "key": "4C765E64-0A7C-4AFC-8301-E428E0E60E9B",
+                  "name": "Set key/values of { variable }",
+                  "value": [
+                      {
+                          "key": "{ $.loop4.index }",
+                          "value": "{$.rawAPIRequest11.data[0].id}"
+                      }
+                  ]
+              }
+          ]
+      },
+      {
+          "id": "984029CA-4EC0-4912-880A-0FA2010E9747",
+          "type": "ShowBlock",
+          "disabled": false,
+          "name": "output36",
+          "displayName": "Output 36",
+          "comment": "Create tag.",
+          "childId": "240DE4BD-65CF-4B9F-BAEA-D6469B83CB50",
+          "inputs": [
+              {
+                  "id": "input",
+                  "value": "| {$.loop2.item.name} - Tags | > Tag does not exist. Created tag `{$.loop4.item}`. |",
+                  "type": "string",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "display_mode",
+                  "value": "add",
+                  "type": "select",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2442,
+          "y": 20614
+      },
+      {
+          "id": "4DA2DA61-2BB9-41DB-B354-3A2B8C5F2F2E",
+          "type": "EndpointBlock",
+          "disabled": false,
+          "name": "rawAPIRequest12",
+          "displayName": "Qlik Cloud Services - Raw API Request 12",
+          "comment": "Create new collection",
+          "childId": "984029CA-4EC0-4912-880A-0FA2010E9747",
+          "inputs": [
+              {
+                  "id": "734cbcc0-bbb0-11f0-b998-f73920377683",
+                  "value": "v1/collections",
+                  "type": "string",
+                  "structure": []
+              },
+              {
+                  "id": "7322a550-bbb0-11f0-9c8c-43f143a32456",
+                  "value": "7347ee10-bbb0-11f0-8cdc-59311dd108b3",
+                  "type": "select",
+                  "displayValue": "POST",
+                  "structure": []
+              },
+              {
+                  "id": "73000fe0-bbb0-11f0-8a80-59ece3571bd9",
+                  "value": "{\"type\":\"public\",\"name\":\"{ $.loop4.item }\"}",
+                  "type": "object",
+                  "mode": "raw",
+                  "structure": []
+              },
+              {
+                  "id": "736fae60-bbb0-11f0-ad62-c98a0046f418",
+                  "value": null,
+                  "type": "object",
+                  "mode": "keyValue",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "blendr_on_error",
+                  "value": "stop",
+                  "type": "select",
+                  "structure": []
+              },
+              {
+                  "id": "automations_censor_data",
+                  "value": false,
+                  "type": "checkbox",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2442,
+          "y": 20494,
+          "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
+          "endpoint_guid": "72d48530-bbb0-11f0-875a-b322bf237aeb",
+          "endpoint_role": "create"
+      },
+      {
+          "id": "240DE4BD-65CF-4B9F-BAEA-D6469B83CB50",
+          "type": "VariableBlock",
+          "disabled": false,
+          "name": "taggerIds",
+          "displayName": "Variable - taggerIds",
+          "comment": "Store the tag ID.",
+          "childId": null,
+          "inputs": [],
+          "settings": [],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2442,
+          "y": 20734,
+          "variableGuid": "FA7C823B-3AA8-41EA-990F-21837758447A",
+          "operations": [
+              {
+                  "id": "set_key_value",
+                  "key": "4C765E64-0A7C-4AFC-8301-E428E0E60E9B",
+                  "name": "Set key/values of { variable }",
+                  "value": [
+                      {
+                          "key": "{ $.loop4.index }",
+                          "value": "{ $.rawAPIRequest12.id }"
+                      }
+                  ]
+              }
+          ]
+      },
+      {
+          "id": "142A4710-D6DC-4919-BE1C-54A699EED20A",
+          "type": "ShowBlock",
+          "disabled": false,
+          "name": "output33",
+          "displayName": "Output 33",
+          "comment": "Altering load script.",
+          "childId": "73B15F09-DCC3-43F4-8DCB-9ACE58E3FACF",
+          "inputs": [
+              {
+                  "id": "input",
+                  "value": "| {$.loop2.item.name} - Load script | > Modifying the load script of the source app so that it can be reloaded using the 'monitoring_apps_REST' data connection within the managed space. |",
+                  "type": "string",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "display_mode",
+                  "value": "add",
+                  "type": "select",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2682,
+          "y": 19314
+      },
+      {
+          "id": "73B15F09-DCC3-43F4-8DCB-9ACE58E3FACF",
+          "type": "SnippetBlock",
+          "disabled": false,
+          "name": "GetLoadScript",
+          "displayName": "Qlik Cloud Services - Get Load Script",
+          "comment": "Get the load script.",
+          "childId": "2A346057-D71F-4D36-87AA-DA1A1EEC1DA0",
+          "inputs": [
+              {
+                  "id": "299dd6e0-7535-11eb-a1b1-8108a69d86b2",
+                  "value": "{$.importAppFromBase64EncodedFile.attributes.id}",
+                  "type": "string",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "blendr_on_error",
+                  "value": "stop",
+                  "type": "select",
+                  "structure": []
+              },
+              {
+                  "id": "automations_censor_data",
+                  "value": false,
+                  "type": "checkbox",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2682,
+          "y": 19434,
+          "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
+          "snippet_guid": "8d2f7da0-5028-11eb-8889-317a6c8ea7fc"
+      },
+      {
+          "id": "2A346057-D71F-4D36-87AA-DA1A1EEC1DA0",
+          "type": "EndpointBlock",
+          "disabled": false,
+          "name": "setLoadScript",
+          "displayName": "Qlik Cloud Services - Set Load Script",
+          "comment": "Modify vu_rest_connection to point to the managed space.",
+          "childId": "36997A20-8F70-47D6-88BD-91AC1E0DB2E1",
+          "inputs": [
+              {
+                  "id": "917b8660-a12b-11ed-873f-fd156b9f0ebb",
+                  "value": "{$.importAppFromBase64EncodedFile.attributes.id}",
+                  "type": "string",
+                  "structure": []
+              },
+              {
+                  "id": "d31e0400-a12c-11ed-b43b-29c58fb1f869",
+                  "value": "{replace: {$.GetLoadScript.qScript}, \"':{ $.dataConnectionName }'\", {if: {textlength: {regexparse: '{$.managedSpaceName}', \"(')\"}} > 0, `{ $.managedSpaceName }:{ $.dataConnectionName }`, \"'{ $.managedSpaceName }:monitoring_apps_REST'\"}}",
+                  "type": "string",
+                  "structure": []
+              },
+              {
+                  "id": "0da08560-a12d-11ed-92bf-6146d9e01e80",
+                  "value": "Updated REST connector reference to point to managed space.",
+                  "type": "string",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "blendr_on_error",
+                  "value": "stop",
+                  "type": "select",
+                  "structure": []
+              },
+              {
+                  "id": "automations_censor_data",
+                  "value": false,
+                  "type": "checkbox",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2682,
+          "y": 19554,
+          "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
+          "endpoint_guid": "916661a0-a12b-11ed-882f-fb01a4e99b0a",
+          "endpoint_role": "create"
+      },
+      {
+          "id": "36997A20-8F70-47D6-88BD-91AC1E0DB2E1",
+          "type": "ShowBlock",
+          "disabled": false,
+          "name": "output34",
+          "displayName": "Output 34",
+          "comment": "Load script updated.",
+          "childId": "9F37EC62-2694-40D2-8DB1-7F5265D9EB9F",
+          "inputs": [
+              {
+                  "id": "input",
+                  "value": "| {$.loop2.item.name} - Load script | > Load script updated. |",
+                  "type": "string",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "display_mode",
+                  "value": "add",
+                  "type": "select",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2682,
+          "y": 19674
+      },
+      {
+          "id": "9EE0A5EF-EE84-4F46-811E-312073C232C6",
+          "type": "ForEachBlock",
+          "disabled": false,
+          "name": "loop6",
+          "displayName": "Loop 6",
+          "comment": "Loop over existing apps to update them.",
+          "childId": null,
+          "inputs": [
+              {
+                  "id": "input",
+                  "value": "{ $.workingAppList }",
+                  "type": "string",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "automations_censor_data",
+                  "value": false,
+                  "type": "checkbox",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": false
+              }
+          ],
+          "x": -2562,
+          "y": 22274,
+          "loopBlockId": "0D70200F-BF52-4CCD-8FB5-C81C9692D24B"
+      },
+      {
+          "id": "75038005-FF42-4CA7-B4C9-0CA9EE70631D",
+          "type": "EndpointBlock",
+          "disabled": false,
+          "name": "rawAPIRequest15",
+          "displayName": "Qlik Cloud Services - Raw API Request 15",
+          "comment": "Add the tag to the item.",
+          "childId": "9A5AE6AA-1CF8-4CD9-BD5B-1522FBC107EF",
+          "inputs": [
+              {
+                  "id": "734cbcc0-bbb0-11f0-b998-f73920377683",
+                  "value": "v1/collections/{$.loop5.item}/items",
+                  "type": "string",
+                  "structure": []
+              },
+              {
+                  "id": "7322a550-bbb0-11f0-9c8c-43f143a32456",
+                  "value": "7347ee10-bbb0-11f0-8cdc-59311dd108b3",
+                  "type": "select",
+                  "displayValue": "POST",
+                  "structure": []
+              },
+              {
+                  "id": "73000fe0-bbb0-11f0-8a80-59ece3571bd9",
+                  "value": "{\n  \"id\": \"{ $.rawAPIRequest14.data[0].id }\"\n}",
+                  "type": "object",
+                  "mode": "raw",
+                  "structure": []
+              },
+              {
+                  "id": "736fae60-bbb0-11f0-ad62-c98a0046f418",
+                  "value": null,
+                  "type": "object",
+                  "mode": "keyValue",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "blendr_on_error",
+                  "value": "stop",
+                  "type": "select",
+                  "structure": []
+              },
+              {
+                  "id": "automations_censor_data",
+                  "value": false,
+                  "type": "checkbox",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2442,
+          "y": 21954,
+          "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
+          "endpoint_guid": "72d48530-bbb0-11f0-875a-b322bf237aeb",
+          "endpoint_role": "create"
+      },
+      {
+          "id": "9A5AE6AA-1CF8-4CD9-BD5B-1522FBC107EF",
+          "type": "ShowBlock",
+          "disabled": false,
+          "name": "output39",
+          "displayName": "Output 39",
+          "comment": "Tag added.",
+          "childId": null,
+          "inputs": [
+              {
+                  "id": "input",
+                  "value": "| {$.loop2.item.name} - Tags (managed) | > Tag `{$.loop5.index}` added to new managed space app. |",
+                  "type": "string",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "display_mode",
+                  "value": "add",
+                  "type": "select",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2442,
+          "y": 22074
+      },
+      {
+          "id": "292F6681-A0A3-4149-8900-B146F799C502",
+          "type": "ForEachBlock",
+          "disabled": false,
+          "name": "loop5",
+          "displayName": "Loop 5",
+          "comment": "Loop over the tags.",
+          "childId": null,
+          "inputs": [
+              {
+                  "id": "input",
+                  "value": "{ $.taggerIds }",
+                  "type": "string",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "automations_censor_data",
+                  "value": false,
+                  "type": "checkbox",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": false
+              }
+          ],
+          "x": -2562,
+          "y": 21854,
+          "loopBlockId": "75038005-FF42-4CA7-B4C9-0CA9EE70631D"
+      },
+      {
+          "id": "00332E92-9B25-4849-B799-0A68E5F4931B",
+          "type": "SleepBlock",
+          "disabled": false,
+          "name": "sleep2",
+          "displayName": "Sleep 2",
+          "comment": "Wait for items to get publish notification.",
+          "childId": "D39D8A7B-718C-46EC-B3F1-24E2A2BF5185",
+          "inputs": [
+              {
+                  "id": "time",
+                  "value": "5",
+                  "type": "string",
+                  "structure": []
+              }
+          ],
+          "settings": [],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2562,
+          "y": 21614
+      },
+      {
+          "id": "D39D8A7B-718C-46EC-B3F1-24E2A2BF5185",
+          "type": "EndpointBlock",
+          "disabled": false,
+          "name": "rawAPIRequest14",
+          "displayName": "Qlik Cloud Services - Raw API Request 14",
+          "comment": "Get item ID of app",
+          "childId": "292F6681-A0A3-4149-8900-B146F799C502",
+          "inputs": [
+              {
+                  "id": "734cbcc0-bbb0-11f0-b998-f73920377683",
+                  "value": "v1/items",
+                  "type": "string",
+                  "structure": []
+              },
+              {
+                  "id": "7322a550-bbb0-11f0-9c8c-43f143a32456",
+                  "value": "7341e840-bbb0-11f0-9bb8-11c201f87b6d",
+                  "type": "select",
+                  "displayValue": "GET",
+                  "structure": []
+              },
+              {
+                  "id": "73000fe0-bbb0-11f0-8a80-59ece3571bd9",
+                  "value": null,
+                  "type": "object",
+                  "mode": "keyValue",
+                  "structure": []
+              },
+              {
+                  "id": "736fae60-bbb0-11f0-ad62-c98a0046f418",
+                  "value": [
+                      {
+                          "key": "resourceId",
+                          "value": "{ $.publishAppToManagedSpace.attributes.id }"
+                      },
+                      {
+                          "key": "resourceType",
+                          "value": "app"
+                      }
+                  ],
+                  "type": "object",
+                  "mode": "keyValue",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "blendr_on_error",
+                  "value": "stop",
+                  "type": "select",
+                  "structure": []
+              },
+              {
+                  "id": "automations_censor_data",
+                  "value": false,
+                  "type": "checkbox",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2562,
+          "y": 21734,
+          "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
+          "endpoint_guid": "72d48530-bbb0-11f0-875a-b322bf237aeb",
+          "endpoint_role": "create"
+      },
+      {
+          "id": "F8D411D5-6606-4BC1-BA09-2A24611D4B6A",
+          "type": "VariableBlock",
+          "disabled": false,
+          "name": "liveApps",
+          "displayName": "Variable - liveApps",
+          "comment": "Add newly published app to live apps.",
+          "childId": "15A91B88-3C31-400B-A2C8-D697AB8F175E",
+          "inputs": [],
+          "settings": [],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2562,
+          "y": 21374,
+          "variableGuid": "A812E467-95BC-419E-B6A6-4341D6347C3A",
+          "operations": [
+              {
+                  "id": "add_item",
+                  "key": "D4AA6196-E54F-4E05-9292-ABBD3AAADBC6",
+                  "name": "Add item to { variable }",
+                  "value": "{ $.publishAppToManagedSpace }"
+              }
+          ]
+      },
+      {
+          "id": "F3CCCABB-3F06-47D2-B3A0-E018A8EAD140",
+          "type": "VariableBlock",
+          "disabled": false,
+          "name": "liveApps",
+          "displayName": "Variable - liveApps",
+          "comment": "Add app to live apps.",
+          "childId": null,
+          "inputs": [],
+          "settings": [],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2322,
+          "y": 17354,
+          "variableGuid": "A812E467-95BC-419E-B6A6-4341D6347C3A",
+          "operations": [
+              {
+                  "id": "add_item",
+                  "key": "D4AA6196-E54F-4E05-9292-ABBD3AAADBC6",
+                  "name": "Add item to { variable }",
+                  "value": "{ $.getApp }"
+              }
+          ]
+      },
+      {
+          "id": "CFCAD086-C1F2-4CCA-878B-5B6ABB27850F",
+          "type": "EndpointBlock",
+          "disabled": false,
+          "name": "rawAPIRequest16",
+          "displayName": "Qlik Cloud Services - Raw API Request 16",
+          "comment": "Republish app by ID in case there are multiple apps with same name in space.",
+          "childId": "CC7C8FB8-9B7E-448D-9D58-393F53575C99",
+          "inputs": [
+              {
+                  "id": "734cbcc0-bbb0-11f0-b998-f73920377683",
+                  "value": "v1/apps/{ $.importAppFromBase64EncodedFile.attributes.id }/publish",
+                  "type": "string",
+                  "structure": []
+              },
+              {
+                  "id": "7322a550-bbb0-11f0-9c8c-43f143a32456",
+                  "value": "734354a0-bbb0-11f0-93a2-75cc9ad6b2d6",
+                  "type": "select",
+                  "displayValue": "PUT",
+                  "structure": []
+              },
+              {
+                  "id": "73000fe0-bbb0-11f0-8a80-59ece3571bd9",
+                  "value": "{\n  \"data\": \"target\",\n  \"targetId\": \"{$.loop6.item.resourceId}\",\n  \"checkOriginAppId\": false,\n  \"attributes\": {\"name\": \"{$.loop6.item.name}\"}\n}",
+                  "type": "object",
+                  "mode": "raw",
+                  "structure": []
+              },
+              {
+                  "id": "736fae60-bbb0-11f0-ad62-c98a0046f418",
+                  "value": null,
+                  "type": "object",
+                  "mode": "keyValue",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "blendr_on_error",
+                  "value": "stop",
+                  "type": "select",
+                  "structure": []
+              },
+              {
+                  "id": "automations_censor_data",
+                  "value": false,
+                  "type": "checkbox",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2442,
+          "y": 22494,
+          "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
+          "endpoint_guid": "72d48530-bbb0-11f0-875a-b322bf237aeb",
+          "endpoint_role": "create"
+      },
+      {
+          "id": "CC7C8FB8-9B7E-448D-9D58-393F53575C99",
+          "type": "ShowBlock",
+          "disabled": false,
+          "name": "output41",
+          "displayName": "Output 41",
+          "comment": "Status output.",
+          "childId": "3ABDBFAA-8E94-4AA9-87C6-AC03B13D58F0",
+          "inputs": [
+              {
+                  "id": "input",
+                  "value": "| {$.loop2.item.name} - Republish | > Republished [{ $.loop6.item.name }]({$.tenantHostname}sense/app/{ $.loop6.item.resourceId }) to [{$.managedSpaceName}]({$.tenantHostname}analytics/catalog?space_filter={$.managedSpaceId}). |",
+                  "type": "string",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "display_mode",
+                  "value": "add",
+                  "type": "select",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2442,
+          "y": 22614
+      },
+      {
+          "id": "0D70200F-BF52-4CCD-8FB5-C81C9692D24B",
+          "type": "ShowBlock",
+          "disabled": false,
+          "name": "output40",
+          "displayName": "Output 40",
+          "comment": "Status output.",
+          "childId": "CFCAD086-C1F2-4CCA-878B-5B6ABB27850F",
+          "inputs": [
+              {
+                  "id": "input",
+                  "value": "| {$.loop2.item.name} - Republish | > Attempting to republish { $.loop6.item.name } in [{$.managedSpaceName}]({$.tenantHostname}analytics/catalog?space_filter={$.managedSpaceId}). |",
+                  "type": "string",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "display_mode",
+                  "value": "add",
+                  "type": "select",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2442,
+          "y": 22374
+      },
+      {
+          "id": "3ABDBFAA-8E94-4AA9-87C6-AC03B13D58F0",
+          "type": "EndpointBlock",
+          "disabled": false,
+          "name": "rawAPIRequest17",
+          "displayName": "Qlik Cloud Services - Raw API Request 17",
+          "comment": "Get item ID of app",
+          "childId": "AD01998A-BEE0-473B-99F7-E6CC8C4B60CF",
+          "inputs": [
+              {
+                  "id": "734cbcc0-bbb0-11f0-b998-f73920377683",
+                  "value": "v1/items",
+                  "type": "string",
+                  "structure": []
+              },
+              {
+                  "id": "7322a550-bbb0-11f0-9c8c-43f143a32456",
+                  "value": "7341e840-bbb0-11f0-9bb8-11c201f87b6d",
+                  "type": "select",
+                  "displayValue": "GET",
+                  "structure": []
+              },
+              {
+                  "id": "73000fe0-bbb0-11f0-8a80-59ece3571bd9",
+                  "value": null,
+                  "type": "object",
+                  "mode": "keyValue",
+                  "structure": []
+              },
+              {
+                  "id": "736fae60-bbb0-11f0-ad62-c98a0046f418",
+                  "value": [
+                      {
+                          "key": "resourceId",
+                          "value": "{ $.loop6.item.resourceId }"
+                      },
+                      {
+                          "key": "resourceType",
+                          "value": "app"
+                      }
+                  ],
+                  "type": "object",
+                  "mode": "keyValue",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "blendr_on_error",
+                  "value": "stop",
+                  "type": "select",
+                  "structure": []
+              },
+              {
+                  "id": "automations_censor_data",
+                  "value": false,
+                  "type": "checkbox",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2442,
+          "y": 22734,
+          "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
+          "endpoint_guid": "72d48530-bbb0-11f0-875a-b322bf237aeb",
+          "endpoint_role": "create"
+      },
+      {
+          "id": "BA3377B4-6CA3-40CF-9915-DC98B9CBBE52",
+          "type": "EndpointBlock",
+          "disabled": false,
+          "name": "rawAPIRequest19",
+          "displayName": "Qlik Cloud Services - Raw API Request 19",
+          "comment": "Add the tag to the item.",
+          "childId": "7E0CB48E-DCF7-4EAE-B86B-02B2AE708592",
+          "inputs": [
+              {
+                  "id": "734cbcc0-bbb0-11f0-b998-f73920377683",
+                  "value": "v1/collections/{ $.taggerIds.versionTag }/items",
+                  "type": "string",
+                  "structure": []
+              },
+              {
+                  "id": "7322a550-bbb0-11f0-9c8c-43f143a32456",
+                  "value": "7347ee10-bbb0-11f0-8cdc-59311dd108b3",
+                  "type": "select",
+                  "displayValue": "POST",
+                  "structure": []
+              },
+              {
+                  "id": "73000fe0-bbb0-11f0-8a80-59ece3571bd9",
+                  "value": "{\n  \"id\": \"{ $.rawAPIRequest17.data[0].id }\"\n}",
+                  "type": "object",
+                  "mode": "raw",
+                  "structure": []
+              },
+              {
+                  "id": "736fae60-bbb0-11f0-ad62-c98a0046f418",
+                  "value": null,
+                  "type": "object",
+                  "mode": "keyValue",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "blendr_on_error",
+                  "value": "stop",
+                  "type": "select",
+                  "structure": []
+              },
+              {
+                  "id": "automations_censor_data",
+                  "value": false,
+                  "type": "checkbox",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2442,
+          "y": 23234,
+          "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
+          "endpoint_guid": "72d48530-bbb0-11f0-875a-b322bf237aeb",
+          "endpoint_role": "create"
+      },
+      {
+          "id": "7E0CB48E-DCF7-4EAE-B86B-02B2AE708592",
+          "type": "ShowBlock",
+          "disabled": false,
+          "name": "output43",
+          "displayName": "Output 43",
+          "comment": "Tag added.",
+          "childId": null,
+          "inputs": [
+              {
+                  "id": "input",
+                  "value": "| {$.loop2.item.name} - Tags (managed) | > Tag `{ $.workingAppTagVersion }` added to managed space app. |",
+                  "type": "string",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "display_mode",
+                  "value": "add",
+                  "type": "select",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2442,
+          "y": 23354
+      },
+      {
+          "id": "AD01998A-BEE0-473B-99F7-E6CC8C4B60CF",
+          "type": "FilterListBlock",
+          "disabled": false,
+          "name": "filterList9",
+          "displayName": "Filter List 9",
+          "comment": "Filter to tags other than app name.",
+          "childId": "BA3377B4-6CA3-40CF-9915-DC98B9CBBE52",
+          "inputs": [
+              {
+                  "id": "list",
+                  "value": "{ $.rawAPIRequest17.data[0].meta.tags }",
+                  "type": "string",
+                  "structure": []
+              },
+              {
+                  "id": "conditions",
+                  "value": {
+                      "mode": "all",
+                      "conditions": [
+                          {
+                              "input1": "name",
+                              "input2": "{ $.workingAppTagName }",
+                              "operator": "!="
+                          }
+                      ]
+                  },
+                  "type": "custom",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "automations_censor_data",
+                  "value": false,
+                  "type": "checkbox",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": false
+              }
+          ],
+          "x": -2442,
+          "y": 22854,
+          "loopBlockId": "151AA8FD-9389-44F0-8522-5AFF01889D68"
+      },
+      {
+          "id": "151AA8FD-9389-44F0-8522-5AFF01889D68",
+          "type": "EndpointBlock",
+          "disabled": false,
+          "name": "rawAPIRequest18",
+          "displayName": "Qlik Cloud Services - Raw API Request 18",
+          "comment": "Remove tag from item.",
+          "childId": "137C7CB4-181B-444B-B0E6-2FE3F7491940",
+          "inputs": [
+              {
+                  "id": "734cbcc0-bbb0-11f0-b998-f73920377683",
+                  "value": "v1/collections/{ $.filterList9.item.id }/items/{$.rawAPIRequest17.data[0].id}",
+                  "type": "string",
+                  "structure": []
+              },
+              {
+                  "id": "7322a550-bbb0-11f0-9c8c-43f143a32456",
+                  "value": "73465660-bbb0-11f0-b65a-eb94ca86d22a",
+                  "type": "select",
+                  "displayValue": "DELETE",
+                  "structure": []
+              },
+              {
+                  "id": "73000fe0-bbb0-11f0-8a80-59ece3571bd9",
+                  "value": null,
+                  "type": "object",
+                  "mode": "keyValue",
+                  "structure": []
+              },
+              {
+                  "id": "736fae60-bbb0-11f0-ad62-c98a0046f418",
+                  "value": null,
+                  "type": "object",
+                  "mode": "keyValue",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "blendr_on_error",
+                  "value": "stop",
+                  "type": "select",
+                  "structure": []
+              },
+              {
+                  "id": "automations_censor_data",
+                  "value": false,
+                  "type": "checkbox",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2322,
+          "y": 22954,
+          "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
+          "endpoint_guid": "72d48530-bbb0-11f0-875a-b322bf237aeb",
+          "endpoint_role": "create"
+      },
+      {
+          "id": "137C7CB4-181B-444B-B0E6-2FE3F7491940",
+          "type": "ShowBlock",
+          "disabled": false,
+          "name": "output42",
+          "displayName": "Output 42",
+          "comment": "Tag removed.",
+          "childId": null,
+          "inputs": [
+              {
+                  "id": "input",
+                  "value": "| {$.loop2.item.name} - Tags (managed) | > Tag `{ $.filterList9.item.name }` removed from managed space app. |",
+                  "type": "string",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "display_mode",
+                  "value": "add",
+                  "type": "select",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2322,
+          "y": 23074
+      },
+      {
+          "id": "F959E5AA-4EC0-4284-AA66-F59C788B6B08",
+          "type": "EndpointBlock",
+          "disabled": false,
+          "name": "rawAPIListRequest",
+          "displayName": "Qlik Cloud Services - Raw API List Request",
+          "comment": "List API keys.",
+          "childId": "6C0A56A0-B3A3-4740-858E-57ABB5BF2CAC",
+          "inputs": [
+              {
+                  "id": "9fd51350-bbb2-11f0-b2b4-c376cf7e2c04",
+                  "value": "v1/api-keys",
+                  "type": "string",
+                  "structure": []
+              },
+              {
+                  "id": "9ff92ee0-bbb2-11f0-8fb9-9146a99c6e2f",
+                  "value": [],
+                  "type": "object",
+                  "mode": "keyValue",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "maxitemcount",
+                  "value": "",
+                  "type": "string",
+                  "structure": []
+              },
+              {
+                  "id": "blendr_on_error",
+                  "value": "stop",
+                  "type": "select",
+                  "structure": []
+              },
+              {
+                  "id": "cache",
+                  "value": "0",
+                  "type": "select",
+                  "structure": []
+              },
+              {
+                  "id": "automations_censor_data",
+                  "value": false,
+                  "type": "checkbox",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": false
+              }
+          ],
+          "x": -2922,
+          "y": 3494,
+          "loopBlockId": null,
+          "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
+          "endpoint_guid": "9f6166e0-bbb2-11f0-acdd-bd47067b5fbf",
+          "endpoint_role": "list"
+      },
+      {
+          "id": "81004D2F-88EF-4DAF-AD93-78CFFD551EB7",
+          "type": "EndpointBlock",
+          "disabled": false,
+          "name": "rawAPIRequest6",
+          "displayName": "Qlik Cloud Services - Raw API Request 6",
+          "comment": "Find existing data connection linked to the monitoring app.",
+          "childId": "1BDB1B6F-3959-4D57-B887-62D7AAABE6CB",
+          "inputs": [
+              {
+                  "id": "734cbcc0-bbb0-11f0-b998-f73920377683",
+                  "value": "v1/data-connections/{$.dataConnectionName}",
+                  "type": "string",
+                  "structure": []
+              },
+              {
+                  "id": "7322a550-bbb0-11f0-9c8c-43f143a32456",
+                  "value": "7341e840-bbb0-11f0-9bb8-11c201f87b6d",
+                  "type": "select",
+                  "displayValue": "GET",
+                  "structure": []
+              },
+              {
+                  "id": "73000fe0-bbb0-11f0-8a80-59ece3571bd9",
+                  "value": [],
+                  "type": "object",
+                  "mode": "keyValue",
+                  "structure": []
+              },
+              {
+                  "id": "736fae60-bbb0-11f0-ad62-c98a0046f418",
+                  "value": "{\n  \"spaceId\": \"{$.managedSpaceId}\",\n  \"type\": \"connectionname\"\n}",
+                  "type": "object",
+                  "mode": "raw",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "blendr_on_error",
+                  "value": "ignore",
+                  "type": "select",
+                  "displayValue": "Ignore - Continue Automation and ignore errors",
+                  "structure": []
+              },
+              {
+                  "id": "automations_censor_data",
+                  "value": false,
+                  "type": "checkbox",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": false
+              }
+          ],
+          "x": -2922,
+          "y": 13894,
+          "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
+          "endpoint_guid": "72d48530-bbb0-11f0-875a-b322bf237aeb",
+          "endpoint_role": "create"
+      },
+      {
+          "id": "1BDB1B6F-3959-4D57-B887-62D7AAABE6CB",
+          "type": "IfElseBlock",
+          "disabled": false,
+          "name": "condition24",
+          "displayName": "Condition 24",
+          "comment": "If data connection exists, delete it.",
+          "childId": "3852BD8D-3C33-41F4-8BDA-7A000D4DC500",
+          "inputs": [
+              {
+                  "id": "conditions",
+                  "value": {
+                      "mode": "all",
+                      "conditions": [
+                          {
+                              "input1": "{ $.rawAPIRequest6.id }",
+                              "input2": null,
+                              "operator": "notEmpty"
+                          }
+                      ]
+                  },
+                  "type": "custom",
+                  "structure": []
+              }
+          ],
+          "settings": [],
+          "collapsed": [
+              {
+                  "name": "both",
+                  "isCollapsed": false
+              },
+              {
+                  "name": "yes",
+                  "isCollapsed": false
+              },
+              {
+                  "name": "no",
+                  "isCollapsed": false
+              }
+          ],
+          "x": -2922,
+          "y": 14014,
+          "childTrueId": "D2202317-6AF5-42C3-A20F-5806BAEABEDA",
+          "childFalseId": null
+      },
+      {
+          "id": "5E99BD17-A9BC-4021-BDE0-F4EA60301C7F",
+          "type": "EndpointBlock",
+          "disabled": false,
+          "name": "rawAPIRequest8",
+          "displayName": "Qlik Cloud Services - Raw API Request 8",
+          "comment": "Create data connection",
+          "childId": "5E1CFE7D-C393-4315-85EF-086507112AC6",
+          "inputs": [
+              {
+                  "id": "734cbcc0-bbb0-11f0-b998-f73920377683",
+                  "value": "v1/data-connections",
+                  "type": "string",
+                  "structure": []
+              },
+              {
+                  "id": "7322a550-bbb0-11f0-9c8c-43f143a32456",
+                  "value": "7347ee10-bbb0-11f0-8cdc-59311dd108b3",
+                  "type": "select",
+                  "displayValue": "POST",
+                  "structure": []
+              },
+              {
+                  "id": "73000fe0-bbb0-11f0-8a80-59ece3571bd9",
+                  "value": "{\n\"dataSourceId\": \"rest\",\n\"qName\": \"{$.dataConnectionName}\",\n\"space\":\"{$.managedSpaceId}\",\n\"connectionProperties\": {\n\"url\": \"https://{$.getCurrentTenantInfo.hostnames[0]}/api/v1/users\",\n\"retryCodes\": \"500,502,503,504\",\n\"retryFailedRequest\": true,\n\"timeout\": \"300\",\n\"readwritetimeout\": \"300\",\n\"queryHeaders\": [\n{\n\"name\": \"Authorization\",\n\"value\": \"Bearer {$.rawAPIRequest5.token}\",\n\"encrypt\": true\n}\n],\n\"allowWithConnection\": \"true\"\n}\n}",
+                  "type": "object",
+                  "mode": "raw",
+                  "structure": []
+              },
+              {
+                  "id": "736fae60-bbb0-11f0-ad62-c98a0046f418",
+                  "value": null,
+                  "type": "object",
+                  "mode": "keyValue",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "blendr_on_error",
+                  "value": "stop",
+                  "type": "select",
+                  "structure": []
+              },
+              {
+                  "id": "automations_censor_data",
+                  "value": true,
+                  "type": "checkbox",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": false
+              }
+          ],
+          "x": -2922,
+          "y": 14654,
+          "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
+          "endpoint_guid": "72d48530-bbb0-11f0-875a-b322bf237aeb",
+          "endpoint_role": "create"
+      },
+      {
+          "id": "60F588B6-B33A-4275-ACF5-7D83B6A96411",
+          "type": "VariableBlock",
+          "disabled": false,
+          "name": "dataConnectionName",
+          "displayName": "Variable - dataConnectionName",
+          "comment": "Variable to store name of the data connection linked to the monitoring app.",
+          "childId": "81004D2F-88EF-4DAF-AD93-78CFFD551EB7",
+          "inputs": [],
+          "settings": [],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": false
+              }
+          ],
+          "x": -2922,
+          "y": 13774,
+          "variableGuid": "218D5568-BA73-49F2-9996-926C40E2AE08",
+          "operations": [
+              {
+                  "id": "set_value",
+                  "key": "49ABB8E7-9FA8-47C1-9212-0346190B156E",
+                  "name": "Set value of { variable }",
+                  "value": "monitoring_apps_REST"
+              }
+          ]
+      },
+      {
+          "id": "3852BD8D-3C33-41F4-8BDA-7A000D4DC500",
+          "type": "ShowBlock",
+          "disabled": false,
+          "name": "output24",
+          "displayName": "Output 24",
+          "comment": "Creating the data connection.",
+          "childId": "5E99BD17-A9BC-4021-BDE0-F4EA60301C7F",
+          "inputs": [
+              {
+                  "id": "input",
+                  "value": "| Data connection | Creating the data connection '{$.dataConnectionName}'. |",
+                  "type": "string",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "display_mode",
+                  "value": "add",
+                  "type": "select",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": false
+              }
+          ],
+          "x": -2922,
+          "y": 14534
+      },
+      {
+          "id": "5E1CFE7D-C393-4315-85EF-086507112AC6",
+          "type": "ShowBlock",
+          "disabled": false,
+          "name": "output25",
+          "displayName": "Output 25",
+          "comment": "Data connection created.",
+          "childId": "D2C679AD-2434-474C-9ACC-B95C8232BA8A",
+          "inputs": [
+              {
+                  "id": "input",
+                  "value": "| Data connection | Data connection created in [{$.managedSpaceName}]({$.tenantHostname}spaces/{$.managedSpaceId}/dataconnections). |",
+                  "type": "string",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "display_mode",
+                  "value": "add",
+                  "type": "select",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": false
+              }
+          ],
+          "x": -2922,
+          "y": 14774
+      },
+      {
+          "id": "C5498C80-2759-492A-A46F-58DEF52F8F9A",
+          "type": "EndpointBlock",
+          "disabled": false,
+          "name": "rawAPIRequest7",
+          "displayName": "Qlik Cloud Services - Raw API Request 7",
+          "comment": "Delete the data connection.",
+          "childId": "D5C5031D-9058-4671-A035-978DBB1DC8E4",
+          "inputs": [
+              {
+                  "id": "734cbcc0-bbb0-11f0-b998-f73920377683",
+                  "value": "v1/data-connections/{$.rawAPIRequest6.id}",
+                  "type": "string",
+                  "structure": []
+              },
+              {
+                  "id": "7322a550-bbb0-11f0-9c8c-43f143a32456",
+                  "value": "73465660-bbb0-11f0-b65a-eb94ca86d22a",
+                  "type": "select",
+                  "displayValue": "DELETE",
+                  "structure": []
+              },
+              {
+                  "id": "73000fe0-bbb0-11f0-8a80-59ece3571bd9",
+                  "value": null,
+                  "type": "object",
+                  "mode": "keyValue",
+                  "structure": []
+              },
+              {
+                  "id": "736fae60-bbb0-11f0-ad62-c98a0046f418",
+                  "value": null,
+                  "type": "object",
+                  "mode": "keyValue",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "blendr_on_error",
+                  "value": "stop",
+                  "type": "select",
+                  "structure": []
+              },
+              {
+                  "id": "automations_censor_data",
+                  "value": false,
+                  "type": "checkbox",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2802,
+          "y": 14214,
+          "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
+          "endpoint_guid": "72d48530-bbb0-11f0-875a-b322bf237aeb",
+          "endpoint_role": "create"
+      },
+      {
+          "id": "D2202317-6AF5-42C3-A20F-5806BAEABEDA",
+          "type": "ShowBlock",
+          "disabled": false,
+          "name": "output22",
+          "displayName": "Output 22",
+          "comment": "Deleting the data connection.",
+          "childId": "C5498C80-2759-492A-A46F-58DEF52F8F9A",
+          "inputs": [
+              {
+                  "id": "input",
+                  "value": "| Data connection | Deleting the data connection '{$.dataConnectionName}'. |",
+                  "type": "string",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "display_mode",
+                  "value": "add",
+                  "type": "select",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2802,
+          "y": 14094
+      },
+      {
+          "id": "D5C5031D-9058-4671-A035-978DBB1DC8E4",
+          "type": "ShowBlock",
+          "disabled": false,
+          "name": "output23",
+          "displayName": "Output 23",
+          "comment": "Deleted the data connection.",
+          "childId": null,
+          "inputs": [
+              {
+                  "id": "input",
+                  "value": "| Data connection | Deleted the data connection. |",
+                  "type": "string",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "display_mode",
+                  "value": "add",
+                  "type": "select",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2802,
+          "y": 14334
+      },
+      {
+          "id": "56DF743F-3565-4BB7-B484-27DB0E8E13F5",
+          "type": "FilterListBlock",
+          "disabled": false,
+          "name": "filterList7",
+          "displayName": "Filter over Qlik Cloud Services - Raw API List Request - Filter List 7",
+          "comment": "Filter API keys",
+          "childId": "C9CA459B-7C50-4EDF-BD71-300FF8437382",
+          "inputs": [
+              {
+                  "id": "list",
+                  "value": "{ $.rawAPIListRequest }",
+                  "type": "string",
+                  "structure": []
+              },
+              {
+                  "id": "conditions",
+                  "value": {
+                      "mode": "all",
+                      "conditions": [
+                          {
+                              "input1": "description",
+                              "input2": "{ $.apiKeyName }",
+                              "operator": "="
+                          }
+                      ]
+                  },
+                  "type": "custom",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "automations_censor_data",
+                  "value": false,
+                  "type": "checkbox",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": false
+              }
+          ],
+          "x": -2922,
+          "y": 12794,
+          "loopBlockId": "439A8A90-8CAD-4F2F-A673-90754BB6B0AD"
+      },
+      {
+          "id": "7C672EAB-B98A-4BBD-A807-3428671C2D3D",
+          "type": "EndpointBlock",
+          "disabled": false,
+          "name": "rawAPIRequest4",
+          "displayName": "Qlik Cloud Services - Raw API Request 4",
+          "comment": "Delete the API key.",
+          "childId": "848D7B98-1FE1-4584-BF60-F518D86E41F0",
+          "inputs": [
+              {
+                  "id": "734cbcc0-bbb0-11f0-b998-f73920377683",
+                  "value": "v1/api-keys/{$.filterList7.item.id}",
+                  "type": "string",
+                  "structure": []
+              },
+              {
+                  "id": "7322a550-bbb0-11f0-9c8c-43f143a32456",
+                  "value": "73465660-bbb0-11f0-b65a-eb94ca86d22a",
+                  "type": "select",
+                  "displayValue": "DELETE",
+                  "structure": []
+              },
+              {
+                  "id": "73000fe0-bbb0-11f0-8a80-59ece3571bd9",
+                  "value": null,
+                  "type": "object",
+                  "mode": "keyValue",
+                  "structure": []
+              },
+              {
+                  "id": "736fae60-bbb0-11f0-ad62-c98a0046f418",
+                  "value": null,
+                  "type": "object",
+                  "mode": "keyValue",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "blendr_on_error",
+                  "value": "stop",
+                  "type": "select",
+                  "structure": []
+              },
+              {
+                  "id": "automations_censor_data",
+                  "value": false,
+                  "type": "checkbox",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2802,
+          "y": 13014,
+          "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
+          "endpoint_guid": "72d48530-bbb0-11f0-875a-b322bf237aeb",
+          "endpoint_role": "create"
+      },
+      {
+          "id": "439A8A90-8CAD-4F2F-A673-90754BB6B0AD",
+          "type": "ShowBlock",
+          "disabled": false,
+          "name": "output18",
+          "displayName": "Output 18",
+          "comment": "Delete existing key",
+          "childId": "7C672EAB-B98A-4BBD-A807-3428671C2D3D",
+          "inputs": [
+              {
+                  "id": "input",
+                  "value": "| API keys | Deleting existing API key named '{ $.filterList7.item.description }'. |",
+                  "type": "string",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "display_mode",
+                  "value": "add",
+                  "type": "select",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2802,
+          "y": 12894
+      },
+      {
+          "id": "848D7B98-1FE1-4584-BF60-F518D86E41F0",
+          "type": "ShowBlock",
+          "disabled": false,
+          "name": "output19",
+          "displayName": "Output 19",
+          "comment": "Existing key deleted",
+          "childId": null,
+          "inputs": [
+              {
+                  "id": "input",
+                  "value": "| API keys | API key deleted. |",
+                  "type": "string",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "display_mode",
+                  "value": "add",
+                  "type": "select",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2802,
+          "y": 13134
+      },
+      {
+          "id": "C9CA459B-7C50-4EDF-BD71-300FF8437382",
+          "type": "ShowBlock",
+          "disabled": false,
+          "name": "output20",
+          "displayName": "Output 20",
+          "comment": "Generating new API key.",
+          "childId": "28997C80-CF89-4863-BAD6-DD9A15FC72EF",
+          "inputs": [
+              {
+                  "id": "input",
+                  "value": "| API keys | Generating new API key named '{ $.apiKeyName }'. |",
+                  "type": "string",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "display_mode",
+                  "value": "add",
+                  "type": "select",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": false
+              }
+          ],
+          "x": -2922,
+          "y": 13294
+      },
+      {
+          "id": "28997C80-CF89-4863-BAD6-DD9A15FC72EF",
+          "type": "EndpointBlock",
+          "disabled": false,
+          "name": "rawAPIRequest5",
+          "displayName": "Qlik Cloud Services - Raw API Request 5",
+          "comment": "Generate API key.",
+          "childId": "A9FB2FA5-C29A-40C7-B008-73D7095910FC",
+          "inputs": [
+              {
+                  "id": "734cbcc0-bbb0-11f0-b998-f73920377683",
+                  "value": "v1/api-keys",
+                  "type": "string",
+                  "structure": []
+              },
+              {
+                  "id": "7322a550-bbb0-11f0-9c8c-43f143a32456",
+                  "value": "7347ee10-bbb0-11f0-8cdc-59311dd108b3",
+                  "type": "select",
+                  "displayValue": "POST",
+                  "structure": []
+              },
+              {
+                  "id": "73000fe0-bbb0-11f0-8a80-59ece3571bd9",
+                  "value": "{\"description\":\"{ $.apiKeyName }\",\"expiry\":\"{ $.apiKeyDuration }\"}",
+                  "type": "object",
+                  "mode": "raw",
+                  "structure": []
+              },
+              {
+                  "id": "736fae60-bbb0-11f0-ad62-c98a0046f418",
+                  "value": null,
+                  "type": "object",
+                  "mode": "keyValue",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "blendr_on_error",
+                  "value": "stop",
+                  "type": "select",
+                  "structure": []
+              },
+              {
+                  "id": "automations_censor_data",
+                  "value": true,
+                  "type": "checkbox",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": false
+              }
+          ],
+          "x": -2922,
+          "y": 13414,
+          "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
+          "endpoint_guid": "72d48530-bbb0-11f0-875a-b322bf237aeb",
+          "endpoint_role": "create"
+      },
+      {
+          "id": "A9FB2FA5-C29A-40C7-B008-73D7095910FC",
+          "type": "VariableBlock",
+          "disabled": false,
+          "name": "apiKeyExpiryDate",
+          "displayName": "Variable - apiKeyExpiryDate",
+          "comment": "Set the expiry to log later.",
+          "childId": "20C5CA2D-D4E9-453B-A275-37990DC61736",
+          "inputs": [],
+          "settings": [],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": false
+              }
+          ],
+          "x": -2922,
+          "y": 13534,
+          "variableGuid": "AABC69B3-4AB6-4777-A443-FCFCFDA805C4",
+          "operations": [
+              {
+                  "id": "set_value",
+                  "key": "4401AA06-FDCC-4053-AD20-B479DC6D056C",
+                  "name": "Set value of { variable }",
+                  "value": "{$.rawAPIRequest5.expiry}"
+              }
+          ]
+      },
+      {
+          "id": "20C5CA2D-D4E9-453B-A275-37990DC61736",
+          "type": "ShowBlock",
+          "disabled": false,
+          "name": "output21",
+          "displayName": "Output 21",
+          "comment": "API key generated",
+          "childId": "60F588B6-B33A-4275-ACF5-7D83B6A96411",
+          "inputs": [
+              {
+                  "id": "input",
+                  "value": "| API keys | API key generated, valid until { $.apiKeyExpiryDate }. |",
+                  "type": "string",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "display_mode",
+                  "value": "add",
+                  "type": "select",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": false
+              }
+          ],
+          "x": -2922,
+          "y": 13654
+      },
+      {
+          "id": "F4D0DE07-AD02-4C58-9CEA-A3409E738389",
+          "type": "VariableBlock",
+          "disabled": false,
+          "name": "apiKeyName",
+          "displayName": "Variable - apiKeyName",
+          "comment": "Name for the installer's API key. Pattern is QCMA - <managedSpaceId>.",
+          "childId": "1724234E-1EE6-475F-9451-68D9482CC2FE",
+          "inputs": [],
+          "settings": [],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": false
+              }
+          ],
+          "x": -2922,
+          "y": 11994,
+          "variableGuid": "DB5AD6FD-CA6D-4BDB-B12B-91C248324EE1",
+          "operations": [
+              {
+                  "id": "set_value",
+                  "key": "3BC25283-EF15-41B0-9528-9DB4D9DDF3FB",
+                  "name": "Set value of { variable }",
+                  "value": "QCMA - { $.managedSpaceId }"
+              }
+          ]
+      },
+      {
+          "id": "1724234E-1EE6-475F-9451-68D9482CC2FE",
+          "type": "FilterListBlock",
+          "disabled": false,
+          "name": "filterList6",
+          "displayName": "Filter over Qlik Cloud Services - Raw API List Request - Filter List 6",
+          "comment": "Filter to user's API keys.",
+          "childId": "6306F3F3-BD9F-4E0B-8C41-EE8E21DD421C",
+          "inputs": [
+              {
+                  "id": "list",
+                  "value": "{ $.rawAPIListRequest }",
+                  "type": "string",
+                  "structure": []
+              },
+              {
+                  "id": "conditions",
+                  "value": {
+                      "mode": "all",
+                      "conditions": [
+                          {
+                              "input1": "sub",
+                              "input2": "{ $.getCurrentUserId }",
+                              "operator": "="
+                          },
+                          {
+                              "input1": "description",
+                              "input2": "{ $.apiKeyName }",
+                              "operator": "!="
+                          }
+                      ]
+                  },
+                  "type": "custom",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "automations_censor_data",
+                  "value": false,
+                  "type": "checkbox",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": false
+              }
+          ],
+          "x": -2922,
+          "y": 12114,
+          "loopBlockId": null
+      },
+      {
+          "id": "6306F3F3-BD9F-4E0B-8C41-EE8E21DD421C",
+          "type": "IfElseBlock",
+          "disabled": false,
+          "name": "condition23",
+          "displayName": "Condition 23",
+          "comment": "If user has max number of API keys already, exit.",
+          "childId": "56DF743F-3565-4BB7-B484-27DB0E8E13F5",
+          "inputs": [
+              {
+                  "id": "conditions",
+                  "value": {
+                      "mode": "all",
+                      "conditions": [
+                          {
+                              "input1": "{ count: { $.filterList6 } }",
+                              "input2": "{ $.rawAPIRequest2.max_keys_per_user }",
+                              "operator": ">="
+                          }
+                      ]
+                  },
+                  "type": "custom",
+                  "structure": []
+              }
+          ],
+          "settings": [],
+          "collapsed": [
+              {
+                  "name": "both",
+                  "isCollapsed": false
+              },
+              {
+                  "name": "yes",
+                  "isCollapsed": false
+              },
+              {
+                  "name": "no",
+                  "isCollapsed": false
+              }
+          ],
+          "x": -2922,
+          "y": 12274,
+          "childTrueId": "1AEE9D36-5C63-4334-8758-ECD4056C36B3",
+          "childFalseId": null
+      },
+      {
+          "id": "1AEE9D36-5C63-4334-8758-ECD4056C36B3",
+          "type": "VariableBlock",
+          "disabled": false,
+          "name": "errorTitle",
+          "displayName": "Variable - errorTitle",
+          "comment": "Set error title for standard error output.",
+          "childId": "489D6F65-006C-4D20-81A8-578A09FE4E8E",
+          "inputs": [],
+          "settings": [],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2802,
+          "y": 12354,
+          "variableGuid": "407730A6-EC96-4337-BE80-CF4C0D552F08",
+          "operations": [
+              {
+                  "id": "set_value",
+                  "key": "1BC10F4C-68C2-42E9-9000-25865B076073",
+                  "name": "Set value of { variable }",
+                  "value": "User cannot create any more API keys."
+              }
+          ]
+      },
+      {
+          "id": "489D6F65-006C-4D20-81A8-578A09FE4E8E",
+          "type": "VariableBlock",
+          "disabled": false,
+          "name": "errorDetail",
+          "displayName": "Variable - errorDetail",
+          "comment": "Variable to store detailed error message.",
+          "childId": "5B590615-6F1A-4D9E-9A37-DB7042C17B13",
+          "inputs": [],
+          "settings": [],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2802,
+          "y": 12474,
+          "variableGuid": "1BF2068B-106E-4D58-BC51-884F1810F03C",
+          "operations": [
+              {
+                  "id": "set_value",
+                  "key": "1BC10F4C-68C2-42E9-9000-25865B076073",
+                  "name": "Set value of { variable }",
+                  "value": "Exiting, current user cannot create more API keys. Either delete some unused API keys, or increase the maximum keys per user."
+              }
+          ]
+      },
+      {
+          "id": "5B590615-6F1A-4D9E-9A37-DB7042C17B13",
+          "type": "GotoBlock",
+          "disabled": false,
+          "name": "goToLabel10",
+          "displayName": "Go To Label 10",
+          "comment": "Go to the label named error.",
+          "childId": null,
+          "inputs": [
+              {
+                  "id": "label",
+                  "value": "EF82AD29-E2CF-44C9-A7DB-24C784618756",
+                  "type": "select",
+                  "displayValue": "error",
+                  "structure": []
+              }
+          ],
+          "settings": [],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2802,
+          "y": 12594
+      },
+      {
+          "id": "2E61A575-F621-4713-B446-C1BAC52D8834",
+          "type": "VariableBlock",
+          "disabled": false,
+          "name": "reloadNow",
+          "displayName": "Variable - reloadNow",
+          "comment": "Configure whether to run a reload on every run. By default, it is set to 1, which will reload every app. Set to 0 to skip a reload.",
+          "childId": "8151B3E3-471C-496B-BB87-F586C46E3CF4",
+          "inputs": [],
+          "settings": [],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2802,
+          "y": -3266,
+          "variableGuid": "12BED549-8F76-4D83-B484-F6121E71753E",
+          "operations": [
+              {
+                  "id": "set_value",
+                  "key": "2A53EE0E-A13C-45CD-9E07-D012532B33CA",
+                  "name": "Set value of { variable }",
+                  "value": "1"
+              }
+          ]
+      },
+      {
+          "id": "8151B3E3-471C-496B-BB87-F586C46E3CF4",
+          "type": "VariableBlock",
+          "disabled": false,
+          "name": "reloadScheduleHour",
+          "displayName": "Variable - reloadScheduleHour",
+          "comment": "Set to the hour of the day (UTC) when the apps should reload. Will create a schedule for each app at this time. Will replace any other schedules on the app. Leave empty to manage schedules yourself.",
+          "childId": "6AC0239B-01A8-47F9-AD4C-ED09CCB2B83F",
+          "inputs": [],
+          "settings": [],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2802,
+          "y": -3146,
+          "variableGuid": "3DA539EC-2C6E-4C2B-9985-6F5BDCA282B2",
+          "operations": [
+              {
+                  "id": "set_value",
+                  "key": "2A53EE0E-A13C-45CD-9E07-D012532B33CA",
+                  "name": "Set value of { variable }",
+                  "value": "06"
+              }
+          ]
+      },
+      {
+          "id": "9745F8DD-9BEC-4E02-B0B9-B275B8BCFCB1",
+          "type": "IfElseBlock",
+          "disabled": false,
+          "name": "condition34",
+          "displayName": "Condition 34",
+          "comment": "If reloadNow=1, reload",
+          "childId": "EC299E1F-F2CA-4149-B148-FC4319064F9D",
+          "inputs": [
+              {
+                  "id": "conditions",
+                  "value": {
+                      "mode": "all",
+                      "conditions": [
+                          {
+                              "input1": "{ $.reloadNow }",
+                              "input2": "1",
+                              "operator": "="
+                          }
+                      ]
+                  },
+                  "type": "custom",
+                  "structure": []
+              }
+          ],
+          "settings": [],
+          "collapsed": [
+              {
+                  "name": "both",
+                  "isCollapsed": false
+              },
+              {
+                  "name": "yes",
+                  "isCollapsed": false
+              },
+              {
+                  "name": "no",
+                  "isCollapsed": false
+              }
+          ],
+          "x": -2922,
+          "y": 24494,
+          "childTrueId": "FB25A35E-49F7-4A93-951E-84B8CF244FC0",
+          "childFalseId": "1AC4CBD1-A4F2-4A7A-AAD8-E90C9F324004"
+      },
+      {
+          "id": "5D9D41EA-BC05-4138-83E8-9486E94834B9",
+          "type": "ForEachBlock",
+          "disabled": false,
+          "name": "loop7",
+          "displayName": "Loop 7",
+          "comment": "Loop over liveApps.",
+          "childId": null,
+          "inputs": [
+              {
+                  "id": "input",
+                  "value": "{ $.liveApps }",
+                  "type": "string",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "automations_censor_data",
+                  "value": false,
+                  "type": "checkbox",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": false
+              }
+          ],
+          "x": -2802,
+          "y": 24694,
+          "loopBlockId": "3B9FCBAE-B4AD-491D-AA8C-95619A4C827C"
+      },
+      {
+          "id": "3B9FCBAE-B4AD-491D-AA8C-95619A4C827C",
+          "type": "SnippetBlock",
+          "disabled": false,
+          "name": "DoReload",
+          "displayName": "Qlik Cloud Services - Do Reload",
+          "comment": "Trigger app reload. Warn on failure since will fail if a reload is ongoing.",
+          "childId": "3F546BF0-1269-4DA8-A132-0F3DE54E86F4",
+          "inputs": [
+              {
+                  "id": "29603390-e716-11ea-9e37-05e08ee32111",
+                  "value": "{ $.loop7.item.attributes.id }",
+                  "type": "string",
+                  "structure": []
+              },
+              {
+                  "id": "2ac9eef0-a677-11eb-aacc-8b755d0fe484",
+                  "value": "Start reload and continue",
+                  "type": "select",
+                  "displayValue": "Start reload and continue",
+                  "structure": []
+              },
+              {
+                  "id": "6892c0c0-c795-11eb-9860-9dc8cb705e25",
+                  "value": null,
+                  "type": "select",
+                  "structure": []
+              },
+              {
+                  "id": "ecebf340-c797-11eb-8671-53658babb1a1",
+                  "value": null,
+                  "type": "select",
+                  "structure": []
+              },
+              {
+                  "id": "069de770-8277-11f0-a252-ad6769632a1c",
+                  "value": null,
+                  "type": "select",
+                  "structure": []
+              },
+              {
+                  "id": "06a02bd0-8277-11f0-b78b-f7910663702f",
+                  "value": null,
+                  "type": "object",
+                  "mode": "keyValue",
+                  "structure": []
+              },
+              {
+                  "id": "cc8dd1c0-a438-11f0-9e17-c77404b63446",
+                  "value": null,
+                  "type": "select",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "blendr_on_error",
+                  "value": "warning",
+                  "type": "select",
+                  "displayValue": "Warning - Continue Automation and report errors",
+                  "structure": []
+              },
+              {
+                  "id": "automations_censor_data",
+                  "value": false,
+                  "type": "checkbox",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2682,
+          "y": 24794,
+          "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
+          "snippet_guid": "b5dbb7a0-e715-11ea-b2bf-43bb35adee19"
+      },
+      {
+          "id": "FB25A35E-49F7-4A93-951E-84B8CF244FC0",
+          "type": "ShowBlock",
+          "disabled": false,
+          "name": "output45",
+          "displayName": "Output 45",
+          "comment": "Status output.",
+          "childId": "5D9D41EA-BC05-4138-83E8-9486E94834B9",
+          "inputs": [
+              {
+                  "id": "input",
+                  "value": "| Reload | Configured to reload all apps now, triggering reloads. |",
+                  "type": "string",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "display_mode",
+                  "value": "add",
+                  "type": "select",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2802,
+          "y": 24574
+      },
+      {
+          "id": "3F546BF0-1269-4DA8-A132-0F3DE54E86F4",
+          "type": "ShowBlock",
+          "disabled": false,
+          "name": "output46",
+          "displayName": "Output 46",
+          "comment": "Status output.",
+          "childId": null,
+          "inputs": [
+              {
+                  "id": "input",
+                  "value": "| Reload | > Triggered reload of [{$.loop7.item.attributes.name}]({$.tenantHostname}sense/app/{ $.loop7.item.attributes.id }). |",
+                  "type": "string",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "display_mode",
+                  "value": "add",
+                  "type": "select",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2682,
+          "y": 24914
+      },
+      {
+          "id": "3F25D3AA-32C6-4C4A-968D-7EA29AA29A76",
+          "type": "ShowBlock",
+          "disabled": false,
+          "name": "output51",
+          "displayName": "Output 51",
+          "comment": "Status output.",
+          "childId": null,
+          "inputs": [
+              {
+                  "id": "input",
+                  "value": "| Reload schedule | > Created task for [{$.loop8.item.attributes.name}]({$.tenantHostname}sense/app/{$.loop8.item.attributes.id}). |",
+                  "type": "string",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "display_mode",
+                  "value": "add",
+                  "type": "select",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2682,
+          "y": 26614
+      },
+      {
+          "id": "CEEB9F64-6EF8-4820-AB01-EE03F916B81D",
+          "type": "ForEachBlock",
+          "disabled": false,
+          "name": "loop8",
+          "displayName": "Loop 8",
+          "comment": "Loop over liveApps.",
+          "childId": null,
+          "inputs": [
+              {
+                  "id": "input",
+                  "value": "{ $.liveApps }",
+                  "type": "string",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "automations_censor_data",
+                  "value": false,
+                  "type": "checkbox",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": false
+              }
+          ],
+          "x": -2802,
+          "y": 25474,
+          "loopBlockId": "DBF1BB1B-4211-420D-8B2C-AC9A5EC74B31"
+      },
+      {
+          "id": "4F1E7C76-BDAF-4C71-A828-279277FEBEBC",
+          "type": "ShowBlock",
+          "disabled": false,
+          "name": "output48",
+          "displayName": "Output 48",
+          "comment": "Status output.",
+          "childId": "CEEB9F64-6EF8-4820-AB01-EE03F916B81D",
+          "inputs": [
+              {
+                  "id": "input",
+                  "value": "| Reload schedule | Creating or replacing reload schedules. |",
+                  "type": "string",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "display_mode",
+                  "value": "add",
+                  "type": "select",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": false
+              }
+          ],
+          "x": -2802,
+          "y": 25354
+      },
+      {
+          "id": "EC299E1F-F2CA-4149-B148-FC4319064F9D",
+          "type": "IfElseBlock",
+          "disabled": false,
+          "name": "condition35",
+          "displayName": "Condition 35",
+          "comment": "If reloadScheduleHour is not empty, manage schedule.",
+          "childId": "FA1DC448-EC02-4CDB-9A20-8E042259A14C",
+          "inputs": [
+              {
+                  "id": "conditions",
+                  "value": {
+                      "mode": "all",
+                      "conditions": [
+                          {
+                              "input1": "{ $.reloadScheduleHour }",
+                              "input2": "1",
+                              "operator": "notEmpty"
+                          }
+                      ]
+                  },
+                  "type": "custom",
+                  "structure": []
+              }
+          ],
+          "settings": [],
+          "collapsed": [
+              {
+                  "name": "both",
+                  "isCollapsed": false
+              },
+              {
+                  "name": "yes",
+                  "isCollapsed": false
+              },
+              {
+                  "name": "no",
+                  "isCollapsed": false
+              }
+          ],
+          "x": -2922,
+          "y": 25274,
+          "childTrueId": "4F1E7C76-BDAF-4C71-A828-279277FEBEBC",
+          "childFalseId": "0B7C9754-D191-41BC-A121-E09CEB1D1E0C"
+      },
+      {
+          "id": "1AC4CBD1-A4F2-4A7A-AAD8-E90C9F324004",
+          "type": "ShowBlock",
+          "disabled": false,
+          "name": "output47",
+          "displayName": "Output 47",
+          "comment": "Status output.",
+          "childId": null,
+          "inputs": [
+              {
+                  "id": "input",
+                  "value": "| Reload | Skipping reload step per configuration. |",
+                  "type": "string",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "display_mode",
+                  "value": "add",
+                  "type": "select",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2802,
+          "y": 25114
+      },
+      {
+          "id": "0B7C9754-D191-41BC-A121-E09CEB1D1E0C",
+          "type": "ShowBlock",
+          "disabled": false,
+          "name": "output52",
+          "displayName": "Output 52",
+          "comment": "Status output.",
+          "childId": null,
+          "inputs": [
+              {
+                  "id": "input",
+                  "value": "| Reload schedule | Skipping reload schedule setup per configuration. |",
+                  "type": "string",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "display_mode",
+                  "value": "add",
+                  "type": "select",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2802,
+          "y": 26814
+      },
+      {
+          "id": "DBF1BB1B-4211-420D-8B2C-AC9A5EC74B31",
+          "type": "EndpointBlock",
+          "disabled": false,
+          "name": "rawAPIListRequest2",
+          "displayName": "Qlik Cloud Services - Raw API List Request 2",
+          "comment": "List reload tasks (ignore error is set on this block as we expect this endpoint to be removed in future).",
+          "childId": "1F217AD2-7D2F-46C9-AA0B-CF650A95E1D4",
+          "inputs": [
+              {
+                  "id": "9fd51350-bbb2-11f0-b2b4-c376cf7e2c04",
+                  "value": "v1/reload-tasks",
+                  "type": "string",
+                  "structure": []
+              },
+              {
+                  "id": "9ff92ee0-bbb2-11f0-8fb9-9146a99c6e2f",
+                  "value": [
+                      {
+                          "key": "appId",
+                          "value": "{ $.loop8.item.attributes.id }"
+                      }
+                  ],
+                  "type": "object",
+                  "mode": "keyValue",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "maxitemcount",
+                  "value": "",
+                  "type": "string",
+                  "structure": []
+              },
+              {
+                  "id": "blendr_on_error",
+                  "value": "ignore",
+                  "type": "select",
+                  "displayValue": "Ignore - Continue Automation and ignore errors",
+                  "structure": []
+              },
+              {
+                  "id": "cache",
+                  "value": "0",
+                  "type": "select",
+                  "structure": []
+              },
+              {
+                  "id": "automations_censor_data",
+                  "value": false,
+                  "type": "checkbox",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": false
+              }
+          ],
+          "x": -2682,
+          "y": 25574,
+          "loopBlockId": null,
+          "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
+          "endpoint_guid": "9f6166e0-bbb2-11f0-acdd-bd47067b5fbf",
+          "endpoint_role": "list"
+      },
+      {
+          "id": "FDC0A602-52CC-46BF-9DAC-9320101C6DE5",
+          "type": "EndpointBlock",
+          "disabled": false,
+          "name": "rawAPIRequest20",
+          "displayName": "Qlik Cloud Services - Raw API Request 20",
+          "comment": "Delete reload task (ignore error for future removal).",
+          "childId": "C78A84B1-7004-4B07-A0EC-9859F8143EC8",
+          "inputs": [
+              {
+                  "id": "734cbcc0-bbb0-11f0-b998-f73920377683",
+                  "value": "v1/reload-tasks/{ $.filterList10.item.id }",
+                  "type": "string",
+                  "structure": []
+              },
+              {
+                  "id": "7322a550-bbb0-11f0-9c8c-43f143a32456",
+                  "value": "73465660-bbb0-11f0-b65a-eb94ca86d22a",
+                  "type": "select",
+                  "displayValue": "DELETE",
+                  "structure": []
+              },
+              {
+                  "id": "73000fe0-bbb0-11f0-8a80-59ece3571bd9",
+                  "value": null,
+                  "type": "object",
+                  "mode": "keyValue",
+                  "structure": []
+              },
+              {
+                  "id": "736fae60-bbb0-11f0-ad62-c98a0046f418",
+                  "value": null,
+                  "type": "object",
+                  "mode": "keyValue",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "blendr_on_error",
+                  "value": "ignore",
+                  "type": "select",
+                  "displayValue": "Ignore - Continue Automation and ignore errors",
+                  "structure": []
+              },
+              {
+                  "id": "automations_censor_data",
+                  "value": false,
+                  "type": "checkbox",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2562,
+          "y": 25834,
+          "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
+          "endpoint_guid": "72d48530-bbb0-11f0-875a-b322bf237aeb",
+          "endpoint_role": "create"
+      },
+      {
+          "id": "1F217AD2-7D2F-46C9-AA0B-CF650A95E1D4",
+          "type": "FilterListBlock",
+          "disabled": false,
+          "name": "filterList10",
+          "displayName": "Filter over Qlik Cloud Services - Raw API List Request 2 - Filter List 10",
+          "comment": "Filter to tasks which haven't been migrated. Migrated tasks can't be updated.",
+          "childId": "87CA29E5-FAC2-4E81-A611-555DD014D546",
+          "inputs": [
+              {
+                  "id": "list",
+                  "value": "{ $.rawAPIListRequest2 }",
+                  "type": "string",
+                  "structure": []
+              },
+              {
+                  "id": "conditions",
+                  "value": {
+                      "mode": "all",
+                      "conditions": [
+                          {
+                              "input1": "migrated",
+                              "input2": null,
+                              "operator": "isFalse"
+                          }
+                      ]
+                  },
+                  "type": "custom",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "automations_censor_data",
+                  "value": false,
+                  "type": "checkbox",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": false
+              }
+          ],
+          "x": -2682,
+          "y": 25734,
+          "loopBlockId": "FDC0A602-52CC-46BF-9DAC-9320101C6DE5"
+      },
+      {
+          "id": "C78A84B1-7004-4B07-A0EC-9859F8143EC8",
+          "type": "ShowBlock",
+          "disabled": false,
+          "name": "output49",
+          "displayName": "Output 49",
+          "comment": "Status output.",
+          "childId": null,
+          "inputs": [
+              {
+                  "id": "input",
+                  "value": "| Reload schedule | > Deleted legacy reload task from [{ $.loop8.item.attributes.name }]({$.tenantHostname}sense/app/{ $.loop8.item.attributes.id }). |",
+                  "type": "string",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "display_mode",
+                  "value": "add",
+                  "type": "select",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2562,
+          "y": 25954
+      },
+      {
+          "id": "87CA29E5-FAC2-4E81-A611-555DD014D546",
+          "type": "EndpointBlock",
+          "disabled": false,
+          "name": "rawAPIListRequest3",
+          "displayName": "Qlik Cloud Services - Raw API List Request 3",
+          "comment": "List tasks.",
+          "childId": "BF1A16BF-5256-4500-953B-F576C3C6B651",
+          "inputs": [
+              {
+                  "id": "9fd51350-bbb2-11f0-b2b4-c376cf7e2c04",
+                  "value": "v1/tasks",
+                  "type": "string",
+                  "structure": []
+              },
+              {
+                  "id": "9ff92ee0-bbb2-11f0-8fb9-9146a99c6e2f",
+                  "value": [
+                      {
+                          "key": "resourceId",
+                          "value": "{ $.loop8.item.attributes.id }"
+                      }
+                  ],
+                  "type": "object",
+                  "mode": "keyValue",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "maxitemcount",
+                  "value": "",
+                  "type": "string",
+                  "structure": []
+              },
+              {
+                  "id": "blendr_on_error",
+                  "value": "stop",
+                  "type": "select",
+                  "displayValue": "Stop - Stop Automation and set to failed",
+                  "structure": []
+              },
+              {
+                  "id": "cache",
+                  "value": "0",
+                  "type": "select",
+                  "structure": []
+              },
+              {
+                  "id": "automations_censor_data",
+                  "value": false,
+                  "type": "checkbox",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": false
+              }
+          ],
+          "x": -2682,
+          "y": 26114,
+          "loopBlockId": "34F8AAE5-2A39-4EA6-84DD-200050879981",
+          "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
+          "endpoint_guid": "9f6166e0-bbb2-11f0-acdd-bd47067b5fbf",
+          "endpoint_role": "list"
+      },
+      {
+          "id": "34F8AAE5-2A39-4EA6-84DD-200050879981",
+          "type": "EndpointBlock",
+          "disabled": false,
+          "name": "rawAPIRequest21",
+          "displayName": "Qlik Cloud Services - Raw API Request 21",
+          "comment": "Delete task.",
+          "childId": "E5158A1B-0875-4B56-849E-D1C48472B46B",
+          "inputs": [
+              {
+                  "id": "734cbcc0-bbb0-11f0-b998-f73920377683",
+                  "value": "v1/tasks/{ $.rawAPIListRequest3.item.id }",
+                  "type": "string",
+                  "structure": []
+              },
+              {
+                  "id": "7322a550-bbb0-11f0-9c8c-43f143a32456",
+                  "value": "73465660-bbb0-11f0-b65a-eb94ca86d22a",
+                  "type": "select",
+                  "displayValue": "DELETE",
+                  "structure": []
+              },
+              {
+                  "id": "73000fe0-bbb0-11f0-8a80-59ece3571bd9",
+                  "value": null,
+                  "type": "object",
+                  "mode": "keyValue",
+                  "structure": []
+              },
+              {
+                  "id": "736fae60-bbb0-11f0-ad62-c98a0046f418",
+                  "value": null,
+                  "type": "object",
+                  "mode": "keyValue",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "blendr_on_error",
+                  "value": "stop",
+                  "type": "select",
+                  "displayValue": "Stop - Stop Automation and set to failed",
+                  "structure": []
+              },
+              {
+                  "id": "automations_censor_data",
+                  "value": false,
+                  "type": "checkbox",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2562,
+          "y": 26214,
+          "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
+          "endpoint_guid": "72d48530-bbb0-11f0-875a-b322bf237aeb",
+          "endpoint_role": "create"
+      },
+      {
+          "id": "E5158A1B-0875-4B56-849E-D1C48472B46B",
+          "type": "ShowBlock",
+          "disabled": false,
+          "name": "output50",
+          "displayName": "Output 50",
+          "comment": "Status output.",
+          "childId": null,
+          "inputs": [
+              {
+                  "id": "input",
+                  "value": "| Reload schedule | > Deleted task from [{$.loop8.item.attributes.name}]({$.tenantHostname}sense/app/{ $.loop8.item.attributes.id }). |",
+                  "type": "string",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "display_mode",
+                  "value": "add",
+                  "type": "select",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2562,
+          "y": 26334
+      },
+      {
+          "id": "BF1A16BF-5256-4500-953B-F576C3C6B651",
+          "type": "EndpointBlock",
+          "disabled": false,
+          "name": "rawAPIRequest22",
+          "displayName": "Qlik Cloud Services - Raw API Request 22",
+          "comment": "Create scheduled task.",
+          "childId": "3F25D3AA-32C6-4C4A-968D-7EA29AA29A76",
+          "inputs": [
+              {
+                  "id": "734cbcc0-bbb0-11f0-b998-f73920377683",
+                  "value": "v1/tasks",
+                  "type": "string",
+                  "structure": []
+              },
+              {
+                  "id": "7322a550-bbb0-11f0-9c8c-43f143a32456",
+                  "value": "7347ee10-bbb0-11f0-8cdc-59311dd108b3",
+                  "type": "select",
+                  "displayValue": "POST",
+                  "structure": []
+              },
+              {
+                  "id": "73000fe0-bbb0-11f0-8a80-59ece3571bd9",
+                  "value": "{\n  \"version\": \"1.0.0\",\n  \"specVersion\": \"1.12.0\",\n  \"name\": \"QCMA automated schedule\",\n  \"description\": \"Automatically deployed schedule by user ID {$.getCurrentUserId}, automation ID {automationid}, run ID {runid}.\",\n  \"enabled\": true,\n  \"states\": [\n    {\n      \"name\": \"init_state\",\n      \"type\": \"EVENT\",\n      \"onEvents\": [\n        {\n          \"eventRefs\": [],\n          \"actions\": [\n            {\n              \"name\": \"AppReload\",\n              \"functionRef\": {\n                \"refName\": \"app.reload\",\n                \"arguments\": {\n                  \"appId\": \"{ $.loop8.item.attributes.id }\",\n                  \"partial\": false\n                }\n              }\n            }\n          ]\n        }\n      ]\n    }\n  ],\n  \"resourceId\": \"{ $.loop8.item.attributes.id }\",\n  \"start\": {\n    \"schedule\": {\n      \"startDateTime\": \"2025-10-17T00:00:00\",\n      \"endDateTime\": null,\n      \"timezone\": \"Europe/London\",\n      \"recurrence\": \"RRULE:FREQ=WEEKLY;INTERVAL=1;BYDAY=MO,TU,WE,TH,FR,SA,SU;BYHOUR={ $.reloadScheduleHour };BYMINUTE=15;BYSECOND=0\"\n    }\n  }\n}",
+                  "type": "object",
+                  "mode": "raw",
+                  "structure": []
+              },
+              {
+                  "id": "736fae60-bbb0-11f0-ad62-c98a0046f418",
+                  "value": null,
+                  "type": "object",
+                  "mode": "keyValue",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "blendr_on_error",
+                  "value": "stop",
+                  "type": "select",
+                  "displayValue": "Stop - Stop Automation and set to failed",
+                  "structure": []
+              },
+              {
+                  "id": "automations_censor_data",
+                  "value": false,
+                  "type": "checkbox",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2682,
+          "y": 26494,
+          "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
+          "endpoint_guid": "72d48530-bbb0-11f0-875a-b322bf237aeb",
+          "endpoint_role": "create"
+      },
+      {
+          "id": "A9BBBC6E-49FE-4819-BE22-504FC54335F2",
+          "type": "IfElseBlock",
+          "disabled": false,
+          "name": "condition",
+          "displayName": "Condition",
+          "comment": "CONFIGURE: Workflow settings. Edit this section only.",
+          "childId": "F9DCB126-6ED4-4D9A-BF35-CFD7A6D9CECD",
+          "inputs": [
+              {
+                  "id": "conditions",
+                  "value": {
+                      "mode": "all",
+                      "conditions": [
+                          {
+                              "input1": "1",
+                              "input2": null,
+                              "operator": "isTrue"
+                          }
+                      ]
+                  },
+                  "type": "custom",
+                  "structure": []
+              }
+          ],
+          "settings": [],
+          "collapsed": [
+              {
+                  "name": "both",
+                  "isCollapsed": false
+              },
+              {
+                  "name": "yes",
+                  "isCollapsed": false
+              },
+              {
+                  "name": "no",
+                  "isCollapsed": false
+              }
+          ],
+          "x": -2922,
+          "y": -3586,
+          "childTrueId": "2E327220-1609-47A0-8385-6B40E70A7CFB",
+          "childFalseId": null
+      },
+      {
+          "id": "A5B767E8-1450-43F7-9E7E-4471FBD5F282",
+          "type": "GotoBlock",
+          "disabled": false,
+          "name": "goToLabel7",
+          "displayName": "Go To Label 7",
+          "comment": "Go to the label named error.",
+          "childId": null,
+          "inputs": [
+              {
+                  "id": "label",
+                  "value": "EF82AD29-E2CF-44C9-A7DB-24C784618756",
+                  "type": "select",
+                  "displayValue": "error",
+                  "structure": []
+              }
+          ],
+          "settings": [],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2802,
+          "y": 7114
+      },
+      {
+          "id": "D0CE93F3-2D1E-4F03-8384-E10EDA8D85F7",
+          "type": "VariableBlock",
+          "disabled": false,
+          "name": "errorDetail",
+          "displayName": "Variable - errorDetail",
+          "comment": "Variable to store detailed error message.",
+          "childId": "A5B767E8-1450-43F7-9E7E-4471FBD5F282",
+          "inputs": [],
+          "settings": [],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2802,
+          "y": 6994,
+          "variableGuid": "1BF2068B-106E-4D58-BC51-884F1810F03C",
+          "operations": [
+              {
+                  "id": "set_value",
+                  "key": "1BC10F4C-68C2-42E9-9000-25865B076073",
+                  "name": "Set value of { variable }",
+                  "value": "Exiting, data connections to REST data sources are disabled on the tenant. This prevents connectivity to tenant data. Enable REST data sources and then re-run the automation."
+              }
+          ]
+      },
+      {
+          "id": "71CF1DF2-EDD5-4BD0-859E-8B644FFA7552",
+          "type": "VariableBlock",
+          "disabled": false,
+          "name": "errorTitle",
+          "displayName": "Variable - errorTitle",
+          "comment": "Set error title for standard error output.",
+          "childId": "D0CE93F3-2D1E-4F03-8384-E10EDA8D85F7",
+          "inputs": [],
+          "settings": [],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2802,
+          "y": 6874,
+          "variableGuid": "407730A6-EC96-4337-BE80-CF4C0D552F08",
+          "operations": [
+              {
+                  "id": "set_value",
+                  "key": "1BC10F4C-68C2-42E9-9000-25865B076073",
+                  "name": "Set value of { variable }",
+                  "value": "REST connections are disabled on the tenant. Enable REST connector support and try again."
+              }
+          ]
+      },
+      {
+          "id": "2CE857A5-5770-4230-B4A7-E64B4B777B22",
+          "type": "IfElseBlock",
+          "disabled": false,
+          "name": "condition12",
+          "displayName": "Condition 12",
+          "comment": "If REST connector disabled, exit.",
+          "childId": "F718EF32-99B6-49C3-A5A5-6996F86B0B87",
+          "inputs": [
+              {
+                  "id": "conditions",
+                  "value": {
+                      "mode": "all",
+                      "conditions": [
+                          {
+                              "input1": "{ $.rawAPIRequest3.disabled }",
+                              "input2": null,
+                              "operator": "isTrue"
+                          }
+                      ]
+                  },
+                  "type": "custom",
+                  "structure": []
+              }
+          ],
+          "settings": [],
+          "collapsed": [
+              {
+                  "name": "both",
+                  "isCollapsed": false
+              },
+              {
+                  "name": "yes",
+                  "isCollapsed": false
+              },
+              {
+                  "name": "no",
+                  "isCollapsed": false
+              }
+          ],
+          "x": -2922,
+          "y": 6794,
+          "childTrueId": "71CF1DF2-EDD5-4BD0-859E-8B644FFA7552",
+          "childFalseId": null
+      },
+      {
+          "id": "FA1DC448-EC02-4CDB-9A20-8E042259A14C",
+          "type": "ShowBlock",
+          "disabled": false,
+          "name": "output53",
+          "displayName": "Output 53",
+          "comment": "Status output.",
+          "childId": "215C3F93-2B59-4ADA-A98E-870483095D2C",
+          "inputs": [
+              {
+                  "id": "input",
+                  "value": "Complete!",
+                  "type": "string",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "display_mode",
+                  "value": "add",
+                  "type": "select",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2922,
+          "y": 26974
+      },
+      {
+          "id": "215C3F93-2B59-4ADA-A98E-870483095D2C",
+          "type": "UpdateJobBlock",
+          "disabled": false,
+          "name": "updateRunTitle",
+          "displayName": "Update Run Title",
+          "comment": "Update the run title to include the monitoring app installation completion status.",
+          "childId": null,
+          "inputs": [
+              {
+                  "id": "title",
+                  "value": "Maintained apps: {implode: { $.monitoringAppsToInstall[*].name }, ', '}",
+                  "type": "string",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "automations_censor_data",
+                  "value": false,
+                  "type": "checkbox",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2922,
+          "y": 27094
+      },
+      {
+          "id": "4D28FE57-54CB-4FA9-A5EE-A7C65992D3FD",
+          "type": "EndpointBlock",
+          "disabled": false,
+          "name": "listRoles",
+          "displayName": "Qlik Cloud Services - List Roles",
+          "comment": "Retrieve user default role configuration, required for checking for API key access.",
+          "childId": "192CAC57-0476-4EA6-9E3B-44900026EB88",
+          "inputs": [
+              {
+                  "id": "61cc2ce0-eb31-11ed-8846-f774c9249948",
+                  "value": "name eq \"UserDefault\"",
+                  "type": "string",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "maxitemcount",
+                  "value": "",
+                  "type": "string",
+                  "structure": []
+              },
+              {
+                  "id": "blendr_on_error",
+                  "value": "stop",
+                  "type": "select",
+                  "structure": []
+              },
+              {
+                  "id": "cache",
+                  "value": "0",
+                  "type": "select",
+                  "structure": []
+              },
+              {
+                  "id": "automations_censor_data",
+                  "value": false,
+                  "type": "checkbox",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": false
+              }
+          ],
+          "x": -2922,
+          "y": 1034,
+          "loopBlockId": "76AA3D41-6FAE-4406-9AAD-67EA9C1B1E7D",
+          "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
+          "endpoint_guid": "61a20140-eb31-11ed-8f08-a515d1528437",
+          "endpoint_role": "list"
+      },
+      {
+          "id": "76AA3D41-6FAE-4406-9AAD-67EA9C1B1E7D",
+          "type": "VariableBlock",
+          "disabled": false,
+          "name": "userPermissions",
+          "displayName": "Variable - userPermissions",
+          "comment": "Add userDefault role to user permissions list.",
+          "childId": null,
+          "inputs": [],
+          "settings": [],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": false
+              }
+          ],
+          "x": -2802,
+          "y": 1134,
+          "variableGuid": "4283B5F6-E6C0-492F-AA5B-21195FFF74DF",
+          "operations": [
+              {
+                  "id": "merge",
+                  "key": "E08C7C2C-0351-4834-9C2B-8621AA9CCFB0",
+                  "name": "Merge other list into { variable }",
+                  "value": "{ $.listRoles.item.assignedScopes }"
+              }
+          ]
+      },
+      {
+          "id": "CA3E018B-042B-421C-9FFE-B53DFA5E392A",
+          "type": "EndpointBlock",
+          "disabled": false,
+          "name": "getApp",
+          "displayName": "Qlik Cloud Services - Get App",
+          "comment": "Retrieve the app definition since this format will match the published app format used in liveApps later. This is more reliable than calling items right after publishing.",
+          "childId": "F3CCCABB-3F06-47D2-B3A0-E018A8EAD140",
+          "inputs": [
+              {
+                  "id": "dbeaab00-c7a5-11ea-9342-e9d6ce76e8f1",
+                  "value": "{ $.loop3.item.resourceId }",
+                  "type": "string",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "blendr_on_error",
+                  "value": "stop",
+                  "type": "select",
+                  "structure": []
+              },
+              {
+                  "id": "cache",
+                  "value": "0",
+                  "type": "select",
+                  "structure": []
+              },
+              {
+                  "id": "automations_censor_data",
+                  "value": false,
+                  "type": "checkbox",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2322,
+          "y": 17234,
+          "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
+          "endpoint_guid": "dbdc5470-c7a5-11ea-9135-b9442d1570d8",
+          "endpoint_role": "get"
+      },
+      {
+          "id": "D93CC85B-1E1E-4EE9-A2C4-D60FB7E19A92",
+          "type": "ForEachBlock",
+          "disabled": false,
+          "name": "loop9",
+          "displayName": "Loop 9",
+          "comment": "Loop - assignedGroups",
+          "childId": "CD1DE6F6-8F1B-43EE-9B1A-E1ED8E200416",
+          "inputs": [
+              {
+                  "id": "input",
+                  "value": "{ $.getUser.assignedGroups }",
+                  "type": "string",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "automations_censor_data",
+                  "value": false,
+                  "type": "checkbox",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": false
+              }
+          ],
+          "x": -2922,
+          "y": 134,
+          "loopBlockId": "EB88BBA6-62CF-4BE2-AE54-D656545BCDB8"
+      },
+      {
+          "id": "EB88BBA6-62CF-4BE2-AE54-D656545BCDB8",
+          "type": "ForEachBlock",
+          "disabled": false,
+          "name": "loop10",
+          "displayName": "Loop 10",
+          "comment": "Loop - group.assignedRoles",
+          "childId": null,
+          "inputs": [
+              {
+                  "id": "input",
+                  "value": "{ $.loop9.item.assignedRoles }",
+                  "type": "string",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "automations_censor_data",
+                  "value": false,
+                  "type": "checkbox",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": false
+              }
+          ],
+          "x": -2802,
+          "y": 234,
+          "loopBlockId": "19CC7B58-34C4-4762-A144-898EF788EA13"
+      },
+      {
+          "id": "19CC7B58-34C4-4762-A144-898EF788EA13",
+          "type": "VariableBlock",
+          "disabled": false,
+          "name": "userRoles",
+          "displayName": "Variable - userRoles",
+          "comment": "Collect all roles for API key access checks.",
+          "childId": null,
+          "inputs": [],
+          "settings": [],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": false
+              }
+          ],
+          "x": -2682,
+          "y": 334,
+          "variableGuid": "CD9F0C76-28B4-482E-A218-EDE5763F6807",
+          "operations": [
+              {
+                  "id": "add_item",
+                  "key": "FF3F1190-B850-4D68-AFF6-CAE2EB644159",
+                  "name": "Add item to { variable }",
+                  "value": "{object: '{\"id\":\"{ $.loop10.item.id }\",\"name\":\"{ $.loop10.item.name }\",\"type\":\"{ $.loop10.item.type }\",\"level\":\"{ $.loop10.item.level }\"}'}"
+              }
+          ]
+      },
+      {
+          "id": "3521F356-424C-44DE-8801-3042B0539E8D",
+          "type": "FormBlock",
+          "disabled": false,
+          "name": "inputs4",
+          "displayName": "Inputs 4",
+          "comment": "want to proceed with update?",
+          "childId": "ABF9478A-D559-4049-BA23-984416DB5D99",
+          "inputs": [],
+          "settings": [
+              {
+                  "id": "persist_data",
+                  "value": "no",
+                  "type": "select",
+                  "structure": []
+              },
+              {
+                  "id": "automations_censor_data",
+                  "value": false,
+                  "type": "checkbox",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": false
+              }
+          ],
+          "x": -2802,
+          "y": -1466,
+          "form": [
+              {
+                  "id": "inputs4-input-0",
+                  "type": "select",
+                  "label": "Automatically update this automation?",
+                  "order": 0,
+                  "values": "Yes,No",
+                  "options": [],
+                  "helpText": "This will update the automation to the latest version of the Qlik Cloud Monitoring Apps deployer. Select Yes to proceed or No to cancel.",
+                  "isRequired": true
+              }
+          ],
+          "persistData": "no"
+      },
+      {
+          "id": "8F006B7D-F5B6-4BAA-8BFB-76D2B794E8AF",
+          "type": "ShowBlock",
+          "disabled": false,
+          "name": "output55",
+          "displayName": "Output 55",
+          "comment": "Ouptut - Upate needed",
+          "childId": "3521F356-424C-44DE-8801-3042B0539E8D",
+          "inputs": [
+              {
+                  "id": "input",
+                  "value": "## Upate needed!\n\nThis deployer template is version \"{$.currentTemplateVersionNum}\", which is less than the required version \"{$.callURL.installers[?(@.template=='qcmad')].version}\"",
+                  "type": "string",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "display_mode",
+                  "value": "add",
+                  "type": "select",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": false
+              }
+          ],
+          "x": -2802,
+          "y": -1586
+      },
+      {
+          "id": "ABF9478A-D559-4049-BA23-984416DB5D99",
+          "type": "IfElseBlock",
+          "disabled": false,
+          "name": "condition36",
+          "displayName": "Condition 36",
+          "comment": "Users answer",
+          "childId": null,
+          "inputs": [
+              {
+                  "id": "conditions",
+                  "value": {
+                      "mode": "all",
+                      "conditions": [
+                          {
+                              "input1": "{ $.inputs4.'Automatically update this automation?' }",
+                              "input2": "Yes",
+                              "operator": "="
+                          }
+                      ]
+                  },
+                  "type": "custom",
+                  "structure": []
+              }
+          ],
+          "settings": [],
+          "collapsed": [
+              {
+                  "name": "both",
+                  "isCollapsed": false
+              },
+              {
+                  "name": "yes",
+                  "isCollapsed": false
+              },
+              {
+                  "name": "no",
+                  "isCollapsed": false
+              }
+          ],
+          "x": -2802,
+          "y": -1346,
+          "childTrueId": "6DB0BCE2-239C-491D-89F1-6E9F63937F49",
+          "childFalseId": "BC3C801D-F2AB-4A2F-9587-18D35113F50A"
+      },
+      {
+          "id": "6DB0BCE2-239C-491D-89F1-6E9F63937F49",
+          "type": "CallUrlBlock",
+          "disabled": false,
+          "name": "callURL4",
+          "displayName": "Call URL 4",
+          "comment": "Get the current version ",
+          "childId": "1C53F6DA-FE4F-4BE3-8A95-82EF0EC3E288",
+          "inputs": [
+              {
+                  "id": "url",
+                  "value": "https://raw.githubusercontent.com/qlik-oss/qlik-cloud-monitoring-apps/main/automations/singleTenantDeployer.json",
+                  "type": "string",
+                  "structure": []
+              },
+              {
+                  "id": "method",
+                  "value": "GET",
+                  "type": "select",
+                  "structure": []
+              },
+              {
+                  "id": "timeout",
+                  "value": "",
+                  "type": "string",
+                  "structure": []
+              },
+              {
+                  "id": "params",
+                  "value": null,
+                  "type": "object",
+                  "mode": "keyValue",
+                  "structure": []
+              },
+              {
+                  "id": "headers",
+                  "value": null,
+                  "type": "object",
+                  "mode": "keyValue",
+                  "structure": []
+              },
+              {
+                  "id": "encoding",
+                  "value": "",
+                  "type": "string",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "blendr_on_error",
+                  "value": "stop",
+                  "type": "select",
+                  "structure": []
+              },
+              {
+                  "id": "full_response",
+                  "value": null,
+                  "type": "checkbox",
+                  "structure": []
+              },
+              {
+                  "id": "capitalize_headers",
+                  "value": true,
+                  "type": "checkbox",
+                  "structure": []
+              },
+              {
+                  "id": "automations_censor_data",
+                  "value": false,
+                  "type": "checkbox",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": false
+              }
+          ],
+          "x": -2682,
+          "y": -1266
+      },
+      {
+          "id": "1C53F6DA-FE4F-4BE3-8A95-82EF0EC3E288",
+          "type": "EndpointBlock",
+          "disabled": false,
+          "name": "updateAutomation",
+          "displayName": "Qlik Cloud Services - Update Automation",
+          "comment": "Update this automation",
+          "childId": "99C259DE-CADE-4561-8634-3C93EA662301",
+          "inputs": [
+              {
+                  "id": "428c8660-d041-11ec-864d-5bed7a9667ee",
+                  "value": "{ automationid }",
+                  "type": "string",
+                  "structure": []
+              },
+              {
+                  "id": "1f1d64b0-d041-11ec-bc03-e5fdbc243961",
+                  "value": null,
+                  "type": "string",
+                  "structure": []
+              },
+              {
+                  "id": "1f272e60-d041-11ec-9044-dda9cc402447",
+                  "value": null,
+                  "type": "string",
+                  "structure": []
+              },
+              {
+                  "id": "7fcdf4c0-2833-11ed-a6a9-797f49b90041",
+                  "value": "{ $.callURL4 }",
+                  "type": "string",
+                  "structure": []
+              },
+              {
+                  "id": "99e1a8c0-2833-11ed-b085-83fc18a9cd7d",
+                  "value": null,
+                  "type": "string",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "blendr_on_error",
+                  "value": "stop",
+                  "type": "select",
+                  "structure": []
+              },
+              {
+                  "id": "automations_censor_data",
+                  "value": false,
+                  "type": "checkbox",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": false
+              }
+          ],
+          "x": -2682,
+          "y": -1146,
+          "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
+          "endpoint_guid": "1f022b50-d041-11ec-a842-e9973f7c493f",
+          "endpoint_role": "update"
+      },
+      {
+          "id": "99C259DE-CADE-4561-8634-3C93EA662301",
+          "type": "ShowBlock",
+          "disabled": false,
+          "name": "output56",
+          "displayName": "Output 56",
+          "comment": "Output - Automation has been updated",
+          "childId": "08CBB6D5-ACC3-40AD-A7DA-AA28CD5AD4DB",
+          "inputs": [
+              {
+                  "id": "input",
+                  "value": "## Automation has been updated. Please refresh the page or open: \n[This link to refresh]({$.tenantHostname}analytics/automations/editor/{automationid})",
+                  "type": "string",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "display_mode",
+                  "value": "add",
+                  "type": "select",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": false
+              }
+          ],
+          "x": -2682,
+          "y": -1026
+      },
+      {
+          "id": "F8CCF961-2D55-43AE-A8B3-CED17A4A0B9A",
+          "type": "StopBlock",
+          "disabled": false,
+          "name": "stop",
+          "displayName": "Stop",
+          "comment": "Don't continue.",
+          "childId": null,
+          "inputs": [],
+          "settings": [],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": false
+              }
+          ],
+          "x": -2682,
+          "y": -786
+      },
+      {
+          "id": "08CBB6D5-ACC3-40AD-A7DA-AA28CD5AD4DB",
+          "type": "UpdateJobBlock",
+          "disabled": false,
+          "name": "updateRunTitle3",
+          "displayName": "Update Run Title 3",
+          "comment": "Update title - New version and run again.",
+          "childId": "F8CCF961-2D55-43AE-A8B3-CED17A4A0B9A",
+          "inputs": [
+              {
+                  "id": "title",
+                  "value": "Updated to version: { $.callURL.installers[?(@.template=='qcma')].version }. Please run again.",
+                  "type": "string",
+                  "structure": []
+              }
+          ],
+          "settings": [
+              {
+                  "id": "automations_censor_data",
+                  "value": false,
+                  "type": "checkbox",
+                  "structure": []
+              }
+          ],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": false
+              }
+          ],
+          "x": -2682,
+          "y": -906
+      },
+      {
+          "id": "BC3C801D-F2AB-4A2F-9587-18D35113F50A",
+          "type": "VariableBlock",
+          "disabled": false,
+          "name": "errorTitle#2",
+          "displayName": "Variable - errorTitle 2",
+          "comment": "Set error title for standard error output.",
+          "childId": "64B8E46A-B998-4661-9D31-97D1D1CE3C2E",
+          "inputs": [],
+          "settings": [],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2620.5,
+          "y": -639.5,
+          "variableGuid": "407730A6-EC96-4337-BE80-CF4C0D552F08",
+          "operations": [
+              {
+                  "id": "set_value",
+                  "key": "1BC10F4C-68C2-42E9-9000-25865B076073",
+                  "name": "Set value of { variable }",
+                  "value": "Cancelled - please view the run output for more information."
+              }
+          ]
+      },
+      {
+          "id": "64B8E46A-B998-4661-9D31-97D1D1CE3C2E",
+          "type": "VariableBlock",
+          "disabled": false,
+          "name": "errorDetail#2",
+          "displayName": "Variable - errorDetail 2",
+          "comment": "Variable to store detailed error message.",
+          "childId": "C01C559D-F45B-4371-9D45-D87EEEF392D7",
+          "inputs": [],
+          "settings": [],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2319.5,
+          "y": -477.5,
+          "variableGuid": "1BF2068B-106E-4D58-BC51-884F1810F03C",
+          "operations": [
+              {
+                  "id": "set_value",
+                  "key": "1BC10F4C-68C2-42E9-9000-25865B076073",
+                  "name": "Set value of { variable }",
+                  "value": "Exiting, this deployer template is version \"{$.currentTemplateVersionNum}\", which is less than the required version \"{$.callURL.installers[?(@.template=='qcmad')].version}\" \n{linebreak}\n{linebreak}\nThe manifest message is: {$.callURL.installers[?(@.template=='qcmad')].message}"
+              }
+          ]
+      },
+      {
+          "id": "C01C559D-F45B-4371-9D45-D87EEEF392D7",
+          "type": "GotoBlock",
+          "disabled": false,
+          "name": "goToLabel",
+          "displayName": "Go To Label",
+          "comment": "Go to the label named error.",
+          "childId": null,
+          "inputs": [
+              {
+                  "id": "label",
+                  "value": "EF82AD29-E2CF-44C9-A7DB-24C784618756",
+                  "type": "select",
+                  "displayValue": "error",
+                  "structure": []
+              }
+          ],
+          "settings": [],
+          "collapsed": [
+              {
+                  "name": "loop",
+                  "isCollapsed": true
+              }
+          ],
+          "x": -2319.5,
+          "y": -357.5
+      }
   ],
   "variables": [
-    {
-      "guid": "E3084D5D-4DE7-428E-BDE0-440DCD055EDD",
-      "name": "sharedSpaceName",
-      "type": "string"
-    },
-    {
-      "guid": "247B71DE-30E7-4526-AC3D-BE5E17AA9194",
-      "name": "managedSpaceName",
-      "type": "string"
-    },
-    {
-      "guid": "9679AB7C-F7EB-4A7F-A217-B2F9F14CE7E5",
-      "name": "versionsToKeep",
-      "type": "number"
-    },
-    {
-      "guid": "DE390532-B1F9-4098-BBE0-B7E6101BD502",
-      "name": "sharedSpaceId",
-      "type": "string"
-    },
-    {
-      "guid": "407730A6-EC96-4337-BE80-CF4C0D552F08",
-      "name": "errorTitle",
-      "type": "string"
-    },
-    {
-      "guid": "1BF2068B-106E-4D58-BC51-884F1810F03C",
-      "name": "errorDetail",
-      "type": "string"
-    },
-    {
-      "guid": "E413E2FB-E4E7-4AFF-8894-6D27792FA8D8",
-      "name": "spaceRoles",
-      "type": "list"
-    },
-    {
-      "guid": "B6C34135-EF0E-42EF-AC0D-621D8A8A165D",
-      "name": "managedSpaceId",
-      "type": "string"
-    },
-    {
-      "guid": "F6ED0768-9852-46AF-B822-2172586824B7",
-      "name": "cleanupCounter",
-      "type": "number"
-    },
-    {
-      "guid": "3723D829-3B14-4B68-AAFE-63966A7025E6",
-      "name": "tenantHostname",
-      "type": "string"
-    },
-    {
-      "guid": "64E41053-153C-41E1-8E96-441CE6CCC379",
-      "name": "refreshConnectorCredentials",
-      "type": "number"
-    },
-    {
-      "guid": "69E3DE89-62A4-4A45-A797-81D480D8BBC9",
-      "name": "currentTemplateVersionNum",
-      "type": "number"
-    },
-    {
-      "guid": "CD9F0C76-28B4-482E-A218-EDE5763F6807",
-      "name": "userRoles",
-      "type": "list"
-    },
-    {
-      "guid": "4283B5F6-E6C0-492F-AA5B-21195FFF74DF",
-      "name": "userPermissions",
-      "type": "list"
-    },
-    {
-      "guid": "51DCB139-A5E7-427D-8E9C-9382DB8A530C",
-      "name": "apiKeyDuration",
-      "type": "string"
-    },
-    {
-      "guid": "4FCFD564-CA0B-4516-AD61-A1A2EE9CF38C",
-      "name": "manifest",
-      "type": "object"
-    },
-    {
-      "guid": "AD716F55-666C-4730-B830-F2D97A502F6B",
-      "name": "isCapacityTenant",
-      "type": "number"
-    },
-    {
-      "guid": "8E1D15E6-7269-4E6B-A87E-AF56400A2F7A",
-      "name": "configuredMonitoringApps",
-      "type": "list"
-    },
-    {
-      "guid": "1ECFDB29-BC7A-4B7A-AE5F-2A2DBE77B1E0",
-      "name": "monitoringAppsToInstall",
-      "type": "list"
-    },
-    {
-      "guid": "09C608F2-CF67-4C9A-983E-F39019D443B9",
-      "name": "requiredRoles",
-      "type": "list"
-    },
-    {
-      "guid": "CB55538C-0F1A-4871-98DD-C68EC5B00D84",
-      "name": "missingRoles",
-      "type": "list"
-    },
-    {
-      "guid": "2E37F6E5-BE30-44ED-B0B6-B544ECEAAB9E",
-      "name": "existingAppList",
-      "type": "list"
-    },
-    {
-      "guid": "B762B4A7-25F9-4764-BECA-D4461377CE04",
-      "name": "workingAppList",
-      "type": "list"
-    },
-    {
-      "guid": "12A37AC8-CD9C-41FC-9626-508B24997C86",
-      "name": "workingAppTagName",
-      "type": "string"
-    },
-    {
-      "guid": "4CFD6FDB-6937-45CE-8677-203A280087D1",
-      "name": "workingAppTagVersion",
-      "type": "string"
-    },
-    {
-      "guid": "D8F8BD27-8FF5-42FF-82ED-0EE947E55327",
-      "name": "workingAppExists",
-      "type": "number"
-    },
-    {
-      "guid": "996190EC-165A-4CF1-A3B6-363B8F0DDF31",
-      "name": "workingAppBinary",
-      "type": "string"
-    },
-    {
-      "guid": "AE6C347F-BAAD-4FD0-A820-80AFEE588B29",
-      "name": "workingAppTags",
-      "type": "object"
-    },
-    {
-      "guid": "FA7C823B-3AA8-41EA-990F-21837758447A",
-      "name": "taggerIds",
-      "type": "object"
-    },
-    {
-      "guid": "A812E467-95BC-419E-B6A6-4341D6347C3A",
-      "name": "liveApps",
-      "type": "list"
-    },
-    {
-      "guid": "218D5568-BA73-49F2-9996-926C40E2AE08",
-      "name": "dataConnectionName",
-      "type": "string"
-    },
-    {
-      "guid": "AABC69B3-4AB6-4777-A443-FCFCFDA805C4",
-      "name": "apiKeyExpiryDate",
-      "type": "string"
-    },
-    {
-      "guid": "DB5AD6FD-CA6D-4BDB-B12B-91C248324EE1",
-      "name": "apiKeyName",
-      "type": "string"
-    },
-    {
-      "guid": "12BED549-8F76-4D83-B484-F6121E71753E",
-      "name": "reloadNow",
-      "type": "number"
-    },
-    {
-      "guid": "3DA539EC-2C6E-4C2B-9985-6F5BDCA282B2",
-      "name": "reloadScheduleHour",
-      "type": "number"
-    }
+      {
+          "guid": "E3084D5D-4DE7-428E-BDE0-440DCD055EDD",
+          "name": "sharedSpaceName",
+          "type": "string"
+      },
+      {
+          "guid": "247B71DE-30E7-4526-AC3D-BE5E17AA9194",
+          "name": "managedSpaceName",
+          "type": "string"
+      },
+      {
+          "guid": "9679AB7C-F7EB-4A7F-A217-B2F9F14CE7E5",
+          "name": "versionsToKeep",
+          "type": "number"
+      },
+      {
+          "guid": "DE390532-B1F9-4098-BBE0-B7E6101BD502",
+          "name": "sharedSpaceId",
+          "type": "string"
+      },
+      {
+          "guid": "407730A6-EC96-4337-BE80-CF4C0D552F08",
+          "name": "errorTitle",
+          "type": "string"
+      },
+      {
+          "guid": "1BF2068B-106E-4D58-BC51-884F1810F03C",
+          "name": "errorDetail",
+          "type": "string"
+      },
+      {
+          "guid": "E413E2FB-E4E7-4AFF-8894-6D27792FA8D8",
+          "name": "spaceRoles",
+          "type": "list"
+      },
+      {
+          "guid": "B6C34135-EF0E-42EF-AC0D-621D8A8A165D",
+          "name": "managedSpaceId",
+          "type": "string"
+      },
+      {
+          "guid": "F6ED0768-9852-46AF-B822-2172586824B7",
+          "name": "cleanupCounter",
+          "type": "number"
+      },
+      {
+          "guid": "3723D829-3B14-4B68-AAFE-63966A7025E6",
+          "name": "tenantHostname",
+          "type": "string"
+      },
+      {
+          "guid": "64E41053-153C-41E1-8E96-441CE6CCC379",
+          "name": "refreshConnectorCredentials",
+          "type": "number"
+      },
+      {
+          "guid": "69E3DE89-62A4-4A45-A797-81D480D8BBC9",
+          "name": "currentTemplateVersionNum",
+          "type": "number"
+      },
+      {
+          "guid": "CD9F0C76-28B4-482E-A218-EDE5763F6807",
+          "name": "userRoles",
+          "type": "list"
+      },
+      {
+          "guid": "4283B5F6-E6C0-492F-AA5B-21195FFF74DF",
+          "name": "userPermissions",
+          "type": "list"
+      },
+      {
+          "guid": "51DCB139-A5E7-427D-8E9C-9382DB8A530C",
+          "name": "apiKeyDuration",
+          "type": "string"
+      },
+      {
+          "guid": "4FCFD564-CA0B-4516-AD61-A1A2EE9CF38C",
+          "name": "manifest",
+          "type": "object"
+      },
+      {
+          "guid": "AD716F55-666C-4730-B830-F2D97A502F6B",
+          "name": "isCapacityTenant",
+          "type": "number"
+      },
+      {
+          "guid": "8E1D15E6-7269-4E6B-A87E-AF56400A2F7A",
+          "name": "configuredMonitoringApps",
+          "type": "list"
+      },
+      {
+          "guid": "1ECFDB29-BC7A-4B7A-AE5F-2A2DBE77B1E0",
+          "name": "monitoringAppsToInstall",
+          "type": "list"
+      },
+      {
+          "guid": "09C608F2-CF67-4C9A-983E-F39019D443B9",
+          "name": "requiredRoles",
+          "type": "list"
+      },
+      {
+          "guid": "CB55538C-0F1A-4871-98DD-C68EC5B00D84",
+          "name": "missingRoles",
+          "type": "list"
+      },
+      {
+          "guid": "2E37F6E5-BE30-44ED-B0B6-B544ECEAAB9E",
+          "name": "existingAppList",
+          "type": "list"
+      },
+      {
+          "guid": "B762B4A7-25F9-4764-BECA-D4461377CE04",
+          "name": "workingAppList",
+          "type": "list"
+      },
+      {
+          "guid": "12A37AC8-CD9C-41FC-9626-508B24997C86",
+          "name": "workingAppTagName",
+          "type": "string"
+      },
+      {
+          "guid": "4CFD6FDB-6937-45CE-8677-203A280087D1",
+          "name": "workingAppTagVersion",
+          "type": "string"
+      },
+      {
+          "guid": "D8F8BD27-8FF5-42FF-82ED-0EE947E55327",
+          "name": "workingAppExists",
+          "type": "number"
+      },
+      {
+          "guid": "996190EC-165A-4CF1-A3B6-363B8F0DDF31",
+          "name": "workingAppBinary",
+          "type": "string"
+      },
+      {
+          "guid": "AE6C347F-BAAD-4FD0-A820-80AFEE588B29",
+          "name": "workingAppTags",
+          "type": "object"
+      },
+      {
+          "guid": "FA7C823B-3AA8-41EA-990F-21837758447A",
+          "name": "taggerIds",
+          "type": "object"
+      },
+      {
+          "guid": "A812E467-95BC-419E-B6A6-4341D6347C3A",
+          "name": "liveApps",
+          "type": "list"
+      },
+      {
+          "guid": "218D5568-BA73-49F2-9996-926C40E2AE08",
+          "name": "dataConnectionName",
+          "type": "string"
+      },
+      {
+          "guid": "AABC69B3-4AB6-4777-A443-FCFCFDA805C4",
+          "name": "apiKeyExpiryDate",
+          "type": "string"
+      },
+      {
+          "guid": "DB5AD6FD-CA6D-4BDB-B12B-91C248324EE1",
+          "name": "apiKeyName",
+          "type": "string"
+      },
+      {
+          "guid": "12BED549-8F76-4D83-B484-F6121E71753E",
+          "name": "reloadNow",
+          "type": "number"
+      },
+      {
+          "guid": "3DA539EC-2C6E-4C2B-9985-6F5BDCA282B2",
+          "name": "reloadScheduleHour",
+          "type": "number"
+      }
   ]
 }

--- a/automations/singleTenantDeployer.json
+++ b/automations/singleTenantDeployer.json
@@ -17,7 +17,12 @@
         }
       ],
       "settings": [],
-      "collapsed": [{ "name": "loop", "isCollapsed": false }],
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": false
+        }
+      ],
       "x": -2922,
       "y": -3826
     },
@@ -45,7 +50,12 @@
           "structure": []
         }
       ],
-      "collapsed": [{ "name": "loop", "isCollapsed": false }],
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": false
+        }
+      ],
       "x": -2922,
       "y": -3706
     },
@@ -59,7 +69,12 @@
       "childId": "816EE781-6447-4CB2-AE71-07512C23A11E",
       "inputs": [],
       "settings": [],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
       "x": -2802,
       "y": -3026,
       "variableGuid": "E3084D5D-4DE7-428E-BDE0-440DCD055EDD",
@@ -82,7 +97,12 @@
       "childId": "749BB890-520A-4E81-8C75-5738241F7586",
       "inputs": [],
       "settings": [],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
       "x": -2802,
       "y": -2906,
       "variableGuid": "247B71DE-30E7-4526-AC3D-BE5E17AA9194",
@@ -105,7 +125,12 @@
       "childId": null,
       "inputs": [],
       "settings": [],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
       "x": -2802,
       "y": -2786,
       "variableGuid": "9679AB7C-F7EB-4A7F-A217-B2F9F14CE7E5",
@@ -134,7 +159,12 @@
           "type": "select",
           "structure": []
         },
-        { "id": "cache", "value": "0", "type": "select", "structure": [] },
+        {
+          "id": "cache",
+          "value": "0",
+          "type": "select",
+          "structure": []
+        },
         {
           "id": "automations_censor_data",
           "value": false,
@@ -142,7 +172,12 @@
           "structure": []
         }
       ],
-      "collapsed": [{ "name": "loop", "isCollapsed": false }],
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": false
+        }
+      ],
       "x": -2922,
       "y": -2586,
       "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
@@ -172,7 +207,12 @@
           "type": "select",
           "structure": []
         },
-        { "id": "cache", "value": "0", "type": "select", "structure": [] },
+        {
+          "id": "cache",
+          "value": "0",
+          "type": "select",
+          "structure": []
+        },
         {
           "id": "automations_censor_data",
           "value": false,
@@ -180,7 +220,12 @@
           "structure": []
         }
       ],
-      "collapsed": [{ "name": "loop", "isCollapsed": false }],
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": false
+        }
+      ],
       "x": -2922,
       "y": -2466,
       "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
@@ -211,7 +256,12 @@
           "structure": []
         }
       ],
-      "collapsed": [{ "name": "loop", "isCollapsed": false }],
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": false
+        }
+      ],
       "x": -2922,
       "y": -1866
     },
@@ -247,12 +297,21 @@
       ],
       "settings": [],
       "collapsed": [
-        { "name": "yes", "isCollapsed": false },
-        { "name": "no", "isCollapsed": false },
-        { "name": "both", "isCollapsed": false }
+        {
+          "name": "yes",
+          "isCollapsed": false
+        },
+        {
+          "name": "no",
+          "isCollapsed": false
+        },
+        {
+          "name": "both",
+          "isCollapsed": false
+        }
       ],
       "x": -2922,
-      "y": -1186,
+      "y": -506,
       "childTrueId": "BE7F53B8-B1FD-48DF-A8A5-D6638F74FA2C",
       "childFalseId": null
     },
@@ -272,7 +331,12 @@
           "type": "select",
           "structure": []
         },
-        { "id": "cache", "value": "0", "type": "select", "structure": [] },
+        {
+          "id": "cache",
+          "value": "0",
+          "type": "select",
+          "structure": []
+        },
         {
           "id": "automations_censor_data",
           "value": false,
@@ -280,9 +344,14 @@
           "structure": []
         }
       ],
-      "collapsed": [{ "name": "loop", "isCollapsed": false }],
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": false
+        }
+      ],
       "x": -2922,
-      "y": 874,
+      "y": 1934,
       "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
       "endpoint_guid": "0e6d4530-3291-11ed-a2e9-3bc221fc190c",
       "endpoint_role": "get"
@@ -311,9 +380,14 @@
           "structure": []
         }
       ],
-      "collapsed": [{ "name": "loop", "isCollapsed": false }],
-      "x": -2922,
-      "y": 2594
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": false
+        }
+      ],
+      "x": -2930,
+      "y": 3657
     },
     {
       "id": "F718EF32-99B6-49C3-A5A5-6996F86B0B87",
@@ -375,9 +449,14 @@
           "structure": []
         }
       ],
-      "collapsed": [{ "name": "loop", "isCollapsed": false }],
-      "x": -2922,
-      "y": 6254,
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": false
+        }
+      ],
+      "x": -3292,
+      "y": 7334,
       "loopBlockId": null,
       "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
       "endpoint_guid": "590a1a20-6d2e-11eb-9714-df1bbaac055d",
@@ -393,9 +472,14 @@
       "childId": "34B88617-9583-4EA4-948E-D580D65F3C49",
       "inputs": [],
       "settings": [],
-      "collapsed": [{ "name": "loop", "isCollapsed": false }],
-      "x": -2922,
-      "y": 6414,
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": false
+        }
+      ],
+      "x": -3292,
+      "y": 7494,
       "variableGuid": "DE390532-B1F9-4098-BBE0-B7E6101BD502",
       "operations": [
         {
@@ -430,9 +514,14 @@
           "structure": []
         }
       ],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
-      "x": -2802,
-      "y": 6754
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
+      "x": -3172,
+      "y": 7834
     },
     {
       "id": "34B88617-9583-4EA4-948E-D580D65F3C49",
@@ -473,9 +562,14 @@
           "structure": []
         }
       ],
-      "collapsed": [{ "name": "loop", "isCollapsed": false }],
-      "x": -2922,
-      "y": 6534,
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": false
+        }
+      ],
+      "x": -3292,
+      "y": 7614,
       "loopBlockId": "7E7CFBF2-F088-4F93-9BA8-DE932E22956E"
     },
     {
@@ -488,9 +582,14 @@
       "childId": "EB27466E-BFCB-4FFC-8B1A-3AA517AB3F4F",
       "inputs": [],
       "settings": [],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
-      "x": -2802,
-      "y": 6634,
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
+      "x": -3172,
+      "y": 7714,
       "variableGuid": "DE390532-B1F9-4098-BBE0-B7E6101BD502",
       "operations": [
         {
@@ -528,12 +627,21 @@
       ],
       "settings": [],
       "collapsed": [
-        { "name": "yes", "isCollapsed": true },
-        { "name": "no", "isCollapsed": true },
-        { "name": "both", "isCollapsed": true }
+        {
+          "name": "yes",
+          "isCollapsed": true
+        },
+        {
+          "name": "no",
+          "isCollapsed": true
+        },
+        {
+          "name": "both",
+          "isCollapsed": true
+        }
       ],
-      "x": -2802,
-      "y": 6874,
+      "x": -3172,
+      "y": 7954,
       "childTrueId": "A29FDF70-7705-4848-B467-90DD6CD8F293",
       "childFalseId": "EABD8111-E99F-4C5B-A67D-3D7F0ACE778E"
     },
@@ -547,7 +655,12 @@
       "childId": "6A1F7D55-1177-4CED-96ED-C5EAB1EF473C",
       "inputs": [],
       "settings": [],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
       "x": -2561,
       "y": 7132,
       "variableGuid": "407730A6-EC96-4337-BE80-CF4C0D552F08",
@@ -570,7 +683,12 @@
       "childId": "4B13B3CA-4EE2-4F26-A4E4-ECBE8AD13378",
       "inputs": [],
       "settings": [],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
       "x": -2561,
       "y": 7252,
       "variableGuid": "1BF2068B-106E-4D58-BC51-884F1810F03C",
@@ -601,7 +719,12 @@
         }
       ],
       "settings": [],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
       "x": -2561,
       "y": 7372
     },
@@ -614,10 +737,20 @@
       "comment": "Standard error handler which provides standardized error output.",
       "childId": "D46F6E49-3856-430B-A685-0A07984CDAEB",
       "inputs": [
-        { "id": "name", "value": "error", "type": "string", "structure": [] }
+        {
+          "id": "name",
+          "value": "error",
+          "type": "string",
+          "structure": []
+        }
       ],
       "settings": [],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
       "x": -1219,
       "y": -2915
     },
@@ -648,9 +781,18 @@
       ],
       "settings": [],
       "collapsed": [
-        { "name": "yes", "isCollapsed": true },
-        { "name": "no", "isCollapsed": true },
-        { "name": "both", "isCollapsed": true }
+        {
+          "name": "yes",
+          "isCollapsed": true
+        },
+        {
+          "name": "no",
+          "isCollapsed": true
+        },
+        {
+          "name": "both",
+          "isCollapsed": true
+        }
       ],
       "x": -2561,
       "y": 7532,
@@ -699,7 +841,12 @@
           "type": "select",
           "structure": []
         },
-        { "id": "cache", "value": "0", "type": "select", "structure": [] },
+        {
+          "id": "cache",
+          "value": "0",
+          "type": "select",
+          "structure": []
+        },
         {
           "id": "automations_censor_data",
           "value": false,
@@ -707,7 +854,12 @@
           "structure": []
         }
       ],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
       "x": -2441,
       "y": 7612,
       "loopBlockId": null,
@@ -742,9 +894,18 @@
       ],
       "settings": [],
       "collapsed": [
-        { "name": "yes", "isCollapsed": true },
-        { "name": "no", "isCollapsed": true },
-        { "name": "both", "isCollapsed": true }
+        {
+          "name": "yes",
+          "isCollapsed": true
+        },
+        {
+          "name": "no",
+          "isCollapsed": true
+        },
+        {
+          "name": "both",
+          "isCollapsed": true
+        }
       ],
       "x": -2441,
       "y": 7732,
@@ -778,9 +939,18 @@
       ],
       "settings": [],
       "collapsed": [
-        { "name": "yes", "isCollapsed": true },
-        { "name": "no", "isCollapsed": true },
-        { "name": "both", "isCollapsed": true }
+        {
+          "name": "yes",
+          "isCollapsed": true
+        },
+        {
+          "name": "no",
+          "isCollapsed": true
+        },
+        {
+          "name": "both",
+          "isCollapsed": true
+        }
       ],
       "x": -2321,
       "y": 7812,
@@ -797,7 +967,12 @@
       "childId": "B6226FFD-EC59-4DB5-91A6-A706091A4FD6",
       "inputs": [],
       "settings": [],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
       "x": -2201,
       "y": 7892,
       "variableGuid": "E413E2FB-E4E7-4AFF-8894-6D27792FA8D8",
@@ -865,7 +1040,12 @@
           "structure": []
         }
       ],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
       "x": -2201,
       "y": 8012,
       "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
@@ -896,7 +1076,12 @@
           "structure": []
         }
       ],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
       "x": -2201,
       "y": 8132
     },
@@ -924,7 +1109,12 @@
           "structure": []
         }
       ],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
       "x": -2201,
       "y": 8292
     },
@@ -977,7 +1167,12 @@
           "structure": []
         }
       ],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
       "x": -2321,
       "y": 8532,
       "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
@@ -1008,7 +1203,12 @@
           "structure": []
         }
       ],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
       "x": -2321,
       "y": 8652
     },
@@ -1036,7 +1236,12 @@
           "structure": []
         }
       ],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
       "x": -2441,
       "y": 8892
     },
@@ -1050,9 +1255,14 @@
       "childId": "8B32EC24-AC36-47A1-B60B-2FC217B835E3",
       "inputs": [],
       "settings": [],
-      "collapsed": [{ "name": "loop", "isCollapsed": false }],
-      "x": -2922,
-      "y": 7234,
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": false
+        }
+      ],
+      "x": -3292,
+      "y": 8314,
       "variableGuid": "B6C34135-EF0E-42EF-AC0D-621D8A8A165D",
       "operations": [
         {
@@ -1078,10 +1288,20 @@
           "type": "string",
           "structure": []
         },
-        { "id": "action", "value": "stop", "type": "select", "structure": [] }
+        {
+          "id": "action",
+          "value": "stop",
+          "type": "select",
+          "structure": []
+        }
       ],
       "settings": [],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
       "x": -1219,
       "y": -2555
     },
@@ -1145,9 +1365,14 @@
           "structure": []
         }
       ],
-      "collapsed": [{ "name": "loop", "isCollapsed": false }],
-      "x": -2922,
-      "y": 7074,
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": false
+        }
+      ],
+      "x": -3292,
+      "y": 8154,
       "loopBlockId": null,
       "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
       "endpoint_guid": "590a1a20-6d2e-11eb-9714-df1bbaac055d",
@@ -1192,9 +1417,14 @@
           "structure": []
         }
       ],
-      "collapsed": [{ "name": "loop", "isCollapsed": false }],
-      "x": -2922,
-      "y": 7354,
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": false
+        }
+      ],
+      "x": -3292,
+      "y": 8434,
       "loopBlockId": "FCBE0570-D739-43D6-B0AD-B16A2DA6F28A"
     },
     {
@@ -1207,9 +1437,14 @@
       "childId": "820347D1-83F1-4F4E-A9A3-AACE4DF3685E",
       "inputs": [],
       "settings": [],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
-      "x": -2802,
-      "y": 7454,
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
+      "x": -3172,
+      "y": 8534,
       "variableGuid": "B6C34135-EF0E-42EF-AC0D-621D8A8A165D",
       "operations": [
         {
@@ -1244,9 +1479,14 @@
           "structure": []
         }
       ],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
-      "x": -2802,
-      "y": 7574
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
+      "x": -3172,
+      "y": 8654
     },
     {
       "id": "B35B33BE-B45B-4749-813C-64BA4AA4FA1D",
@@ -1275,12 +1515,21 @@
       ],
       "settings": [],
       "collapsed": [
-        { "name": "yes", "isCollapsed": false },
-        { "name": "no", "isCollapsed": false },
-        { "name": "both", "isCollapsed": false }
+        {
+          "name": "yes",
+          "isCollapsed": false
+        },
+        {
+          "name": "no",
+          "isCollapsed": false
+        },
+        {
+          "name": "both",
+          "isCollapsed": false
+        }
       ],
-      "x": -2802,
-      "y": 7694,
+      "x": -3172,
+      "y": 8774,
       "childTrueId": "F0DEE5BC-C9A2-4F91-964A-EA7C64F90457",
       "childFalseId": "2FDCB00D-3E41-4B95-A904-51DBFF7345AA"
     },
@@ -1294,9 +1543,14 @@
       "childId": "CDB7C2AB-E721-492F-9238-2A91F9B67CF2",
       "inputs": [],
       "settings": [],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
-      "x": -2682,
-      "y": 7774,
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
+      "x": -3052,
+      "y": 8854,
       "variableGuid": "407730A6-EC96-4337-BE80-CF4C0D552F08",
       "operations": [
         {
@@ -1317,9 +1571,14 @@
       "childId": "1324CB60-D99D-4A46-AB5A-734A7B31D12B",
       "inputs": [],
       "settings": [],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
-      "x": -2682,
-      "y": 7894,
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
+      "x": -3052,
+      "y": 8974,
       "variableGuid": "1BF2068B-106E-4D58-BC51-884F1810F03C",
       "operations": [
         {
@@ -1348,9 +1607,14 @@
         }
       ],
       "settings": [],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
-      "x": -2682,
-      "y": 8014
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
+      "x": -3052,
+      "y": 9094
     },
     {
       "id": "2FDCB00D-3E41-4B95-A904-51DBFF7345AA",
@@ -1379,12 +1643,21 @@
       ],
       "settings": [],
       "collapsed": [
-        { "name": "yes", "isCollapsed": false },
-        { "name": "no", "isCollapsed": false },
-        { "name": "both", "isCollapsed": false }
+        {
+          "name": "yes",
+          "isCollapsed": false
+        },
+        {
+          "name": "no",
+          "isCollapsed": false
+        },
+        {
+          "name": "both",
+          "isCollapsed": false
+        }
       ],
-      "x": -2682,
-      "y": 8174,
+      "x": -3052,
+      "y": 9254,
       "childTrueId": "064FC5B0-AF19-4C57-B22A-E171D71F3643",
       "childFalseId": "F37D6ACE-DF7C-4EB9-A990-E7DBCD31ABDF"
     },
@@ -1430,7 +1703,12 @@
           "type": "select",
           "structure": []
         },
-        { "id": "cache", "value": "0", "type": "select", "structure": [] },
+        {
+          "id": "cache",
+          "value": "0",
+          "type": "select",
+          "structure": []
+        },
         {
           "id": "automations_censor_data",
           "value": false,
@@ -1438,9 +1716,14 @@
           "structure": []
         }
       ],
-      "collapsed": [{ "name": "loop", "isCollapsed": false }],
-      "x": -2562,
-      "y": 8254,
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": false
+        }
+      ],
+      "x": -2932,
+      "y": 9334,
       "loopBlockId": null,
       "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
       "endpoint_guid": "ffe6d930-6d33-11eb-ad8a-334e25c5e295",
@@ -1473,12 +1756,21 @@
       ],
       "settings": [],
       "collapsed": [
-        { "name": "yes", "isCollapsed": false },
-        { "name": "no", "isCollapsed": false },
-        { "name": "both", "isCollapsed": false }
+        {
+          "name": "yes",
+          "isCollapsed": false
+        },
+        {
+          "name": "no",
+          "isCollapsed": false
+        },
+        {
+          "name": "both",
+          "isCollapsed": false
+        }
       ],
-      "x": -2562,
-      "y": 8414,
+      "x": -2932,
+      "y": 9494,
       "childTrueId": "D0EEE98C-7DA0-47F5-B8C6-31B0507505FD",
       "childFalseId": "9CC93349-E133-4BCC-860C-7AAE4991A788"
     },
@@ -1514,12 +1806,21 @@
       ],
       "settings": [],
       "collapsed": [
-        { "name": "yes", "isCollapsed": false },
-        { "name": "no", "isCollapsed": false },
-        { "name": "both", "isCollapsed": false }
+        {
+          "name": "yes",
+          "isCollapsed": false
+        },
+        {
+          "name": "no",
+          "isCollapsed": false
+        },
+        {
+          "name": "both",
+          "isCollapsed": false
+        }
       ],
-      "x": -2442,
-      "y": 8494,
+      "x": -2812,
+      "y": 9574,
       "childTrueId": "BE0D6DE8-CA32-466A-917B-40EA75EB91C9",
       "childFalseId": "253E7602-5CB9-473C-A66A-ABB7711934A6"
     },
@@ -1533,9 +1834,14 @@
       "childId": "759EE2C8-9EAF-4D15-9A14-D059BC43154C",
       "inputs": [],
       "settings": [],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
-      "x": -2322,
-      "y": 8574,
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
+      "x": -2692,
+      "y": 9654,
       "variableGuid": "E413E2FB-E4E7-4AFF-8894-6D27792FA8D8",
       "operations": [
         {
@@ -1607,9 +1913,14 @@
           "structure": []
         }
       ],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
-      "x": -2322,
-      "y": 8694,
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
+      "x": -2692,
+      "y": 9774,
       "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
       "endpoint_guid": "8c54ade0-6d42-11eb-b3a8-75befcc89b0a",
       "endpoint_role": "update"
@@ -1638,9 +1949,14 @@
           "structure": []
         }
       ],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
-      "x": -2322,
-      "y": 8814
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
+      "x": -2692,
+      "y": 9894
     },
     {
       "id": "253E7602-5CB9-473C-A66A-ABB7711934A6",
@@ -1666,9 +1982,14 @@
           "structure": []
         }
       ],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
-      "x": -2322,
-      "y": 8974
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
+      "x": -2692,
+      "y": 10054
     },
     {
       "id": "9CC93349-E133-4BCC-860C-7AAE4991A788",
@@ -1719,9 +2040,14 @@
           "structure": []
         }
       ],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
-      "x": -2442,
-      "y": 9214,
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
+      "x": -2812,
+      "y": 10294,
       "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
       "endpoint_guid": "272d9c70-6d31-11eb-870f-67624392ed86",
       "endpoint_role": "create"
@@ -1750,9 +2076,14 @@
           "structure": []
         }
       ],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
-      "x": -2442,
-      "y": 9334
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
+      "x": -2812,
+      "y": 10414
     },
     {
       "id": "F37D6ACE-DF7C-4EB9-A990-E7DBCD31ABDF",
@@ -1778,9 +2109,14 @@
           "structure": []
         }
       ],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
-      "x": -2562,
-      "y": 9574
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
+      "x": -2932,
+      "y": 10654
     },
     {
       "id": "7C0C15A5-F334-4AD6-A9D4-C0AC674CC34B",
@@ -1809,12 +2145,21 @@
       ],
       "settings": [],
       "collapsed": [
-        { "name": "yes", "isCollapsed": false },
-        { "name": "no", "isCollapsed": false },
-        { "name": "both", "isCollapsed": false }
+        {
+          "name": "yes",
+          "isCollapsed": false
+        },
+        {
+          "name": "no",
+          "isCollapsed": false
+        },
+        {
+          "name": "both",
+          "isCollapsed": false
+        }
       ],
-      "x": -2922,
-      "y": 9894,
+      "x": -3292,
+      "y": 10974,
       "childTrueId": "A835D799-19FC-450D-BF01-88DB67C89291",
       "childFalseId": null
     },
@@ -1860,9 +2205,14 @@
           "structure": []
         }
       ],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
-      "x": -2802,
-      "y": 9974,
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
+      "x": -3172,
+      "y": 11054,
       "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
       "endpoint_guid": "f0c14620-6d24-11eb-aa67-c519e2671d3d",
       "endpoint_role": "create"
@@ -1877,9 +2227,14 @@
       "childId": "E43BB4EB-9F53-4ACA-9649-051763575EE8",
       "inputs": [],
       "settings": [],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
-      "x": -2802,
-      "y": 10094,
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
+      "x": -3172,
+      "y": 11174,
       "variableGuid": "DE390532-B1F9-4098-BBE0-B7E6101BD502",
       "operations": [
         {
@@ -1914,9 +2269,14 @@
           "structure": []
         }
       ],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
-      "x": -2802,
-      "y": 10214
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
+      "x": -3172,
+      "y": 11294
     },
     {
       "id": "230E3338-D040-459F-A88C-47CD38B6BD39",
@@ -1945,12 +2305,21 @@
       ],
       "settings": [],
       "collapsed": [
-        { "name": "yes", "isCollapsed": false },
-        { "name": "no", "isCollapsed": false },
-        { "name": "both", "isCollapsed": false }
+        {
+          "name": "yes",
+          "isCollapsed": false
+        },
+        {
+          "name": "no",
+          "isCollapsed": false
+        },
+        {
+          "name": "both",
+          "isCollapsed": false
+        }
       ],
-      "x": -2922,
-      "y": 10414,
+      "x": -3292,
+      "y": 11494,
       "childTrueId": "ED0FFFF7-7BA3-4BC5-B2CC-37F2AE4C0408",
       "childFalseId": null
     },
@@ -1996,9 +2365,14 @@
           "structure": []
         }
       ],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
-      "x": -2802,
-      "y": 10494,
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
+      "x": -3172,
+      "y": 11574,
       "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
       "endpoint_guid": "f0c14620-6d24-11eb-aa67-c519e2671d3d",
       "endpoint_role": "create"
@@ -2013,9 +2387,14 @@
       "childId": "8EA716DA-A818-45D1-8D97-92171239EAE3",
       "inputs": [],
       "settings": [],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
-      "x": -2802,
-      "y": 10614,
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
+      "x": -3172,
+      "y": 11694,
       "variableGuid": "B6C34135-EF0E-42EF-AC0D-621D8A8A165D",
       "operations": [
         {
@@ -2050,9 +2429,14 @@
           "structure": []
         }
       ],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
-      "x": -2802,
-      "y": 10734
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
+      "x": -3172,
+      "y": 11814
     },
     {
       "id": "4BE16981-95D8-4418-B598-B26CA6843820",
@@ -2064,9 +2448,14 @@
       "childId": "5006AC77-27D1-4EA3-AF11-DA559F907DB8",
       "inputs": [],
       "settings": [],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
-      "x": -2682,
-      "y": 22494,
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
+      "x": -3052,
+      "y": 23574,
       "variableGuid": "F6ED0768-9852-46AF-B822-2172586824B7",
       "operations": [
         {
@@ -2191,9 +2580,14 @@
           "structure": []
         }
       ],
-      "collapsed": [{ "name": "loop", "isCollapsed": false }],
-      "x": -2682,
-      "y": 22614,
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": false
+        }
+      ],
+      "x": -3052,
+      "y": 23694,
       "loopBlockId": "1B323E62-40BB-40D7-AD9A-D04DA4A5FFB6",
       "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
       "endpoint_guid": "84ad9050-6f72-11eb-aa08-a1dda4364ef5",
@@ -2226,12 +2620,21 @@
       ],
       "settings": [],
       "collapsed": [
-        { "name": "yes", "isCollapsed": false },
-        { "name": "no", "isCollapsed": false },
-        { "name": "both", "isCollapsed": false }
+        {
+          "name": "yes",
+          "isCollapsed": false
+        },
+        {
+          "name": "no",
+          "isCollapsed": false
+        },
+        {
+          "name": "both",
+          "isCollapsed": false
+        }
       ],
-      "x": -2562,
-      "y": 22714,
+      "x": -2932,
+      "y": 23794,
       "childTrueId": "1C69733A-CADE-4901-9BC2-4CDA59A50DA2",
       "childFalseId": null
     },
@@ -2265,9 +2668,14 @@
           "structure": []
         }
       ],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
-      "x": -2442,
-      "y": 22794,
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
+      "x": -2812,
+      "y": 23874,
       "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
       "endpoint_guid": "fcc108b0-67b2-11eb-806a-3957ec36f31b",
       "endpoint_role": "delete"
@@ -2296,9 +2704,14 @@
           "structure": []
         }
       ],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
-      "x": -2442,
-      "y": 22914
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
+      "x": -2812,
+      "y": 23994
     },
     {
       "id": "D5570044-9796-4DC7-81B6-C6D2F937FB1F",
@@ -2310,9 +2723,14 @@
       "childId": null,
       "inputs": [],
       "settings": [],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
-      "x": -2562,
-      "y": 23114,
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
+      "x": -2932,
+      "y": 24194,
       "variableGuid": "F6ED0768-9852-46AF-B822-2172586824B7",
       "operations": [
         {
@@ -2333,9 +2751,14 @@
       "childId": "A8F7B895-B7BB-4F7A-9189-B757D5A85B52",
       "inputs": [],
       "settings": [],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
       "x": -2802,
-      "y": -1106,
+      "y": -426,
       "variableGuid": "407730A6-EC96-4337-BE80-CF4C0D552F08",
       "operations": [
         {
@@ -2356,9 +2779,14 @@
       "childId": "1D1FB21E-ADAA-4284-8526-5C849D304B59",
       "inputs": [],
       "settings": [],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
       "x": -2802,
-      "y": -986,
+      "y": -306,
       "variableGuid": "1BF2068B-106E-4D58-BC51-884F1810F03C",
       "operations": [
         {
@@ -2387,9 +2815,14 @@
         }
       ],
       "settings": [],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
       "x": -2802,
-      "y": -866
+      "y": -186
     },
     {
       "id": "D46F6E49-3856-430B-A685-0A07984CDAEB",
@@ -2415,7 +2848,12 @@
           "structure": []
         }
       ],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
       "x": -1219,
       "y": -2795
     },
@@ -2443,7 +2881,12 @@
           "structure": []
         }
       ],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
       "x": -1219,
       "y": -2675
     },
@@ -2463,7 +2906,12 @@
           "type": "select",
           "structure": []
         },
-        { "id": "cache", "value": "0", "type": "select", "structure": [] },
+        {
+          "id": "cache",
+          "value": "0",
+          "type": "select",
+          "structure": []
+        },
         {
           "id": "automations_censor_data",
           "value": false,
@@ -2471,7 +2919,12 @@
           "structure": []
         }
       ],
-      "collapsed": [{ "name": "loop", "isCollapsed": false }],
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": false
+        }
+      ],
       "x": -2922,
       "y": -2346,
       "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
@@ -2488,7 +2941,12 @@
       "childId": "82CEC2F2-0C2A-438F-8D85-41BF9C90E37B",
       "inputs": [],
       "settings": [],
-      "collapsed": [{ "name": "loop", "isCollapsed": false }],
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": false
+        }
+      ],
       "x": -2922,
       "y": -2226,
       "variableGuid": "3723D829-3B14-4B68-AAFE-63966A7025E6",
@@ -2511,7 +2969,12 @@
       "childId": "2E61A575-F621-4713-B446-C1BAC52D8834",
       "inputs": [],
       "settings": [],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
       "x": -2802,
       "y": -3386,
       "variableGuid": "64E41053-153C-41E1-8E96-441CE6CCC379",
@@ -2534,7 +2997,12 @@
       "childId": "D7D4A126-BDC4-41D8-AB46-9D581AAE2FED",
       "inputs": [],
       "settings": [],
-      "collapsed": [{ "name": "loop", "isCollapsed": false }],
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": false
+        }
+      ],
       "x": -2922,
       "y": -2106,
       "variableGuid": "69E3DE89-62A4-4A45-A797-81D480D8BBC9",
@@ -2562,8 +3030,18 @@
           "type": "string",
           "structure": []
         },
-        { "id": "method", "value": "GET", "type": "select", "structure": [] },
-        { "id": "timeout", "value": "", "type": "string", "structure": [] },
+        {
+          "id": "method",
+          "value": "GET",
+          "type": "select",
+          "structure": []
+        },
+        {
+          "id": "timeout",
+          "value": "",
+          "type": "string",
+          "structure": []
+        },
         {
           "id": "params",
           "value": null,
@@ -2578,7 +3056,12 @@
           "mode": "keyValue",
           "structure": []
         },
-        { "id": "encoding", "value": "", "type": "string", "structure": [] }
+        {
+          "id": "encoding",
+          "value": "",
+          "type": "string",
+          "structure": []
+        }
       ],
       "settings": [
         {
@@ -2606,7 +3089,12 @@
           "structure": []
         }
       ],
-      "collapsed": [{ "name": "loop", "isCollapsed": false }],
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": false
+        }
+      ],
       "x": -2922,
       "y": -1986
     },
@@ -2642,14 +3130,23 @@
       ],
       "settings": [],
       "collapsed": [
-        { "name": "both", "isCollapsed": false },
-        { "name": "yes", "isCollapsed": false },
-        { "name": "no", "isCollapsed": false }
+        {
+          "name": "both",
+          "isCollapsed": false
+        },
+        {
+          "name": "yes",
+          "isCollapsed": false
+        },
+        {
+          "name": "no",
+          "isCollapsed": false
+        }
       ],
       "x": -2922,
       "y": -1746,
       "childTrueId": null,
-      "childFalseId": "8A147572-A4B4-436E-AEEA-D3B0D9E2CE1B"
+      "childFalseId": "8F006B7D-F5B6-4BAA-8BFB-76D2B794E8AF"
     },
     {
       "id": "8C8FFCA6-849B-49E7-9852-7B0C074D6F65",
@@ -2707,9 +3204,14 @@
           "structure": []
         }
       ],
-      "collapsed": [{ "name": "loop", "isCollapsed": false }],
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": false
+        }
+      ],
       "x": -2922,
-      "y": 754,
+      "y": 1814,
       "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
       "endpoint_guid": "72d48530-bbb0-11f0-875a-b322bf237aeb",
       "endpoint_role": "create"
@@ -2746,12 +3248,21 @@
       ],
       "settings": [],
       "collapsed": [
-        { "name": "both", "isCollapsed": false },
-        { "name": "yes", "isCollapsed": false },
-        { "name": "no", "isCollapsed": false }
+        {
+          "name": "both",
+          "isCollapsed": false
+        },
+        {
+          "name": "yes",
+          "isCollapsed": false
+        },
+        {
+          "name": "no",
+          "isCollapsed": false
+        }
       ],
       "x": -2922,
-      "y": 1114,
+      "y": 2174,
       "childTrueId": "D115A0F9-A1B3-4483-8169-145D1F47A9B1",
       "childFalseId": null
     },
@@ -2765,9 +3276,14 @@
       "childId": "6064DA9A-04D6-49DD-B223-C3752D3769F4",
       "inputs": [],
       "settings": [],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
       "x": -2802,
-      "y": 1194,
+      "y": 2254,
       "variableGuid": "407730A6-EC96-4337-BE80-CF4C0D552F08",
       "operations": [
         {
@@ -2788,9 +3304,14 @@
       "childId": "F81EA66B-BC74-4856-AE46-4B9C1D64A6AE",
       "inputs": [],
       "settings": [],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
       "x": -2802,
-      "y": 1314,
+      "y": 2374,
       "variableGuid": "1BF2068B-106E-4D58-BC51-884F1810F03C",
       "operations": [
         {
@@ -2819,77 +3340,14 @@
         }
       ],
       "settings": [],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
-      "x": -2802,
-      "y": 1434
-    },
-    {
-      "id": "8A147572-A4B4-436E-AEEA-D3B0D9E2CE1B",
-      "type": "VariableBlock",
-      "disabled": false,
-      "name": "errorTitle",
-      "displayName": "Variable - errorTitle",
-      "comment": "Set error title for standard error output.",
-      "childId": "76BA5BAA-674D-40E9-8AF5-7A8BC1163723",
-      "inputs": [],
-      "settings": [],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
-      "x": -2802,
-      "y": -1586,
-      "variableGuid": "407730A6-EC96-4337-BE80-CF4C0D552F08",
-      "operations": [
+      "collapsed": [
         {
-          "id": "set_value",
-          "key": "1BC10F4C-68C2-42E9-9000-25865B076073",
-          "name": "Set value of { variable }",
-          "value": "Cancelled - please view the run output for more information."
-        }
-      ]
-    },
-    {
-      "id": "76BA5BAA-674D-40E9-8AF5-7A8BC1163723",
-      "type": "VariableBlock",
-      "disabled": false,
-      "name": "errorDetail",
-      "displayName": "Variable - errorDetail",
-      "comment": "Variable to store detailed error message.",
-      "childId": "D5160C26-BED7-49E2-8A96-463AE880E7AA",
-      "inputs": [],
-      "settings": [],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
-      "x": -2802,
-      "y": -1466,
-      "variableGuid": "1BF2068B-106E-4D58-BC51-884F1810F03C",
-      "operations": [
-        {
-          "id": "set_value",
-          "key": "1BC10F4C-68C2-42E9-9000-25865B076073",
-          "name": "Set value of { variable }",
-          "value": "Exiting, this deployer template is version \"{$.currentTemplateVersionNum}\", which is less than the required version \"{$.callURL.installers[?(@.template=='qcmad')].version}\" \n{linebreak}\n{linebreak}\nThe manifest message is: {$.callURL.installers[?(@.template=='qcmad')].message}"
-        }
-      ]
-    },
-    {
-      "id": "D5160C26-BED7-49E2-8A96-463AE880E7AA",
-      "type": "GotoBlock",
-      "disabled": false,
-      "name": "goToLabel",
-      "displayName": "Go To Label",
-      "comment": "Go to the label named error.",
-      "childId": null,
-      "inputs": [
-        {
-          "id": "label",
-          "value": "EF82AD29-E2CF-44C9-A7DB-24C784618756",
-          "type": "select",
-          "displayValue": "error",
-          "structure": []
+          "name": "loop",
+          "isCollapsed": true
         }
       ],
-      "settings": [],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
       "x": -2802,
-      "y": -1346
+      "y": 2494
     },
     {
       "id": "948CF475-AF52-4C8B-AF9E-07DD7DE82F45",
@@ -2898,12 +3356,17 @@
       "name": "userRoles",
       "displayName": "Variable - userRoles",
       "comment": "Collect all roles for API key access checks.",
-      "childId": "CD1DE6F6-8F1B-43EE-9B1A-E1ED8E200416",
+      "childId": "D93CC85B-1E1E-4EE9-A2C4-D60FB7E19A92",
       "inputs": [],
       "settings": [],
-      "collapsed": [{ "name": "loop", "isCollapsed": false }],
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": false
+        }
+      ],
       "x": -2922,
-      "y": -666,
+      "y": 14,
       "variableGuid": "CD9F0C76-28B4-482E-A218-EDE5763F6807",
       "operations": [
         {
@@ -2911,12 +3374,6 @@
           "key": "1835DD18-E922-44C8-B5B7-CE7182E56679",
           "name": "Merge other list into { variable }",
           "value": "{ $.getUser.assignedRoles }"
-        },
-        {
-          "id": "merge",
-          "key": "D055F0D5-48CC-4BAB-99C0-5CA64200759F",
-          "name": "Merge other list into { variable }",
-          "value": "{ $.getUser.assignedGroups[*].assignedRoles }"
         }
       ]
     },
@@ -2940,7 +3397,11 @@
           "value": {
             "mode": "all",
             "conditions": [
-              { "input1": "type", "input2": "custom", "operator": "=" }
+              {
+                "input1": "type",
+                "input2": "custom",
+                "operator": "="
+              }
             ]
           },
           "type": "custom",
@@ -2955,9 +3416,14 @@
           "structure": []
         }
       ],
-      "collapsed": [{ "name": "loop", "isCollapsed": false }],
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": false
+        }
+      ],
       "x": -2922,
-      "y": -426,
+      "y": 654,
       "loopBlockId": "73CC9998-44BE-4947-9526-54DE0D4A39C4"
     },
     {
@@ -2983,7 +3449,12 @@
           "type": "select",
           "structure": []
         },
-        { "id": "cache", "value": "0", "type": "select", "structure": [] },
+        {
+          "id": "cache",
+          "value": "0",
+          "type": "select",
+          "structure": []
+        },
         {
           "id": "automations_censor_data",
           "value": false,
@@ -2991,9 +3462,14 @@
           "structure": []
         }
       ],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
       "x": -2802,
-      "y": -326,
+      "y": 754,
       "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
       "endpoint_guid": "76c4e5d0-3702-11f0-bd5c-8b8be373d450",
       "endpoint_role": "get"
@@ -3008,9 +3484,14 @@
       "childId": "3F9D73BE-55D6-406B-B9DE-D518B12BAA4E",
       "inputs": [],
       "settings": [],
-      "collapsed": [{ "name": "loop", "isCollapsed": false }],
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": false
+        }
+      ],
       "x": -2922,
-      "y": -546,
+      "y": 534,
       "variableGuid": "4283B5F6-E6C0-492F-AA5B-21195FFF74DF",
       "operations": [
         {
@@ -3031,9 +3512,14 @@
       "childId": null,
       "inputs": [],
       "settings": [],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
       "x": -2802,
-      "y": -206,
+      "y": 874,
       "variableGuid": "4283B5F6-E6C0-492F-AA5B-21195FFF74DF",
       "operations": [
         {
@@ -3071,12 +3557,21 @@
       ],
       "settings": [],
       "collapsed": [
-        { "name": "both", "isCollapsed": false },
-        { "name": "yes", "isCollapsed": false },
-        { "name": "no", "isCollapsed": false }
+        {
+          "name": "both",
+          "isCollapsed": false
+        },
+        {
+          "name": "yes",
+          "isCollapsed": false
+        },
+        {
+          "name": "no",
+          "isCollapsed": false
+        }
       ],
       "x": -2922,
-      "y": 234,
+      "y": 1294,
       "childTrueId": "85BD0C04-9778-4A9E-A153-DE2A74C1CE3B",
       "childFalseId": null
     },
@@ -3090,9 +3585,14 @@
       "childId": "0C31D3FC-EAF9-4A51-B843-F7E4F7817619",
       "inputs": [],
       "settings": [],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
       "x": -2802,
-      "y": 314,
+      "y": 1374,
       "variableGuid": "407730A6-EC96-4337-BE80-CF4C0D552F08",
       "operations": [
         {
@@ -3113,9 +3613,14 @@
       "childId": "EBC4167E-EF3B-4828-B452-457EB4B11613",
       "inputs": [],
       "settings": [],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
       "x": -2802,
-      "y": 434,
+      "y": 1494,
       "variableGuid": "1BF2068B-106E-4D58-BC51-884F1810F03C",
       "operations": [
         {
@@ -3144,9 +3649,14 @@
         }
       ],
       "settings": [],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
       "x": -2802,
-      "y": 554
+      "y": 1614
     },
     {
       "id": "6DA24FBE-A1C7-4EF8-85CA-9C796A00B84D",
@@ -3199,9 +3709,14 @@
           "structure": []
         }
       ],
-      "collapsed": [{ "name": "loop", "isCollapsed": false }],
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": false
+        }
+      ],
       "x": -2922,
-      "y": 1634,
+      "y": 2694,
       "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
       "endpoint_guid": "72d48530-bbb0-11f0-875a-b322bf237aeb",
       "endpoint_role": "create"
@@ -3238,12 +3753,21 @@
       ],
       "settings": [],
       "collapsed": [
-        { "name": "both", "isCollapsed": false },
-        { "name": "yes", "isCollapsed": false },
-        { "name": "no", "isCollapsed": false }
+        {
+          "name": "both",
+          "isCollapsed": false
+        },
+        {
+          "name": "yes",
+          "isCollapsed": false
+        },
+        {
+          "name": "no",
+          "isCollapsed": false
+        }
       ],
       "x": -2922,
-      "y": 1874,
+      "y": 2934,
       "childTrueId": null,
       "childFalseId": "D31546CE-90C1-43CA-9A5E-10B35DDE0BFE"
     },
@@ -3257,9 +3781,14 @@
       "childId": "D25BBAB7-8646-46AC-BC9B-D512B163DE2A",
       "inputs": [],
       "settings": [],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
       "x": -2802,
-      "y": 2034,
+      "y": 3094,
       "variableGuid": "407730A6-EC96-4337-BE80-CF4C0D552F08",
       "operations": [
         {
@@ -3280,9 +3809,14 @@
       "childId": "2C6FA9CF-3DE8-45CE-B24E-0979C9A78584",
       "inputs": [],
       "settings": [],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
       "x": -2802,
-      "y": 2154,
+      "y": 3214,
       "variableGuid": "1BF2068B-106E-4D58-BC51-884F1810F03C",
       "operations": [
         {
@@ -3311,9 +3845,14 @@
         }
       ],
       "settings": [],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
       "x": -2802,
-      "y": 2274
+      "y": 3334
     },
     {
       "id": "60DC4193-EAC7-4353-86C5-C9233AF169EA",
@@ -3325,9 +3864,14 @@
       "childId": "E98AA699-4CAD-416D-81EF-A97EB737FD6C",
       "inputs": [],
       "settings": [],
-      "collapsed": [{ "name": "loop", "isCollapsed": false }],
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": false
+        }
+      ],
       "x": -2922,
-      "y": 1754,
+      "y": 2814,
       "variableGuid": "51DCB139-A5E7-427D-8E9C-9382DB8A530C",
       "operations": [
         {
@@ -3353,8 +3897,18 @@
           "type": "string",
           "structure": []
         },
-        { "id": "method", "value": "GET", "type": "select", "structure": [] },
-        { "id": "timeout", "value": "", "type": "string", "structure": [] },
+        {
+          "id": "method",
+          "value": "GET",
+          "type": "select",
+          "structure": []
+        },
+        {
+          "id": "timeout",
+          "value": "",
+          "type": "string",
+          "structure": []
+        },
         {
           "id": "params",
           "value": null,
@@ -3369,7 +3923,12 @@
           "mode": "keyValue",
           "structure": []
         },
-        { "id": "encoding", "value": "", "type": "string", "structure": [] }
+        {
+          "id": "encoding",
+          "value": "",
+          "type": "string",
+          "structure": []
+        }
       ],
       "settings": [
         {
@@ -3397,9 +3956,14 @@
           "structure": []
         }
       ],
-      "collapsed": [{ "name": "loop", "isCollapsed": false }],
-      "x": -2922,
-      "y": 2714
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": false
+        }
+      ],
+      "x": -3292,
+      "y": 3794
     },
     {
       "id": "D68D0C47-8D62-4ADC-AC47-553E8E9A05ED",
@@ -3411,9 +3975,14 @@
       "childId": "66C7B574-5D06-4B85-BCEB-A11CBD175283",
       "inputs": [],
       "settings": [],
-      "collapsed": [{ "name": "loop", "isCollapsed": false }],
-      "x": -2922,
-      "y": 2834,
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": false
+        }
+      ],
+      "x": -3292,
+      "y": 3914,
       "variableGuid": "4FCFD564-CA0B-4516-AD61-A1A2EE9CF38C",
       "operations": [
         {
@@ -3451,12 +4020,21 @@
       ],
       "settings": [],
       "collapsed": [
-        { "name": "both", "isCollapsed": false },
-        { "name": "yes", "isCollapsed": false },
-        { "name": "no", "isCollapsed": false }
+        {
+          "name": "both",
+          "isCollapsed": false
+        },
+        {
+          "name": "yes",
+          "isCollapsed": false
+        },
+        {
+          "name": "no",
+          "isCollapsed": false
+        }
       ],
-      "x": -2922,
-      "y": 3074,
+      "x": -3292,
+      "y": 4154,
       "childTrueId": "FBD838AA-F63C-4948-B755-00F8F6F2CDCF",
       "childFalseId": "8968628A-54FC-4578-98FD-32FAE0B1454F"
     },
@@ -3504,9 +4082,14 @@
           "structure": []
         }
       ],
-      "collapsed": [{ "name": "loop", "isCollapsed": false }],
-      "x": -2802,
-      "y": 3154,
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": false
+        }
+      ],
+      "x": -3172,
+      "y": 4234,
       "loopBlockId": "D3F1FBD1-BEBC-4148-92AF-528D93FE1B8A"
     },
     {
@@ -3519,9 +4102,14 @@
       "childId": null,
       "inputs": [],
       "settings": [],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
-      "x": -2562,
-      "y": 3334,
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
+      "x": -2932,
+      "y": 4414,
       "variableGuid": "1ECFDB29-BC7A-4B7A-AE5F-2A2DBE77B1E0",
       "operations": [
         {
@@ -3576,9 +4164,14 @@
           "structure": []
         }
       ],
-      "collapsed": [{ "name": "loop", "isCollapsed": false }],
-      "x": -2802,
-      "y": 3654,
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": false
+        }
+      ],
+      "x": -3172,
+      "y": 4734,
       "loopBlockId": "619BAD5D-8B64-4866-9E4B-A6E8108FF386"
     },
     {
@@ -3591,9 +4184,14 @@
       "childId": null,
       "inputs": [],
       "settings": [],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
-      "x": -2562,
-      "y": 3834,
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
+      "x": -2932,
+      "y": 4914,
       "variableGuid": "1ECFDB29-BC7A-4B7A-AE5F-2A2DBE77B1E0",
       "operations": [
         {
@@ -3614,9 +4212,14 @@
       "childId": "F893CB46-17A5-4082-BB7B-5564538B5F8B",
       "inputs": [],
       "settings": [],
-      "collapsed": [{ "name": "loop", "isCollapsed": false }],
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": false
+        }
+      ],
       "x": -2922,
-      "y": 994,
+      "y": 2054,
       "variableGuid": "AD716F55-666C-4730-B830-F2D97A502F6B",
       "operations": [
         {
@@ -3637,9 +4240,14 @@
       "childId": "9BC2CF3D-A602-4940-A86B-73BA20439C0F",
       "inputs": [],
       "settings": [],
-      "collapsed": [{ "name": "loop", "isCollapsed": false }],
-      "x": -2922,
-      "y": 2954,
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": false
+        }
+      ],
+      "x": -3292,
+      "y": 4034,
       "variableGuid": "1ECFDB29-BC7A-4B7A-AE5F-2A2DBE77B1E0",
       "operations": [
         {
@@ -3660,7 +4268,12 @@
       "childId": "AABAC2BF-30E8-49FC-982B-52BD9707DAE0",
       "inputs": [],
       "settings": [],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
       "x": -2802,
       "y": -3506,
       "variableGuid": "8E1D15E6-7269-4E6B-A87E-AF56400A2F7A",
@@ -3736,12 +4349,21 @@
       ],
       "settings": [],
       "collapsed": [
-        { "name": "both", "isCollapsed": false },
-        { "name": "yes", "isCollapsed": false },
-        { "name": "no", "isCollapsed": false }
+        {
+          "name": "both",
+          "isCollapsed": false
+        },
+        {
+          "name": "yes",
+          "isCollapsed": false
+        },
+        {
+          "name": "no",
+          "isCollapsed": false
+        }
       ],
-      "x": -2682,
-      "y": 3254,
+      "x": -3052,
+      "y": 4334,
       "childTrueId": "8C37F961-8477-4705-A167-CACE4E579177",
       "childFalseId": null
     },
@@ -3772,12 +4394,21 @@
       ],
       "settings": [],
       "collapsed": [
-        { "name": "both", "isCollapsed": false },
-        { "name": "yes", "isCollapsed": false },
-        { "name": "no", "isCollapsed": false }
+        {
+          "name": "both",
+          "isCollapsed": false
+        },
+        {
+          "name": "yes",
+          "isCollapsed": false
+        },
+        {
+          "name": "no",
+          "isCollapsed": false
+        }
       ],
-      "x": -2682,
-      "y": 3754,
+      "x": -3052,
+      "y": 4834,
       "childTrueId": "D5F81616-F18E-481D-8254-DC54513F20A3",
       "childFalseId": null
     },
@@ -3805,9 +4436,14 @@
           "structure": []
         }
       ],
-      "collapsed": [{ "name": "loop", "isCollapsed": false }],
-      "x": -2922,
-      "y": 4154
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": false
+        }
+      ],
+      "x": -3292,
+      "y": 5234
     },
     {
       "id": "F211A56A-FBCB-4413-BA12-91144F38B722",
@@ -3833,9 +4469,14 @@
           "structure": []
         }
       ],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
-      "x": -2682,
-      "y": 4694
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
+      "x": -3052,
+      "y": 5774
     },
     {
       "id": "B67C3598-6171-40D5-87CE-E7CBA1D58E16",
@@ -3847,9 +4488,14 @@
       "childId": "432F3D61-2AEC-471B-8837-04AB4F56B9DB",
       "inputs": [],
       "settings": [],
-      "collapsed": [{ "name": "loop", "isCollapsed": false }],
-      "x": -2922,
-      "y": 4274,
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": false
+        }
+      ],
+      "x": -3292,
+      "y": 5354,
       "variableGuid": "09C608F2-CF67-4C9A-983E-F39019D443B9",
       "operations": [
         {
@@ -3884,9 +4530,14 @@
           "structure": []
         }
       ],
-      "collapsed": [{ "name": "loop", "isCollapsed": false }],
-      "x": -2922,
-      "y": 4514,
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": false
+        }
+      ],
+      "x": -3292,
+      "y": 5594,
       "loopBlockId": "7CE340D0-20D9-4B6B-80C0-9295582D1CF9"
     },
     {
@@ -3916,12 +4567,21 @@
       ],
       "settings": [],
       "collapsed": [
-        { "name": "both", "isCollapsed": false },
-        { "name": "yes", "isCollapsed": false },
-        { "name": "no", "isCollapsed": false }
+        {
+          "name": "both",
+          "isCollapsed": false
+        },
+        {
+          "name": "yes",
+          "isCollapsed": false
+        },
+        {
+          "name": "no",
+          "isCollapsed": false
+        }
       ],
-      "x": -2802,
-      "y": 4614,
+      "x": -3172,
+      "y": 5694,
       "childTrueId": "F211A56A-FBCB-4413-BA12-91144F38B722",
       "childFalseId": null
     },
@@ -3952,12 +4612,21 @@
       ],
       "settings": [],
       "collapsed": [
-        { "name": "both", "isCollapsed": false },
-        { "name": "yes", "isCollapsed": false },
-        { "name": "no", "isCollapsed": false }
+        {
+          "name": "both",
+          "isCollapsed": false
+        },
+        {
+          "name": "yes",
+          "isCollapsed": false
+        },
+        {
+          "name": "no",
+          "isCollapsed": false
+        }
       ],
-      "x": -2922,
-      "y": 5094,
+      "x": -3292,
+      "y": 6174,
       "childTrueId": "EBDE966E-F544-46BF-89EA-FB5A671494B7",
       "childFalseId": null
     },
@@ -3971,9 +4640,14 @@
       "childId": "D13F1BD0-95CE-4118-B875-7DC61E17AA1E",
       "inputs": [],
       "settings": [],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
-      "x": -2802,
-      "y": 5174,
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
+      "x": -3172,
+      "y": 6254,
       "variableGuid": "407730A6-EC96-4337-BE80-CF4C0D552F08",
       "operations": [
         {
@@ -3994,9 +4668,14 @@
       "childId": "69F43DAF-28FE-44A5-8D0F-5BF0E066A618",
       "inputs": [],
       "settings": [],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
-      "x": -2802,
-      "y": 5294,
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
+      "x": -3172,
+      "y": 6374,
       "variableGuid": "1BF2068B-106E-4D58-BC51-884F1810F03C",
       "operations": [
         {
@@ -4025,9 +4704,14 @@
         }
       ],
       "settings": [],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
-      "x": -2802,
-      "y": 5414
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
+      "x": -3172,
+      "y": 6494
     },
     {
       "id": "ECCD6D36-805D-44EF-A411-A73316586DD1",
@@ -4080,9 +4764,14 @@
           "structure": []
         }
       ],
-      "collapsed": [{ "name": "loop", "isCollapsed": false }],
-      "x": -2922,
-      "y": 5614,
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": false
+        }
+      ],
+      "x": -3292,
+      "y": 6694,
       "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
       "endpoint_guid": "72d48530-bbb0-11f0-875a-b322bf237aeb",
       "endpoint_role": "create"
@@ -4097,9 +4786,14 @@
       "childId": null,
       "inputs": [],
       "settings": [],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
-      "x": -2682,
-      "y": 4814,
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
+      "x": -3052,
+      "y": 5894,
       "variableGuid": "CB55538C-0F1A-4871-98DD-C68EC5B00D84",
       "operations": [
         {
@@ -4120,9 +4814,14 @@
       "childId": "F364D449-B628-4325-9617-1B04B7DBFB6A",
       "inputs": [],
       "settings": [],
-      "collapsed": [{ "name": "loop", "isCollapsed": false }],
-      "x": -2922,
-      "y": 4394,
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": false
+        }
+      ],
+      "x": -3292,
+      "y": 5474,
       "variableGuid": "CB55538C-0F1A-4871-98DD-C68EC5B00D84",
       "operations": [
         {
@@ -4168,7 +4867,12 @@
           "type": "select",
           "structure": []
         },
-        { "id": "cache", "value": "0", "type": "select", "structure": [] },
+        {
+          "id": "cache",
+          "value": "0",
+          "type": "select",
+          "structure": []
+        },
         {
           "id": "automations_censor_data",
           "value": false,
@@ -4176,9 +4880,14 @@
           "structure": []
         }
       ],
-      "collapsed": [{ "name": "loop", "isCollapsed": false }],
-      "x": -2922,
-      "y": 13954,
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": false
+        }
+      ],
+      "x": -3292,
+      "y": 15034,
       "loopBlockId": "DAD45F04-D485-42E3-B7DD-D8C3106EA5FC",
       "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
       "endpoint_guid": "8cc63340-107b-11ec-ab5d-f9b221ed2dc5",
@@ -4235,9 +4944,14 @@
           "structure": []
         }
       ],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
-      "x": -2802,
-      "y": 14054,
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
+      "x": -3172,
+      "y": 15134,
       "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
       "endpoint_guid": "72d48530-bbb0-11f0-875a-b322bf237aeb",
       "endpoint_role": "create"
@@ -4252,9 +4966,14 @@
       "childId": "7151B1C7-58CC-49D0-AE62-51CBB945D6D4",
       "inputs": [],
       "settings": [],
-      "collapsed": [{ "name": "loop", "isCollapsed": false }],
-      "x": -2922,
-      "y": 13834,
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": false
+        }
+      ],
+      "x": -3292,
+      "y": 14914,
       "variableGuid": "2E37F6E5-BE30-44ED-B0B6-B544ECEAAB9E",
       "operations": [
         {
@@ -4289,9 +5008,14 @@
           "structure": []
         }
       ],
-      "collapsed": [{ "name": "loop", "isCollapsed": false }],
-      "x": -2922,
-      "y": 14334,
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": false
+        }
+      ],
+      "x": -3292,
+      "y": 15414,
       "loopBlockId": "0DBF0B78-A809-4DDE-B02F-EF043A628D39"
     },
     {
@@ -4326,12 +5050,21 @@
       ],
       "settings": [],
       "collapsed": [
-        { "name": "both", "isCollapsed": false },
-        { "name": "yes", "isCollapsed": false },
-        { "name": "no", "isCollapsed": false }
+        {
+          "name": "both",
+          "isCollapsed": false
+        },
+        {
+          "name": "yes",
+          "isCollapsed": false
+        },
+        {
+          "name": "no",
+          "isCollapsed": false
+        }
       ],
-      "x": -2802,
-      "y": 17054,
+      "x": -3172,
+      "y": 18134,
       "childTrueId": "40EC15FE-C25F-442B-8CD9-5C87150436B3",
       "childFalseId": null
     },
@@ -4345,9 +5078,14 @@
       "childId": null,
       "inputs": [],
       "settings": [],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
-      "x": -2802,
-      "y": 14174,
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
+      "x": -3172,
+      "y": 15254,
       "variableGuid": "2E37F6E5-BE30-44ED-B0B6-B544ECEAAB9E",
       "operations": [
         {
@@ -4382,9 +5120,14 @@
           "structure": []
         }
       ],
-      "collapsed": [{ "name": "loop", "isCollapsed": false }],
-      "x": -2802,
-      "y": 14914,
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": false
+        }
+      ],
+      "x": -3172,
+      "y": 15994,
       "loopBlockId": "5BD148B9-BDD1-4C37-8EB3-73641F532BB3"
     },
     {
@@ -4414,12 +5157,21 @@
       ],
       "settings": [],
       "collapsed": [
-        { "name": "both", "isCollapsed": false },
-        { "name": "yes", "isCollapsed": false },
-        { "name": "no", "isCollapsed": false }
+        {
+          "name": "both",
+          "isCollapsed": false
+        },
+        {
+          "name": "yes",
+          "isCollapsed": false
+        },
+        {
+          "name": "no",
+          "isCollapsed": false
+        }
       ],
-      "x": -2682,
-      "y": 15014,
+      "x": -3052,
+      "y": 16094,
       "childTrueId": "0C03554A-88E9-4987-8DA7-2707C33613B5",
       "childFalseId": null
     },
@@ -4433,9 +5185,14 @@
       "childId": "981978BE-431B-4AF5-BD0D-451A3885B024",
       "inputs": [],
       "settings": [],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
-      "x": -2802,
-      "y": 14434,
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
+      "x": -3172,
+      "y": 15514,
       "variableGuid": "B762B4A7-25F9-4764-BECA-D4461377CE04",
       "operations": [
         {
@@ -4456,9 +5213,14 @@
       "childId": "0C14812A-A344-4903-9697-1426DB5C5DFA",
       "inputs": [],
       "settings": [],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
-      "x": -2202,
-      "y": 15614,
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
+      "x": -2572,
+      "y": 16694,
       "variableGuid": "B762B4A7-25F9-4764-BECA-D4461377CE04",
       "operations": [
         {
@@ -4493,9 +5255,14 @@
           "structure": []
         }
       ],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
-      "x": -2442,
-      "y": 16694
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
+      "x": -2812,
+      "y": 17774
     },
     {
       "id": "0C03554A-88E9-4987-8DA7-2707C33613B5",
@@ -4517,7 +5284,11 @@
           "value": {
             "mode": "all",
             "conditions": [
-              { "input1": "name", "input2": "QCMA - v", "operator": "contain" }
+              {
+                "input1": "name",
+                "input2": "QCMA - v",
+                "operator": "contain"
+              }
             ]
           },
           "type": "custom",
@@ -4532,9 +5303,14 @@
           "structure": []
         }
       ],
-      "collapsed": [{ "name": "loop", "isCollapsed": false }],
-      "x": -2562,
-      "y": 15094,
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": false
+        }
+      ],
+      "x": -2932,
+      "y": 16174,
       "loopBlockId": null
     },
     {
@@ -4564,12 +5340,21 @@
       ],
       "settings": [],
       "collapsed": [
-        { "name": "both", "isCollapsed": false },
-        { "name": "yes", "isCollapsed": false },
-        { "name": "no", "isCollapsed": false }
+        {
+          "name": "both",
+          "isCollapsed": false
+        },
+        {
+          "name": "yes",
+          "isCollapsed": false
+        },
+        {
+          "name": "no",
+          "isCollapsed": false
+        }
       ],
-      "x": -2562,
-      "y": 15254,
+      "x": -2932,
+      "y": 16334,
       "childTrueId": "7FC2859A-CB6D-4A81-B1B7-8DA4C1DF9E27",
       "childFalseId": "1D37B0B5-533A-4C98-8C0C-5D27CA83E613"
     },
@@ -4600,12 +5385,21 @@
       ],
       "settings": [],
       "collapsed": [
-        { "name": "both", "isCollapsed": false },
-        { "name": "yes", "isCollapsed": false },
-        { "name": "no", "isCollapsed": false }
+        {
+          "name": "both",
+          "isCollapsed": false
+        },
+        {
+          "name": "yes",
+          "isCollapsed": false
+        },
+        {
+          "name": "no",
+          "isCollapsed": false
+        }
       ],
-      "x": -2442,
-      "y": 15334,
+      "x": -2812,
+      "y": 16414,
       "childTrueId": "C1A9C7CC-6DAC-4E03-B987-F44C2C040BF9",
       "childFalseId": "A6B5E4EE-819B-4767-AE9A-2E127BD6DC6C"
     },
@@ -4619,9 +5413,14 @@
       "childId": "6D0F022E-164E-4CE3-B955-5961AA02A540",
       "inputs": [],
       "settings": [],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
-      "x": -2802,
-      "y": 14794,
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
+      "x": -3172,
+      "y": 15874,
       "variableGuid": "4CFD6FDB-6937-45CE-8677-203A280087D1",
       "operations": [
         {
@@ -4642,9 +5441,14 @@
       "childId": "8A8AB1EE-BE5B-46F6-981A-5ABB5FA348D9",
       "inputs": [],
       "settings": [],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
-      "x": -2802,
-      "y": 14674,
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
+      "x": -3172,
+      "y": 15754,
       "variableGuid": "12A37AC8-CD9C-41FC-9626-508B24997C86",
       "operations": [
         {
@@ -4679,9 +5483,14 @@
           "structure": []
         }
       ],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
-      "x": -2322,
-      "y": 16454
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
+      "x": -2692,
+      "y": 17534
     },
     {
       "id": "EE2B05F0-E29D-4EF4-8016-AD92050B6D2D",
@@ -4707,9 +5516,14 @@
           "structure": []
         }
       ],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
-      "x": -2202,
-      "y": 15494
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
+      "x": -2572,
+      "y": 16574
     },
     {
       "id": "C1A9C7CC-6DAC-4E03-B987-F44C2C040BF9",
@@ -4738,12 +5552,21 @@
       ],
       "settings": [],
       "collapsed": [
-        { "name": "both", "isCollapsed": false },
-        { "name": "yes", "isCollapsed": false },
-        { "name": "no", "isCollapsed": false }
+        {
+          "name": "both",
+          "isCollapsed": false
+        },
+        {
+          "name": "yes",
+          "isCollapsed": false
+        },
+        {
+          "name": "no",
+          "isCollapsed": false
+        }
       ],
-      "x": -2322,
-      "y": 15414,
+      "x": -2692,
+      "y": 16494,
       "childTrueId": "EE2B05F0-E29D-4EF4-8016-AD92050B6D2D",
       "childFalseId": "6E0F226F-5497-4493-9201-8FB2CFE66C25"
     },
@@ -4757,9 +5580,14 @@
       "childId": "6035B77C-4061-44DD-B0B4-BA016EF2F537",
       "inputs": [],
       "settings": [],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
-      "x": -2802,
-      "y": 14554,
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
+      "x": -3172,
+      "y": 15634,
       "variableGuid": "D8F8BD27-8FF5-42FF-82ED-0EE947E55327",
       "operations": [
         {
@@ -4780,9 +5608,14 @@
       "childId": null,
       "inputs": [],
       "settings": [],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
-      "x": -2202,
-      "y": 16014,
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
+      "x": -2572,
+      "y": 17094,
       "variableGuid": "D8F8BD27-8FF5-42FF-82ED-0EE947E55327",
       "operations": [
         {
@@ -4817,9 +5650,14 @@
           "structure": []
         }
       ],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
-      "x": -2202,
-      "y": 15894
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
+      "x": -2572,
+      "y": 16974
     },
     {
       "id": "0C14812A-A344-4903-9697-1426DB5C5DFA",
@@ -4831,9 +5669,14 @@
       "childId": null,
       "inputs": [],
       "settings": [],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
-      "x": -2202,
-      "y": 15734,
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
+      "x": -2572,
+      "y": 16814,
       "variableGuid": "D8F8BD27-8FF5-42FF-82ED-0EE947E55327",
       "operations": [
         {
@@ -4868,9 +5711,14 @@
           "structure": []
         }
       ],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
-      "x": -2682,
-      "y": 17414
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
+      "x": -3052,
+      "y": 18494
     },
     {
       "id": "4F36612D-0B32-4DA5-9803-85D5EEB3EDCB",
@@ -4887,8 +5735,18 @@
           "type": "string",
           "structure": []
         },
-        { "id": "method", "value": "GET", "type": "select", "structure": [] },
-        { "id": "timeout", "value": "", "type": "string", "structure": [] },
+        {
+          "id": "method",
+          "value": "GET",
+          "type": "select",
+          "structure": []
+        },
+        {
+          "id": "timeout",
+          "value": "",
+          "type": "string",
+          "structure": []
+        },
         {
           "id": "params",
           "value": null,
@@ -4903,7 +5761,12 @@
           "mode": "keyValue",
           "structure": []
         },
-        { "id": "encoding", "value": "", "type": "string", "structure": [] }
+        {
+          "id": "encoding",
+          "value": "",
+          "type": "string",
+          "structure": []
+        }
       ],
       "settings": [
         {
@@ -4931,9 +5794,14 @@
           "structure": []
         }
       ],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
-      "x": -2682,
-      "y": 17534
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
+      "x": -3052,
+      "y": 18614
     },
     {
       "id": "9E937365-2524-466B-95E9-309B3293FF8D",
@@ -4945,9 +5813,14 @@
       "childId": "8E819B1F-C085-4394-B9FA-537D1A20F440",
       "inputs": [],
       "settings": [],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
-      "x": -2682,
-      "y": 17654,
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
+      "x": -3052,
+      "y": 18734,
       "variableGuid": "996190EC-165A-4CF1-A3B6-363B8F0DDF31",
       "operations": [
         {
@@ -5012,9 +5885,14 @@
           "structure": []
         }
       ],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
-      "x": -2682,
-      "y": 17774,
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
+      "x": -3052,
+      "y": 18854,
       "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
       "endpoint_guid": "194b9430-67b1-11eb-9e04-6dbde84bea83",
       "endpoint_role": "create"
@@ -5043,9 +5921,14 @@
           "structure": []
         }
       ],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
-      "x": -2682,
-      "y": 18134
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
+      "x": -3052,
+      "y": 19214
     },
     {
       "id": "40EC15FE-C25F-442B-8CD9-5C87150436B3",
@@ -5074,12 +5957,21 @@
       ],
       "settings": [],
       "collapsed": [
-        { "name": "both", "isCollapsed": false },
-        { "name": "yes", "isCollapsed": false },
-        { "name": "no", "isCollapsed": false }
+        {
+          "name": "both",
+          "isCollapsed": false
+        },
+        {
+          "name": "yes",
+          "isCollapsed": false
+        },
+        {
+          "name": "no",
+          "isCollapsed": false
+        }
       ],
-      "x": -2682,
-      "y": 17134,
+      "x": -3052,
+      "y": 18214,
       "childTrueId": "BC596D9A-38F8-4F9A-8DC9-1D0DC81A57C4",
       "childFalseId": null
     },
@@ -5107,9 +5999,14 @@
           "structure": []
         }
       ],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
-      "x": -2562,
-      "y": 17214
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
+      "x": -2932,
+      "y": 18294
     },
     {
       "id": "15A91B88-3C31-400B-A2C8-D697AB8F175E",
@@ -5135,9 +6032,14 @@
           "structure": []
         }
       ],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
-      "x": -2562,
-      "y": 20434
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
+      "x": -2932,
+      "y": 21514
     },
     {
       "id": "ECB7B639-F151-4B44-A89E-491B20BE66F3",
@@ -5166,12 +6068,21 @@
       ],
       "settings": [],
       "collapsed": [
-        { "name": "both", "isCollapsed": false },
-        { "name": "yes", "isCollapsed": false },
-        { "name": "no", "isCollapsed": false }
+        {
+          "name": "both",
+          "isCollapsed": false
+        },
+        {
+          "name": "yes",
+          "isCollapsed": false
+        },
+        {
+          "name": "no",
+          "isCollapsed": false
+        }
       ],
-      "x": -2682,
-      "y": 20114,
+      "x": -3052,
+      "y": 21194,
       "childTrueId": "35EFB375-D90C-4F76-A966-47EDB1EAFAD2",
       "childFalseId": "9EE0A5EF-EE84-4F46-811E-312073C232C6"
     },
@@ -5237,9 +6148,14 @@
           "structure": []
         }
       ],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
-      "x": -2562,
-      "y": 20194,
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
+      "x": -2932,
+      "y": 21274,
       "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
       "snippet_guid": "76a45090-00e1-11ec-ad85-b3b86b5b9a24"
     },
@@ -5279,7 +6195,10 @@
               "key": "resourceId",
               "value": "{$.importAppFromBase64EncodedFile.attributes.id}"
             },
-            { "key": "resourceType", "value": "app" }
+            {
+              "key": "resourceType",
+              "value": "app"
+            }
           ],
           "type": "object",
           "mode": "keyValue",
@@ -5300,9 +6219,14 @@
           "structure": []
         }
       ],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
-      "x": -2682,
-      "y": 18014,
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
+      "x": -3052,
+      "y": 19094,
       "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
       "endpoint_guid": "72d48530-bbb0-11f0-875a-b322bf237aeb",
       "endpoint_role": "create"
@@ -5316,12 +6240,22 @@
       "comment": "Wait for items to be aware of app.",
       "childId": "FF63005B-73C8-4593-8609-AC99855C7167",
       "inputs": [
-        { "id": "time", "value": "5", "type": "string", "structure": [] }
+        {
+          "id": "time",
+          "value": "5",
+          "type": "string",
+          "structure": []
+        }
       ],
       "settings": [],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
-      "x": -2682,
-      "y": 17894
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
+      "x": -3052,
+      "y": 18974
     },
     {
       "id": "9F37EC62-2694-40D2-8DB1-7F5265D9EB9F",
@@ -5333,9 +6267,14 @@
       "childId": "22D8A6B4-A055-40DE-BA67-0638D6005250",
       "inputs": [],
       "settings": [],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
-      "x": -2682,
-      "y": 18734,
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
+      "x": -3052,
+      "y": 19814,
       "variableGuid": "AE6C347F-BAAD-4FD0-A820-80AFEE588B29",
       "operations": [
         {
@@ -5349,8 +6288,14 @@
           "key": "4FFB7E92-7F6F-4A27-ADA6-FBC6DF13C3B3",
           "name": "Set key/values of { variable }",
           "value": [
-            { "key": "appTag", "value": "{ $.workingAppTagName }" },
-            { "key": "versionTag", "value": "{ $.workingAppTagVersion }" }
+            {
+              "key": "appTag",
+              "value": "{ $.workingAppTagName }"
+            },
+            {
+              "key": "versionTag",
+              "value": "{ $.workingAppTagVersion }"
+            }
           ]
         }
       ]
@@ -5379,9 +6324,14 @@
           "structure": []
         }
       ],
-      "collapsed": [{ "name": "loop", "isCollapsed": false }],
-      "x": -2682,
-      "y": 18854,
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": false
+        }
+      ],
+      "x": -3052,
+      "y": 19934,
       "loopBlockId": "AFD7305E-B419-4128-95D3-1A9EAF98F9C8"
     },
     {
@@ -5416,8 +6366,14 @@
         {
           "id": "736fae60-bbb0-11f0-ad62-c98a0046f418",
           "value": [
-            { "key": "name", "value": "{ $.loop4.item }" },
-            { "key": "type", "value": "public" }
+            {
+              "key": "name",
+              "value": "{ $.loop4.item }"
+            },
+            {
+              "key": "type",
+              "value": "public"
+            }
           ],
           "type": "object",
           "mode": "keyValue",
@@ -5438,9 +6394,14 @@
           "structure": []
         }
       ],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
-      "x": -2562,
-      "y": 18954,
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
+      "x": -2932,
+      "y": 20034,
       "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
       "endpoint_guid": "72d48530-bbb0-11f0-875a-b322bf237aeb",
       "endpoint_role": "create"
@@ -5472,12 +6433,21 @@
       ],
       "settings": [],
       "collapsed": [
-        { "name": "both", "isCollapsed": false },
-        { "name": "yes", "isCollapsed": false },
-        { "name": "no", "isCollapsed": false }
+        {
+          "name": "both",
+          "isCollapsed": false
+        },
+        {
+          "name": "yes",
+          "isCollapsed": false
+        },
+        {
+          "name": "no",
+          "isCollapsed": false
+        }
       ],
-      "x": -2562,
-      "y": 19074,
+      "x": -2932,
+      "y": 20154,
       "childTrueId": "814E1A6D-6BCB-47DD-BD1D-39EC0CA9C101",
       "childFalseId": "4DA2DA61-2BB9-41DB-B354-3A2B8C5F2F2E"
     },
@@ -5532,9 +6502,14 @@
           "structure": []
         }
       ],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
-      "x": -2562,
-      "y": 19834,
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
+      "x": -2932,
+      "y": 20914,
       "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
       "endpoint_guid": "72d48530-bbb0-11f0-875a-b322bf237aeb",
       "endpoint_role": "create"
@@ -5563,9 +6538,14 @@
           "structure": []
         }
       ],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
-      "x": -2562,
-      "y": 19954
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
+      "x": -2932,
+      "y": 21034
     },
     {
       "id": "814E1A6D-6BCB-47DD-BD1D-39EC0CA9C101",
@@ -5591,9 +6571,14 @@
           "structure": []
         }
       ],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
-      "x": -2442,
-      "y": 19154
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
+      "x": -2812,
+      "y": 20234
     },
     {
       "id": "E287D197-83E3-4C50-8598-34DDB03BD857",
@@ -5605,9 +6590,14 @@
       "childId": null,
       "inputs": [],
       "settings": [],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
-      "x": -2442,
-      "y": 19274,
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
+      "x": -2812,
+      "y": 20354,
       "variableGuid": "FA7C823B-3AA8-41EA-990F-21837758447A",
       "operations": [
         {
@@ -5647,9 +6637,14 @@
           "structure": []
         }
       ],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
-      "x": -2442,
-      "y": 19554
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
+      "x": -2812,
+      "y": 20634
     },
     {
       "id": "4DA2DA61-2BB9-41DB-B354-3A2B8C5F2F2E",
@@ -5702,9 +6697,14 @@
           "structure": []
         }
       ],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
-      "x": -2442,
-      "y": 19434,
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
+      "x": -2812,
+      "y": 20514,
       "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
       "endpoint_guid": "72d48530-bbb0-11f0-875a-b322bf237aeb",
       "endpoint_role": "create"
@@ -5719,9 +6719,14 @@
       "childId": null,
       "inputs": [],
       "settings": [],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
-      "x": -2442,
-      "y": 19674,
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
+      "x": -2812,
+      "y": 20754,
       "variableGuid": "FA7C823B-3AA8-41EA-990F-21837758447A",
       "operations": [
         {
@@ -5729,7 +6734,10 @@
           "key": "4C765E64-0A7C-4AFC-8301-E428E0E60E9B",
           "name": "Set key/values of { variable }",
           "value": [
-            { "key": "{ $.loop4.index }", "value": "{ $.rawAPIRequest12.id }" }
+            {
+              "key": "{ $.loop4.index }",
+              "value": "{ $.rawAPIRequest12.id }"
+            }
           ]
         }
       ]
@@ -5758,9 +6766,14 @@
           "structure": []
         }
       ],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
-      "x": -2682,
-      "y": 18254
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
+      "x": -3052,
+      "y": 19334
     },
     {
       "id": "73B15F09-DCC3-43F4-8DCB-9ACE58E3FACF",
@@ -5792,9 +6805,14 @@
           "structure": []
         }
       ],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
-      "x": -2682,
-      "y": 18374,
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
+      "x": -3052,
+      "y": 19454,
       "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
       "snippet_guid": "8d2f7da0-5028-11eb-8889-317a6c8ea7fc"
     },
@@ -5840,9 +6858,14 @@
           "structure": []
         }
       ],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
-      "x": -2682,
-      "y": 18494,
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
+      "x": -3052,
+      "y": 19574,
       "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
       "endpoint_guid": "916661a0-a12b-11ed-882f-fb01a4e99b0a",
       "endpoint_role": "create"
@@ -5871,9 +6894,14 @@
           "structure": []
         }
       ],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
-      "x": -2682,
-      "y": 18614
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
+      "x": -3052,
+      "y": 19694
     },
     {
       "id": "9EE0A5EF-EE84-4F46-811E-312073C232C6",
@@ -5899,9 +6927,14 @@
           "structure": []
         }
       ],
-      "collapsed": [{ "name": "loop", "isCollapsed": false }],
-      "x": -2562,
-      "y": 21214,
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": false
+        }
+      ],
+      "x": -2932,
+      "y": 22294,
       "loopBlockId": "0D70200F-BF52-4CCD-8FB5-C81C9692D24B"
     },
     {
@@ -5955,9 +6988,14 @@
           "structure": []
         }
       ],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
-      "x": -2442,
-      "y": 20894,
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
+      "x": -2812,
+      "y": 21974,
       "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
       "endpoint_guid": "72d48530-bbb0-11f0-875a-b322bf237aeb",
       "endpoint_role": "create"
@@ -5986,9 +7024,14 @@
           "structure": []
         }
       ],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
-      "x": -2442,
-      "y": 21014
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
+      "x": -2812,
+      "y": 22094
     },
     {
       "id": "292F6681-A0A3-4149-8900-B146F799C502",
@@ -6014,9 +7057,14 @@
           "structure": []
         }
       ],
-      "collapsed": [{ "name": "loop", "isCollapsed": false }],
-      "x": -2562,
-      "y": 20794,
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": false
+        }
+      ],
+      "x": -2932,
+      "y": 21874,
       "loopBlockId": "75038005-FF42-4CA7-B4C9-0CA9EE70631D"
     },
     {
@@ -6028,12 +7076,22 @@
       "comment": "Wait for items to get publish notification.",
       "childId": "D39D8A7B-718C-46EC-B3F1-24E2A2BF5185",
       "inputs": [
-        { "id": "time", "value": "5", "type": "string", "structure": [] }
+        {
+          "id": "time",
+          "value": "5",
+          "type": "string",
+          "structure": []
+        }
       ],
       "settings": [],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
-      "x": -2562,
-      "y": 20554
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
+      "x": -2932,
+      "y": 21634
     },
     {
       "id": "D39D8A7B-718C-46EC-B3F1-24E2A2BF5185",
@@ -6071,7 +7129,10 @@
               "key": "resourceId",
               "value": "{ $.publishAppToManagedSpace.attributes.id }"
             },
-            { "key": "resourceType", "value": "app" }
+            {
+              "key": "resourceType",
+              "value": "app"
+            }
           ],
           "type": "object",
           "mode": "keyValue",
@@ -6092,9 +7153,14 @@
           "structure": []
         }
       ],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
-      "x": -2562,
-      "y": 20674,
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
+      "x": -2932,
+      "y": 21754,
       "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
       "endpoint_guid": "72d48530-bbb0-11f0-875a-b322bf237aeb",
       "endpoint_role": "create"
@@ -6109,9 +7175,14 @@
       "childId": "15A91B88-3C31-400B-A2C8-D697AB8F175E",
       "inputs": [],
       "settings": [],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
-      "x": -2562,
-      "y": 20314,
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
+      "x": -2932,
+      "y": 21394,
       "variableGuid": "A812E467-95BC-419E-B6A6-4341D6347C3A",
       "operations": [
         {
@@ -6132,9 +7203,14 @@
       "childId": null,
       "inputs": [],
       "settings": [],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
-      "x": -2322,
-      "y": 16294,
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
+      "x": -2692,
+      "y": 17374,
       "variableGuid": "A812E467-95BC-419E-B6A6-4341D6347C3A",
       "operations": [
         {
@@ -6196,9 +7272,14 @@
           "structure": []
         }
       ],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
-      "x": -2442,
-      "y": 21434,
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
+      "x": -2812,
+      "y": 22514,
       "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
       "endpoint_guid": "72d48530-bbb0-11f0-875a-b322bf237aeb",
       "endpoint_role": "create"
@@ -6227,9 +7308,14 @@
           "structure": []
         }
       ],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
-      "x": -2442,
-      "y": 21554
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
+      "x": -2812,
+      "y": 22634
     },
     {
       "id": "0D70200F-BF52-4CCD-8FB5-C81C9692D24B",
@@ -6255,9 +7341,14 @@
           "structure": []
         }
       ],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
-      "x": -2442,
-      "y": 21314
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
+      "x": -2812,
+      "y": 22394
     },
     {
       "id": "3ABDBFAA-8E94-4AA9-87C6-AC03B13D58F0",
@@ -6291,8 +7382,14 @@
         {
           "id": "736fae60-bbb0-11f0-ad62-c98a0046f418",
           "value": [
-            { "key": "resourceId", "value": "{ $.loop6.item.resourceId }" },
-            { "key": "resourceType", "value": "app" }
+            {
+              "key": "resourceId",
+              "value": "{ $.loop6.item.resourceId }"
+            },
+            {
+              "key": "resourceType",
+              "value": "app"
+            }
           ],
           "type": "object",
           "mode": "keyValue",
@@ -6313,9 +7410,14 @@
           "structure": []
         }
       ],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
-      "x": -2442,
-      "y": 21674,
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
+      "x": -2812,
+      "y": 22754,
       "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
       "endpoint_guid": "72d48530-bbb0-11f0-875a-b322bf237aeb",
       "endpoint_role": "create"
@@ -6371,9 +7473,14 @@
           "structure": []
         }
       ],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
-      "x": -2442,
-      "y": 22174,
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
+      "x": -2812,
+      "y": 23254,
       "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
       "endpoint_guid": "72d48530-bbb0-11f0-875a-b322bf237aeb",
       "endpoint_role": "create"
@@ -6402,9 +7509,14 @@
           "structure": []
         }
       ],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
-      "x": -2442,
-      "y": 22294
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
+      "x": -2812,
+      "y": 23374
     },
     {
       "id": "AD01998A-BEE0-473B-99F7-E6CC8C4B60CF",
@@ -6445,9 +7557,14 @@
           "structure": []
         }
       ],
-      "collapsed": [{ "name": "loop", "isCollapsed": false }],
-      "x": -2442,
-      "y": 21794,
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": false
+        }
+      ],
+      "x": -2812,
+      "y": 22874,
       "loopBlockId": "151AA8FD-9389-44F0-8522-5AFF01889D68"
     },
     {
@@ -6501,9 +7618,14 @@
           "structure": []
         }
       ],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
-      "x": -2322,
-      "y": 21894,
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
+      "x": -2692,
+      "y": 22974,
       "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
       "endpoint_guid": "72d48530-bbb0-11f0-875a-b322bf237aeb",
       "endpoint_role": "create"
@@ -6532,9 +7654,14 @@
           "structure": []
         }
       ],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
-      "x": -2322,
-      "y": 22014
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
+      "x": -2692,
+      "y": 23094
     },
     {
       "id": "F959E5AA-4EC0-4284-AA66-F59C788B6B08",
@@ -6572,7 +7699,12 @@
           "type": "select",
           "structure": []
         },
-        { "id": "cache", "value": "0", "type": "select", "structure": [] },
+        {
+          "id": "cache",
+          "value": "0",
+          "type": "select",
+          "structure": []
+        },
         {
           "id": "automations_censor_data",
           "value": false,
@@ -6580,9 +7712,14 @@
           "structure": []
         }
       ],
-      "collapsed": [{ "name": "loop", "isCollapsed": false }],
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": false
+        }
+      ],
       "x": -2922,
-      "y": 2434,
+      "y": 3494,
       "loopBlockId": null,
       "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
       "endpoint_guid": "9f6166e0-bbb2-11f0-acdd-bd47067b5fbf",
@@ -6640,9 +7777,14 @@
           "structure": []
         }
       ],
-      "collapsed": [{ "name": "loop", "isCollapsed": false }],
-      "x": -2922,
-      "y": 12834,
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": false
+        }
+      ],
+      "x": -3292,
+      "y": 13914,
       "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
       "endpoint_guid": "72d48530-bbb0-11f0-875a-b322bf237aeb",
       "endpoint_role": "create"
@@ -6674,12 +7816,21 @@
       ],
       "settings": [],
       "collapsed": [
-        { "name": "both", "isCollapsed": false },
-        { "name": "yes", "isCollapsed": false },
-        { "name": "no", "isCollapsed": false }
+        {
+          "name": "both",
+          "isCollapsed": false
+        },
+        {
+          "name": "yes",
+          "isCollapsed": false
+        },
+        {
+          "name": "no",
+          "isCollapsed": false
+        }
       ],
-      "x": -2922,
-      "y": 12954,
+      "x": -3292,
+      "y": 14034,
       "childTrueId": "D2202317-6AF5-42C3-A20F-5806BAEABEDA",
       "childFalseId": null
     },
@@ -6734,9 +7885,14 @@
           "structure": []
         }
       ],
-      "collapsed": [{ "name": "loop", "isCollapsed": false }],
-      "x": -2922,
-      "y": 13594,
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": false
+        }
+      ],
+      "x": -3292,
+      "y": 14674,
       "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
       "endpoint_guid": "72d48530-bbb0-11f0-875a-b322bf237aeb",
       "endpoint_role": "create"
@@ -6751,9 +7907,14 @@
       "childId": "81004D2F-88EF-4DAF-AD93-78CFFD551EB7",
       "inputs": [],
       "settings": [],
-      "collapsed": [{ "name": "loop", "isCollapsed": false }],
-      "x": -2922,
-      "y": 12714,
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": false
+        }
+      ],
+      "x": -3292,
+      "y": 13794,
       "variableGuid": "218D5568-BA73-49F2-9996-926C40E2AE08",
       "operations": [
         {
@@ -6788,9 +7949,14 @@
           "structure": []
         }
       ],
-      "collapsed": [{ "name": "loop", "isCollapsed": false }],
-      "x": -2922,
-      "y": 13474
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": false
+        }
+      ],
+      "x": -3292,
+      "y": 14554
     },
     {
       "id": "5E1CFE7D-C393-4315-85EF-086507112AC6",
@@ -6816,9 +7982,14 @@
           "structure": []
         }
       ],
-      "collapsed": [{ "name": "loop", "isCollapsed": false }],
-      "x": -2922,
-      "y": 13714
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": false
+        }
+      ],
+      "x": -3292,
+      "y": 14794
     },
     {
       "id": "C5498C80-2759-492A-A46F-58DEF52F8F9A",
@@ -6871,9 +8042,14 @@
           "structure": []
         }
       ],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
-      "x": -2802,
-      "y": 13154,
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
+      "x": -3172,
+      "y": 14234,
       "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
       "endpoint_guid": "72d48530-bbb0-11f0-875a-b322bf237aeb",
       "endpoint_role": "create"
@@ -6902,9 +8078,14 @@
           "structure": []
         }
       ],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
-      "x": -2802,
-      "y": 13034
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
+      "x": -3172,
+      "y": 14114
     },
     {
       "id": "D5C5031D-9058-4671-A035-978DBB1DC8E4",
@@ -6930,9 +8111,14 @@
           "structure": []
         }
       ],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
-      "x": -2802,
-      "y": 13274
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
+      "x": -3172,
+      "y": 14354
     },
     {
       "id": "56DF743F-3565-4BB7-B484-27DB0E8E13F5",
@@ -6973,9 +8159,14 @@
           "structure": []
         }
       ],
-      "collapsed": [{ "name": "loop", "isCollapsed": false }],
-      "x": -2922,
-      "y": 11734,
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": false
+        }
+      ],
+      "x": -3292,
+      "y": 12814,
       "loopBlockId": "439A8A90-8CAD-4F2F-A673-90754BB6B0AD"
     },
     {
@@ -7029,9 +8220,14 @@
           "structure": []
         }
       ],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
-      "x": -2802,
-      "y": 11954,
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
+      "x": -3172,
+      "y": 13034,
       "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
       "endpoint_guid": "72d48530-bbb0-11f0-875a-b322bf237aeb",
       "endpoint_role": "create"
@@ -7060,9 +8256,14 @@
           "structure": []
         }
       ],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
-      "x": -2802,
-      "y": 11834
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
+      "x": -3172,
+      "y": 12914
     },
     {
       "id": "848D7B98-1FE1-4584-BF60-F518D86E41F0",
@@ -7088,9 +8289,14 @@
           "structure": []
         }
       ],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
-      "x": -2802,
-      "y": 12074
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
+      "x": -3172,
+      "y": 13154
     },
     {
       "id": "C9CA459B-7C50-4EDF-BD71-300FF8437382",
@@ -7116,9 +8322,14 @@
           "structure": []
         }
       ],
-      "collapsed": [{ "name": "loop", "isCollapsed": false }],
-      "x": -2922,
-      "y": 12234
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": false
+        }
+      ],
+      "x": -3292,
+      "y": 13314
     },
     {
       "id": "28997C80-CF89-4863-BAD6-DD9A15FC72EF",
@@ -7171,9 +8382,14 @@
           "structure": []
         }
       ],
-      "collapsed": [{ "name": "loop", "isCollapsed": false }],
-      "x": -2922,
-      "y": 12354,
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": false
+        }
+      ],
+      "x": -3292,
+      "y": 13434,
       "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
       "endpoint_guid": "72d48530-bbb0-11f0-875a-b322bf237aeb",
       "endpoint_role": "create"
@@ -7188,9 +8404,14 @@
       "childId": "20C5CA2D-D4E9-453B-A275-37990DC61736",
       "inputs": [],
       "settings": [],
-      "collapsed": [{ "name": "loop", "isCollapsed": false }],
-      "x": -2922,
-      "y": 12474,
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": false
+        }
+      ],
+      "x": -3292,
+      "y": 13554,
       "variableGuid": "AABC69B3-4AB6-4777-A443-FCFCFDA805C4",
       "operations": [
         {
@@ -7225,9 +8446,14 @@
           "structure": []
         }
       ],
-      "collapsed": [{ "name": "loop", "isCollapsed": false }],
-      "x": -2922,
-      "y": 12594
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": false
+        }
+      ],
+      "x": -3292,
+      "y": 13674
     },
     {
       "id": "F4D0DE07-AD02-4C58-9CEA-A3409E738389",
@@ -7239,9 +8465,14 @@
       "childId": "1724234E-1EE6-475F-9451-68D9482CC2FE",
       "inputs": [],
       "settings": [],
-      "collapsed": [{ "name": "loop", "isCollapsed": false }],
-      "x": -2922,
-      "y": 10934,
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": false
+        }
+      ],
+      "x": -3292,
+      "y": 12014,
       "variableGuid": "DB5AD6FD-CA6D-4BDB-B12B-91C248324EE1",
       "operations": [
         {
@@ -7296,9 +8527,14 @@
           "structure": []
         }
       ],
-      "collapsed": [{ "name": "loop", "isCollapsed": false }],
-      "x": -2922,
-      "y": 11054,
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": false
+        }
+      ],
+      "x": -3292,
+      "y": 12134,
       "loopBlockId": null
     },
     {
@@ -7328,12 +8564,21 @@
       ],
       "settings": [],
       "collapsed": [
-        { "name": "both", "isCollapsed": false },
-        { "name": "yes", "isCollapsed": false },
-        { "name": "no", "isCollapsed": false }
+        {
+          "name": "both",
+          "isCollapsed": false
+        },
+        {
+          "name": "yes",
+          "isCollapsed": false
+        },
+        {
+          "name": "no",
+          "isCollapsed": false
+        }
       ],
-      "x": -2922,
-      "y": 11214,
+      "x": -3292,
+      "y": 12294,
       "childTrueId": "1AEE9D36-5C63-4334-8758-ECD4056C36B3",
       "childFalseId": null
     },
@@ -7347,9 +8592,14 @@
       "childId": "489D6F65-006C-4D20-81A8-578A09FE4E8E",
       "inputs": [],
       "settings": [],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
-      "x": -2802,
-      "y": 11294,
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
+      "x": -3172,
+      "y": 12374,
       "variableGuid": "407730A6-EC96-4337-BE80-CF4C0D552F08",
       "operations": [
         {
@@ -7370,9 +8620,14 @@
       "childId": "5B590615-6F1A-4D9E-9A37-DB7042C17B13",
       "inputs": [],
       "settings": [],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
-      "x": -2802,
-      "y": 11414,
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
+      "x": -3172,
+      "y": 12494,
       "variableGuid": "1BF2068B-106E-4D58-BC51-884F1810F03C",
       "operations": [
         {
@@ -7401,9 +8656,14 @@
         }
       ],
       "settings": [],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
-      "x": -2802,
-      "y": 11534
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
+      "x": -3172,
+      "y": 12614
     },
     {
       "id": "2E61A575-F621-4713-B446-C1BAC52D8834",
@@ -7415,7 +8675,12 @@
       "childId": "8151B3E3-471C-496B-BB87-F586C46E3CF4",
       "inputs": [],
       "settings": [],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
       "x": -2802,
       "y": -3266,
       "variableGuid": "12BED549-8F76-4D83-B484-F6121E71753E",
@@ -7438,7 +8703,12 @@
       "childId": "6AC0239B-01A8-47F9-AD4C-ED09CCB2B83F",
       "inputs": [],
       "settings": [],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
       "x": -2802,
       "y": -3146,
       "variableGuid": "3DA539EC-2C6E-4C2B-9985-6F5BDCA282B2",
@@ -7465,7 +8735,11 @@
           "value": {
             "mode": "all",
             "conditions": [
-              { "input1": "{ $.reloadNow }", "input2": "1", "operator": "=" }
+              {
+                "input1": "{ $.reloadNow }",
+                "input2": "1",
+                "operator": "="
+              }
             ]
           },
           "type": "custom",
@@ -7474,12 +8748,21 @@
       ],
       "settings": [],
       "collapsed": [
-        { "name": "both", "isCollapsed": false },
-        { "name": "yes", "isCollapsed": false },
-        { "name": "no", "isCollapsed": false }
+        {
+          "name": "both",
+          "isCollapsed": false
+        },
+        {
+          "name": "yes",
+          "isCollapsed": false
+        },
+        {
+          "name": "no",
+          "isCollapsed": false
+        }
       ],
-      "x": -2922,
-      "y": 23434,
+      "x": -3292,
+      "y": 24514,
       "childTrueId": "FB25A35E-49F7-4A93-951E-84B8CF244FC0",
       "childFalseId": "1AC4CBD1-A4F2-4A7A-AAD8-E90C9F324004"
     },
@@ -7507,9 +8790,14 @@
           "structure": []
         }
       ],
-      "collapsed": [{ "name": "loop", "isCollapsed": false }],
-      "x": -2802,
-      "y": 23634,
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": false
+        }
+      ],
+      "x": -3172,
+      "y": 24714,
       "loopBlockId": "3B9FCBAE-B4AD-491D-AA8C-95619A4C827C"
     },
     {
@@ -7581,9 +8869,14 @@
           "structure": []
         }
       ],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
-      "x": -2682,
-      "y": 23734,
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
+      "x": -3052,
+      "y": 24814,
       "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
       "snippet_guid": "b5dbb7a0-e715-11ea-b2bf-43bb35adee19"
     },
@@ -7611,9 +8904,14 @@
           "structure": []
         }
       ],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
-      "x": -2802,
-      "y": 23514
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
+      "x": -3172,
+      "y": 24594
     },
     {
       "id": "3F546BF0-1269-4DA8-A132-0F3DE54E86F4",
@@ -7639,9 +8937,14 @@
           "structure": []
         }
       ],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
-      "x": -2682,
-      "y": 23854
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
+      "x": -3052,
+      "y": 24934
     },
     {
       "id": "3F25D3AA-32C6-4C4A-968D-7EA29AA29A76",
@@ -7667,9 +8970,14 @@
           "structure": []
         }
       ],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
-      "x": -2682,
-      "y": 25554
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
+      "x": -3052,
+      "y": 26634
     },
     {
       "id": "CEEB9F64-6EF8-4820-AB01-EE03F916B81D",
@@ -7695,9 +9003,14 @@
           "structure": []
         }
       ],
-      "collapsed": [{ "name": "loop", "isCollapsed": false }],
-      "x": -2802,
-      "y": 24414,
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": false
+        }
+      ],
+      "x": -3172,
+      "y": 25494,
       "loopBlockId": "DBF1BB1B-4211-420D-8B2C-AC9A5EC74B31"
     },
     {
@@ -7724,9 +9037,14 @@
           "structure": []
         }
       ],
-      "collapsed": [{ "name": "loop", "isCollapsed": false }],
-      "x": -2802,
-      "y": 24294
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": false
+        }
+      ],
+      "x": -3172,
+      "y": 25374
     },
     {
       "id": "EC299E1F-F2CA-4149-B148-FC4319064F9D",
@@ -7755,12 +9073,21 @@
       ],
       "settings": [],
       "collapsed": [
-        { "name": "both", "isCollapsed": false },
-        { "name": "yes", "isCollapsed": false },
-        { "name": "no", "isCollapsed": false }
+        {
+          "name": "both",
+          "isCollapsed": false
+        },
+        {
+          "name": "yes",
+          "isCollapsed": false
+        },
+        {
+          "name": "no",
+          "isCollapsed": false
+        }
       ],
-      "x": -2922,
-      "y": 24214,
+      "x": -3292,
+      "y": 25294,
       "childTrueId": "4F1E7C76-BDAF-4C71-A828-279277FEBEBC",
       "childFalseId": "0B7C9754-D191-41BC-A121-E09CEB1D1E0C"
     },
@@ -7788,9 +9115,14 @@
           "structure": []
         }
       ],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
-      "x": -2802,
-      "y": 24054
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
+      "x": -3172,
+      "y": 25134
     },
     {
       "id": "0B7C9754-D191-41BC-A121-E09CEB1D1E0C",
@@ -7816,9 +9148,14 @@
           "structure": []
         }
       ],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
-      "x": -2802,
-      "y": 25754
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
+      "x": -3172,
+      "y": 26834
     },
     {
       "id": "DBF1BB1B-4211-420D-8B2C-AC9A5EC74B31",
@@ -7838,7 +9175,10 @@
         {
           "id": "9ff92ee0-bbb2-11f0-8fb9-9146a99c6e2f",
           "value": [
-            { "key": "appId", "value": "{ $.loop8.item.attributes.id }" }
+            {
+              "key": "appId",
+              "value": "{ $.loop8.item.attributes.id }"
+            }
           ],
           "type": "object",
           "mode": "keyValue",
@@ -7859,7 +9199,12 @@
           "displayValue": "Ignore - Continue Automation and ignore errors",
           "structure": []
         },
-        { "id": "cache", "value": "0", "type": "select", "structure": [] },
+        {
+          "id": "cache",
+          "value": "0",
+          "type": "select",
+          "structure": []
+        },
         {
           "id": "automations_censor_data",
           "value": false,
@@ -7867,9 +9212,14 @@
           "structure": []
         }
       ],
-      "collapsed": [{ "name": "loop", "isCollapsed": false }],
-      "x": -2682,
-      "y": 24514,
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": false
+        }
+      ],
+      "x": -3052,
+      "y": 25594,
       "loopBlockId": null,
       "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
       "endpoint_guid": "9f6166e0-bbb2-11f0-acdd-bd47067b5fbf",
@@ -7927,9 +9277,14 @@
           "structure": []
         }
       ],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
-      "x": -2562,
-      "y": 24774,
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
+      "x": -2932,
+      "y": 25854,
       "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
       "endpoint_guid": "72d48530-bbb0-11f0-875a-b322bf237aeb",
       "endpoint_role": "create"
@@ -7954,7 +9309,11 @@
           "value": {
             "mode": "all",
             "conditions": [
-              { "input1": "migrated", "input2": null, "operator": "isFalse" }
+              {
+                "input1": "migrated",
+                "input2": null,
+                "operator": "isFalse"
+              }
             ]
           },
           "type": "custom",
@@ -7969,9 +9328,14 @@
           "structure": []
         }
       ],
-      "collapsed": [{ "name": "loop", "isCollapsed": false }],
-      "x": -2682,
-      "y": 24674,
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": false
+        }
+      ],
+      "x": -3052,
+      "y": 25754,
       "loopBlockId": "FDC0A602-52CC-46BF-9DAC-9320101C6DE5"
     },
     {
@@ -7998,9 +9362,14 @@
           "structure": []
         }
       ],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
-      "x": -2562,
-      "y": 24894
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
+      "x": -2932,
+      "y": 25974
     },
     {
       "id": "87CA29E5-FAC2-4E81-A611-555DD014D546",
@@ -8020,7 +9389,10 @@
         {
           "id": "9ff92ee0-bbb2-11f0-8fb9-9146a99c6e2f",
           "value": [
-            { "key": "resourceId", "value": "{ $.loop8.item.attributes.id }" }
+            {
+              "key": "resourceId",
+              "value": "{ $.loop8.item.attributes.id }"
+            }
           ],
           "type": "object",
           "mode": "keyValue",
@@ -8041,7 +9413,12 @@
           "displayValue": "Stop - Stop Automation and set to failed",
           "structure": []
         },
-        { "id": "cache", "value": "0", "type": "select", "structure": [] },
+        {
+          "id": "cache",
+          "value": "0",
+          "type": "select",
+          "structure": []
+        },
         {
           "id": "automations_censor_data",
           "value": false,
@@ -8049,9 +9426,14 @@
           "structure": []
         }
       ],
-      "collapsed": [{ "name": "loop", "isCollapsed": false }],
-      "x": -2682,
-      "y": 25054,
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": false
+        }
+      ],
+      "x": -3052,
+      "y": 26134,
       "loopBlockId": "34F8AAE5-2A39-4EA6-84DD-200050879981",
       "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
       "endpoint_guid": "9f6166e0-bbb2-11f0-acdd-bd47067b5fbf",
@@ -8109,9 +9491,14 @@
           "structure": []
         }
       ],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
-      "x": -2562,
-      "y": 25154,
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
+      "x": -2932,
+      "y": 26234,
       "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
       "endpoint_guid": "72d48530-bbb0-11f0-875a-b322bf237aeb",
       "endpoint_role": "create"
@@ -8140,9 +9527,14 @@
           "structure": []
         }
       ],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
-      "x": -2562,
-      "y": 25274
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
+      "x": -2932,
+      "y": 26354
     },
     {
       "id": "BF1A16BF-5256-4500-953B-F576C3C6B651",
@@ -8196,9 +9588,14 @@
           "structure": []
         }
       ],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
-      "x": -2682,
-      "y": 25434,
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
+      "x": -3052,
+      "y": 26514,
       "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
       "endpoint_guid": "72d48530-bbb0-11f0-875a-b322bf237aeb",
       "endpoint_role": "create"
@@ -8217,7 +9614,11 @@
           "value": {
             "mode": "all",
             "conditions": [
-              { "input1": "1", "input2": null, "operator": "isTrue" }
+              {
+                "input1": "1",
+                "input2": null,
+                "operator": "isTrue"
+              }
             ]
           },
           "type": "custom",
@@ -8226,9 +9627,18 @@
       ],
       "settings": [],
       "collapsed": [
-        { "name": "both", "isCollapsed": false },
-        { "name": "yes", "isCollapsed": false },
-        { "name": "no", "isCollapsed": false }
+        {
+          "name": "both",
+          "isCollapsed": false
+        },
+        {
+          "name": "yes",
+          "isCollapsed": false
+        },
+        {
+          "name": "no",
+          "isCollapsed": false
+        }
       ],
       "x": -2922,
       "y": -3586,
@@ -8253,9 +9663,14 @@
         }
       ],
       "settings": [],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
-      "x": -2802,
-      "y": 6054
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
+      "x": -3172,
+      "y": 7134
     },
     {
       "id": "D0CE93F3-2D1E-4F03-8384-E10EDA8D85F7",
@@ -8267,9 +9682,14 @@
       "childId": "A5B767E8-1450-43F7-9E7E-4471FBD5F282",
       "inputs": [],
       "settings": [],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
-      "x": -2802,
-      "y": 5934,
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
+      "x": -3172,
+      "y": 7014,
       "variableGuid": "1BF2068B-106E-4D58-BC51-884F1810F03C",
       "operations": [
         {
@@ -8290,9 +9710,14 @@
       "childId": "D0CE93F3-2D1E-4F03-8384-E10EDA8D85F7",
       "inputs": [],
       "settings": [],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
-      "x": -2802,
-      "y": 5814,
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
+      "x": -3172,
+      "y": 6894,
       "variableGuid": "407730A6-EC96-4337-BE80-CF4C0D552F08",
       "operations": [
         {
@@ -8330,12 +9755,21 @@
       ],
       "settings": [],
       "collapsed": [
-        { "name": "both", "isCollapsed": false },
-        { "name": "yes", "isCollapsed": false },
-        { "name": "no", "isCollapsed": false }
+        {
+          "name": "both",
+          "isCollapsed": false
+        },
+        {
+          "name": "yes",
+          "isCollapsed": false
+        },
+        {
+          "name": "no",
+          "isCollapsed": false
+        }
       ],
-      "x": -2922,
-      "y": 5734,
+      "x": -3292,
+      "y": 6814,
       "childTrueId": "71CF1DF2-EDD5-4BD0-859E-8B644FFA7552",
       "childFalseId": null
     },
@@ -8363,9 +9797,14 @@
           "structure": []
         }
       ],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
-      "x": -2922,
-      "y": 25914
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
+      "x": -3292,
+      "y": 26994
     },
     {
       "id": "215C3F93-2B59-4ADA-A98E-870483095D2C",
@@ -8391,9 +9830,14 @@
           "structure": []
         }
       ],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
-      "x": -2922,
-      "y": 26034
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
+      "x": -3292,
+      "y": 27114
     },
     {
       "id": "4D28FE57-54CB-4FA9-A5EE-A7C65992D3FD",
@@ -8402,7 +9846,7 @@
       "name": "listRoles",
       "displayName": "Qlik Cloud Services - List Roles",
       "comment": "Retrieve user default role configuration, required for checking for API key access.",
-      "childId": "76AA3D41-6FAE-4406-9AAD-67EA9C1B1E7D",
+      "childId": "192CAC57-0476-4EA6-9E3B-44900026EB88",
       "inputs": [
         {
           "id": "61cc2ce0-eb31-11ed-8846-f774c9249948",
@@ -8424,7 +9868,12 @@
           "type": "select",
           "structure": []
         },
-        { "id": "cache", "value": "0", "type": "select", "structure": [] },
+        {
+          "id": "cache",
+          "value": "0",
+          "type": "select",
+          "structure": []
+        },
         {
           "id": "automations_censor_data",
           "value": false,
@@ -8432,10 +9881,15 @@
           "structure": []
         }
       ],
-      "collapsed": [{ "name": "loop", "isCollapsed": false }],
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": false
+        }
+      ],
       "x": -2922,
-      "y": -46,
-      "loopBlockId": null,
+      "y": 1034,
+      "loopBlockId": "76AA3D41-6FAE-4406-9AAD-67EA9C1B1E7D",
       "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
       "endpoint_guid": "61a20140-eb31-11ed-8f08-a515d1528437",
       "endpoint_role": "list"
@@ -8447,19 +9901,24 @@
       "name": "userPermissions",
       "displayName": "Variable - userPermissions",
       "comment": "Add userDefault role to user permissions list.",
-      "childId": "192CAC57-0476-4EA6-9E3B-44900026EB88",
+      "childId": null,
       "inputs": [],
       "settings": [],
-      "collapsed": [{ "name": "loop", "isCollapsed": false }],
-      "x": -2922,
-      "y": 114,
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": false
+        }
+      ],
+      "x": -2802,
+      "y": 1134,
       "variableGuid": "4283B5F6-E6C0-492F-AA5B-21195FFF74DF",
       "operations": [
         {
           "id": "merge",
           "key": "E08C7C2C-0351-4834-9C2B-8621AA9CCFB0",
           "name": "Merge other list into { variable }",
-          "value": "{ $.listRoles[*].assignedScopes }"
+          "value": "{ $.listRoles.item.assignedScopes }"
         }
       ]
     },
@@ -8486,7 +9945,12 @@
           "type": "select",
           "structure": []
         },
-        { "id": "cache", "value": "0", "type": "select", "structure": [] },
+        {
+          "id": "cache",
+          "value": "0",
+          "type": "select",
+          "structure": []
+        },
         {
           "id": "automations_censor_data",
           "value": false,
@@ -8494,12 +9958,470 @@
           "structure": []
         }
       ],
-      "collapsed": [{ "name": "loop", "isCollapsed": true }],
-      "x": -2322,
-      "y": 16174,
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": true
+        }
+      ],
+      "x": -2692,
+      "y": 17254,
       "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
       "endpoint_guid": "dbdc5470-c7a5-11ea-9135-b9442d1570d8",
       "endpoint_role": "get"
+    },
+    {
+      "id": "D93CC85B-1E1E-4EE9-A2C4-D60FB7E19A92",
+      "type": "ForEachBlock",
+      "disabled": false,
+      "name": "loop9",
+      "displayName": "Loop 9",
+      "comment": "Loop - assignedGroups",
+      "childId": "CD1DE6F6-8F1B-43EE-9B1A-E1ED8E200416",
+      "inputs": [
+        {
+          "id": "input",
+          "value": "{ $.getUser.assignedGroups }",
+          "type": "string",
+          "structure": {}
+        }
+      ],
+      "settings": [
+        {
+          "id": "automations_censor_data",
+          "value": false,
+          "type": "checkbox",
+          "structure": {}
+        }
+      ],
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": false
+        }
+      ],
+      "x": -2922,
+      "y": 134,
+      "loopBlockId": "EB88BBA6-62CF-4BE2-AE54-D656545BCDB8"
+    },
+    {
+      "id": "EB88BBA6-62CF-4BE2-AE54-D656545BCDB8",
+      "type": "ForEachBlock",
+      "disabled": false,
+      "name": "loop10",
+      "displayName": "Loop 10",
+      "comment": "Loop - group.assignedRoles",
+      "childId": null,
+      "inputs": [
+        {
+          "id": "input",
+          "value": "{ $.loop9.item.assignedRoles }",
+          "type": "string",
+          "structure": {}
+        }
+      ],
+      "settings": [
+        {
+          "id": "automations_censor_data",
+          "value": false,
+          "type": "checkbox",
+          "structure": {}
+        }
+      ],
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": false
+        }
+      ],
+      "x": -2802,
+      "y": 234,
+      "loopBlockId": "19CC7B58-34C4-4762-A144-898EF788EA13"
+    },
+    {
+      "id": "19CC7B58-34C4-4762-A144-898EF788EA13",
+      "type": "VariableBlock",
+      "disabled": false,
+      "name": "userRoles#2",
+      "displayName": "Variable - userRoles 2",
+      "comment": "Collect all roles for API key access checks.",
+      "childId": null,
+      "inputs": [],
+      "settings": [],
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": false
+        }
+      ],
+      "x": -2682,
+      "y": 334,
+      "variableGuid": "CD9F0C76-28B4-482E-A218-EDE5763F6807",
+      "operations": [
+        {
+          "key": "FF3F1190-B850-4D68-AFF6-CAE2EB644159",
+          "id": "add_item",
+          "name": "Add item to { variable }",
+          "value": "{object: '{\"id\":\"{ $.loop10.item.id }\",\"name\":\"{ $.loop10.item.name }\",\"type\":\"{ $.loop10.item.type }\",\"level\":\"{ $.loop10.item.level }\"}'}"
+        }
+      ]
+    },
+    {
+      "id": "3521F356-424C-44DE-8801-3042B0539E8D",
+      "type": "FormBlock",
+      "disabled": false,
+      "name": "inputs4",
+      "displayName": "Inputs 4",
+      "comment": "",
+      "childId": "ABF9478A-D559-4049-BA23-984416DB5D99",
+      "inputs": [],
+      "settings": [
+        {
+          "id": "persist_data",
+          "value": "no",
+          "type": "select",
+          "structure": []
+        },
+        {
+          "id": "automations_censor_data",
+          "value": false,
+          "type": "checkbox",
+          "structure": []
+        }
+      ],
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": false
+        }
+      ],
+      "x": -2802,
+      "y": -1466,
+      "form": [
+        {
+          "id": "inputs4-input-0",
+          "label": "Automatically update this automation?",
+          "helpText": "This will update the automation to the latest version of the Qlik Cloud Monitoring Apps deployer. Select Yes to proceed or No to cancel.",
+          "type": "select",
+          "values": "Yes,No",
+          "isRequired": true,
+          "options": {},
+          "order": 0
+        }
+      ],
+      "persistData": "no"
+    },
+    {
+      "id": "8F006B7D-F5B6-4BAA-8BFB-76D2B794E8AF",
+      "type": "ShowBlock",
+      "disabled": false,
+      "name": "output55",
+      "displayName": "Output 55",
+      "comment": "",
+      "childId": "3521F356-424C-44DE-8801-3042B0539E8D",
+      "inputs": [
+        {
+          "id": "input",
+          "value": "## Upate needed!\n\nThis deployer template is version \"{$.currentTemplateVersionNum}\", which is less than the required version \"{$.callURL.installers[?(@.template=='qcmad')].version}\"",
+          "type": "string",
+          "structure": {}
+        }
+      ],
+      "settings": [
+        {
+          "id": "display_mode",
+          "value": "add",
+          "type": "select",
+          "structure": {}
+        }
+      ],
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": false
+        }
+      ],
+      "x": -2802,
+      "y": -1586
+    },
+    {
+      "id": "ABF9478A-D559-4049-BA23-984416DB5D99",
+      "type": "IfElseBlock",
+      "disabled": false,
+      "name": "condition36",
+      "displayName": "Condition 36",
+      "comment": "",
+      "childId": null,
+      "inputs": [
+        {
+          "id": "conditions",
+          "value": {
+            "mode": "all",
+            "conditions": [
+              {
+                "input1": "{ $.inputs4.'Automatically update this automation?' }",
+                "input2": "Yes",
+                "operator": "="
+              }
+            ]
+          },
+          "type": "custom",
+          "structure": []
+        }
+      ],
+      "settings": [],
+      "collapsed": [
+        {
+          "name": "both",
+          "isCollapsed": false
+        },
+        {
+          "name": "yes",
+          "isCollapsed": false
+        },
+        {
+          "name": "no",
+          "isCollapsed": false
+        }
+      ],
+      "x": -2802,
+      "y": -1346,
+      "childTrueId": "6DB0BCE2-239C-491D-89F1-6E9F63937F49",
+      "childFalseId": null
+    },
+    {
+      "id": "6DB0BCE2-239C-491D-89F1-6E9F63937F49",
+      "type": "CallUrlBlock",
+      "disabled": false,
+      "name": "callURL4",
+      "displayName": "Call URL 4",
+      "comment": "",
+      "childId": "1C53F6DA-FE4F-4BE3-8A95-82EF0EC3E288",
+      "inputs": [
+        {
+          "id": "url",
+          "value": "https://raw.githubusercontent.com/qlik-oss/qlik-cloud-monitoring-apps/main/automations/singleTenantDeployer.json",
+          "type": "string",
+          "structure": {}
+        },
+        {
+          "id": "method",
+          "value": "GET",
+          "type": "select",
+          "structure": {}
+        },
+        {
+          "id": "timeout",
+          "value": "",
+          "type": "string",
+          "structure": {}
+        },
+        {
+          "id": "params",
+          "value": null,
+          "type": "object",
+          "mode": "keyValue",
+          "structure": {}
+        },
+        {
+          "id": "headers",
+          "value": null,
+          "type": "object",
+          "mode": "keyValue",
+          "structure": {}
+        },
+        {
+          "id": "encoding",
+          "value": "",
+          "type": "string",
+          "structure": {}
+        }
+      ],
+      "settings": [
+        {
+          "id": "blendr_on_error",
+          "value": "stop",
+          "type": "select",
+          "structure": {}
+        },
+        {
+          "id": "full_response",
+          "value": null,
+          "type": "checkbox",
+          "structure": {}
+        },
+        {
+          "id": "capitalize_headers",
+          "value": true,
+          "type": "checkbox",
+          "structure": {}
+        },
+        {
+          "id": "automations_censor_data",
+          "value": false,
+          "type": "checkbox",
+          "structure": {}
+        }
+      ],
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": false
+        }
+      ],
+      "x": -2682,
+      "y": -1266
+    },
+    {
+      "id": "1C53F6DA-FE4F-4BE3-8A95-82EF0EC3E288",
+      "type": "EndpointBlock",
+      "disabled": false,
+      "name": "updateAutomation",
+      "displayName": "Qlik Cloud Services - Update Automation",
+      "comment": "",
+      "childId": "99C259DE-CADE-4561-8634-3C93EA662301",
+      "inputs": [
+        {
+          "id": "428c8660-d041-11ec-864d-5bed7a9667ee",
+          "value": "{ automationid }",
+          "type": "string",
+          "structure": []
+        },
+        {
+          "id": "1f1d64b0-d041-11ec-bc03-e5fdbc243961",
+          "value": null,
+          "type": "string",
+          "structure": []
+        },
+        {
+          "id": "1f272e60-d041-11ec-9044-dda9cc402447",
+          "value": null,
+          "type": "string",
+          "structure": []
+        },
+        {
+          "id": "7fcdf4c0-2833-11ed-a6a9-797f49b90041",
+          "value": "{ $.callURL4 }",
+          "type": "string",
+          "structure": []
+        },
+        {
+          "id": "99e1a8c0-2833-11ed-b085-83fc18a9cd7d",
+          "value": null,
+          "type": "string",
+          "structure": []
+        }
+      ],
+      "settings": [
+        {
+          "id": "blendr_on_error",
+          "value": "stop",
+          "type": "select",
+          "structure": []
+        },
+        {
+          "id": "automations_censor_data",
+          "value": false,
+          "type": "checkbox",
+          "structure": []
+        }
+      ],
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": false
+        }
+      ],
+      "x": -2682,
+      "y": -1146,
+      "datasourcetype_guid": "61a87510-c7a3-11ea-95da-0fb0c241e75c",
+      "endpoint_guid": "1f022b50-d041-11ec-a842-e9973f7c493f",
+      "endpoint_role": "update"
+    },
+    {
+      "id": "99C259DE-CADE-4561-8634-3C93EA662301",
+      "type": "ShowBlock",
+      "disabled": false,
+      "name": "output56",
+      "displayName": "Output 56",
+      "comment": "",
+      "childId": "08CBB6D5-ACC3-40AD-A7DA-AA28CD5AD4DB",
+      "inputs": [
+        {
+          "id": "input",
+          "value": "## Automation has been updated. Please refresh the page or open: \n[This link to refresh]({$.tenantHostname}analytics/automations/editor/{automationid})",
+          "type": "string",
+          "structure": []
+        }
+      ],
+      "settings": [
+        {
+          "id": "display_mode",
+          "value": "add",
+          "type": "select",
+          "structure": []
+        }
+      ],
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": false
+        }
+      ],
+      "x": -2682,
+      "y": -1026
+    },
+    {
+      "id": "F8CCF961-2D55-43AE-A8B3-CED17A4A0B9A",
+      "type": "StopBlock",
+      "disabled": false,
+      "name": "stop",
+      "displayName": "Stop",
+      "comment": "",
+      "childId": null,
+      "inputs": [],
+      "settings": [],
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": false
+        }
+      ],
+      "x": -2682,
+      "y": -786
+    },
+    {
+      "id": "08CBB6D5-ACC3-40AD-A7DA-AA28CD5AD4DB",
+      "type": "UpdateJobBlock",
+      "disabled": false,
+      "name": "updateRunTitle3",
+      "displayName": "Update Run Title 3",
+      "comment": "",
+      "childId": "F8CCF961-2D55-43AE-A8B3-CED17A4A0B9A",
+      "inputs": [
+        {
+          "id": "title",
+          "value": "Updated to version: { $.callURL.installers[?(@.template=='qcma')].version }. Please run again.",
+          "type": "string",
+          "structure": {}
+        }
+      ],
+      "settings": [
+        {
+          "id": "automations_censor_data",
+          "value": false,
+          "type": "checkbox",
+          "structure": {}
+        }
+      ],
+      "collapsed": [
+        {
+          "name": "loop",
+          "isCollapsed": false
+        }
+      ],
+      "x": -2682,
+      "y": -906
     }
   ],
   "variables": [


### PR DESCRIPTION
## Fixes
Closes #111

## Changes
- Fixed group role scanning — now correctly merges roles from both 
  direct assignments and group assignments when checking for api:key role
<img width="901" height="601" alt="image" src="https://github.com/user-attachments/assets/f6ed2eab-f7e2-4f8e-967d-5200b1219607" />
- Fixed misplaced "List Roles" / "Variable - userPermissions" blocks 
  that caused group roles to be appended as nested arrays rather than 
  flat objects, resulting in an inconsistent permissions list structure
<img width="936" height="297" alt="image" src="https://github.com/user-attachments/assets/d9cf66e1-6c6b-47de-8ea2-8a89156e28ed" />
- Added auto-update: if the automation version is older than the version 
  on GitHub, the user is prompted and it updates automatically
<img width="1417" height="390" alt="image" src="https://github.com/user-attachments/assets/1accc421-90e9-4374-a184-661f8f3f2703" />
<img width="607" height="1181" alt="image" src="https://github.com/user-attachments/assets/10b18a2b-0dcd-4103-83a3-f936bee1248b" />
